### PR TITLE
Add swipe gesture for skipping classes, grey out finished courses, and make sure the class tile are in time order

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -43,6 +43,15 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         return load(type, "assignments.json") ?: emptyList()
     }
 
+    // MARK: - Skipped Dates (courseNo -> list of ISO date strings "yyyy-MM-dd")
+
+    fun saveSkippedDates(data: Map<String, List<String>>) = save(data, "skipped_dates.json")
+
+    fun loadSkippedDates(): Map<String, List<String>> {
+        val type = object : TypeToken<Map<String, List<String>>>() {}.type
+        return load(type, "skipped_dates.json") ?: emptyMap()
+    }
+
     // MARK: - Calendar Events
 
     fun saveCalendarEvents(events: List<CalendarEvent>) = save(events, "calendar_events.json")

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -21,6 +21,8 @@ import javax.inject.Singleton
 class DataCache @Inject constructor(@ApplicationContext context: Context) {
 
     private val cacheDir: File = File(context.cacheDir, "TigerDuckCache").also { it.mkdirs() }
+    // User-generated state that has no remote source — stored in filesDir so the OS never evicts it.
+    private val userDataDir: File = File(context.filesDir, "TigerDuckData").also { it.mkdirs() }
     private val gson: Gson = GsonBuilder()
         .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
         .create()
@@ -44,12 +46,21 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
     }
 
     // MARK: - Skipped Dates (courseNo -> list of ISO date strings "yyyy-MM-dd")
+    // Stored in filesDir — never cleared by the OS, unlike cacheDir.
 
-    fun saveSkippedDates(data: Map<String, List<String>>) = save(data, "skipped_dates.json")
+    fun saveSkippedDates(data: Map<String, List<String>>) {
+        try {
+            File(userDataDir, "skipped_dates.json").writeText(gson.toJson(data))
+        } catch (e: Exception) { }
+    }
 
     fun loadSkippedDates(): Map<String, List<String>> {
         val type = object : TypeToken<Map<String, List<String>>>() {}.type
-        return load(type, "skipped_dates.json") ?: emptyMap()
+        return try {
+            val file = File(userDataDir, "skipped_dates.json")
+            if (!file.exists()) return emptyMap()
+            gson.fromJson(file.readText(), type) ?: emptyMap()
+        } catch (e: Exception) { emptyMap() }
     }
 
     // MARK: - Calendar Events

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
@@ -22,17 +22,21 @@ import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 fun CourseCard(
     course: Course,
     hasAssignment: Boolean = false,
+    isFinished: Boolean = false,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val color = TigerDuckTheme.courseColor(course.courseNo)
+    val cardAlpha = if (isFinished) 0.08f else 0.15f
+    val accentAlpha = if (isFinished) 0.3f else 1f
+    val textAlpha = if (isFinished) 0.4f else 1f
 
     Card(
         modifier = modifier
             .width(160.dp)
             .clickable { onClick() },
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.15f)),
+        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = cardAlpha)),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
         Box {
@@ -42,13 +46,14 @@ fun CourseCard(
                         .width(4.dp)
                         .height(48.dp)
                         .clip(RoundedCornerShape(2.dp))
-                        .background(color)
+                        .background(color.copy(alpha = accentAlpha))
                 )
                 Spacer(Modifier.width(8.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = course.courseName,
                         style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = textAlpha),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis
                     )
@@ -56,13 +61,13 @@ fun CourseCard(
                     Text(
                         text = course.instructor,
                         style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f * textAlpha)
                     )
                     if (course.classroom.isNotEmpty()) {
                         Text(
                             text = course.classroom,
                             style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f * textAlpha)
                         )
                     }
                 }
@@ -76,7 +81,7 @@ fun CourseCard(
                         .align(Alignment.BottomEnd)
                         .padding(8.dp)
                         .size(14.dp),
-                    tint = Color.Gray.copy(alpha = 0.5f)
+                    tint = Color.Gray.copy(alpha = 0.5f * textAlpha)
                 )
             }
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -97,6 +97,7 @@ fun ClassTableScreen(
                         CourseCard(
                             course = course,
                             hasAssignment = viewModel.hasAssignment(course.courseNo),
+                            isFinished = viewModel.isCourseFinishedToday(course),
                             onClick = {
                                 val today = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_WEEK)
                                 val dayIndex = when (today) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Book
+import org.ntust.app.tigerduck.data.AppConstants
 import org.ntust.app.tigerduck.data.model.Course
 import org.ntust.app.tigerduck.ui.component.CourseCard
 import org.ntust.app.tigerduck.ui.component.SectionHeader
@@ -107,7 +108,8 @@ fun ClassTableScreen(
                                     java.util.Calendar.FRIDAY -> 5; java.util.Calendar.SATURDAY -> 6
                                     else -> 7
                                 }
-                                val firstPeriod = course.schedule[dayIndex]?.firstOrNull() ?: ""
+                                val firstPeriod = course.schedule[dayIndex]
+                                    ?.minByOrNull { AppConstants.Periods.chronologicalOrder.indexOf(it) } ?: ""
                                 viewModel.selectCourse(course, dayIndex, firstPeriod)
                             }
                         )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -38,6 +38,7 @@ fun ClassTableScreen(
 ) {
     val courses by viewModel.courses.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
+    viewModel.currentMinute.collectAsState() // drives recomposition when a class ends
     val selectedCourse by viewModel.selectedCourse.collectAsState()
     val todayCourses = viewModel.todayCourses
     val activePeriods = viewModel.activePeriods

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -96,7 +96,8 @@ class ClassTableViewModel @Inject constructor(
                 .sortedBy { course ->
                     val firstPeriod = course.schedule[today]
                         ?.minByOrNull { AppConstants.Periods.chronologicalOrder.indexOf(it) }
-                    AppConstants.Periods.chronologicalOrder.indexOf(firstPeriod ?: "")
+                    firstPeriod?.let { AppConstants.Periods.chronologicalOrder.indexOf(it) }
+                        ?: Int.MAX_VALUE
                 }
         }
 
@@ -146,7 +147,8 @@ class ClassTableViewModel @Inject constructor(
         val lastPeriodId = periods?.lastOrNull() ?: return false
         val endTimeStr = AppConstants.PeriodTimes.mapping[lastPeriodId]?.second ?: return false
         val parts = endTimeStr.split(":")
-        val endMinutes = parts[0].toInt() * 60 + parts[1].toInt()
+        val endMinutes = (parts.getOrNull(0)?.toIntOrNull() ?: return false) * 60 +
+                         (parts.getOrNull(1)?.toIntOrNull() ?: return false)
         return _currentMinute.value > endMinutes
     }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -45,7 +45,24 @@ class ClassTableViewModel @Inject constructor(
     private val _currentSemester = MutableStateFlow(courseService.currentSemesterCode())
     val currentSemester: StateFlow<String> = _currentSemester
 
+    private val _currentMinute = MutableStateFlow(currentMinuteOfDay())
+    val currentMinute: StateFlow<Int> = _currentMinute
+
     private var hasLoaded = false
+
+    init {
+        viewModelScope.launch {
+            while (true) {
+                kotlinx.coroutines.delay(60_000)
+                _currentMinute.value = currentMinuteOfDay()
+            }
+        }
+    }
+
+    private fun currentMinuteOfDay(): Int {
+        val c = Calendar.getInstance()
+        return c.get(Calendar.HOUR_OF_DAY) * 60 + c.get(Calendar.MINUTE)
+    }
 
     val availableSemesters: List<String>
         get() {
@@ -130,8 +147,7 @@ class ClassTableViewModel @Inject constructor(
         val endTimeStr = AppConstants.PeriodTimes.mapping[lastPeriodId]?.second ?: return false
         val parts = endTimeStr.split(":")
         val endMinutes = parts[0].toInt() * 60 + parts[1].toInt()
-        val nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE)
-        return nowMinutes > endMinutes
+        return _currentMinute.value > endMinutes
     }
 
     fun courseAt(weekday: Int, period: String): Course? =

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -74,7 +74,13 @@ class ClassTableViewModel @Inject constructor(
                     Calendar.SUNDAY -> 7; else -> 1
                 }
             }
-            return _courses.value.filter { it.schedule.containsKey(today) }
+            return _courses.value
+                .filter { it.schedule.containsKey(today) }
+                .sortedBy { course ->
+                    val firstPeriod = course.schedule[today]
+                        ?.minByOrNull { AppConstants.Periods.chronologicalOrder.indexOf(it) }
+                    AppConstants.Periods.chronologicalOrder.indexOf(firstPeriod ?: "")
+                }
         }
 
     val activeWeekdays: List<Int>
@@ -108,6 +114,25 @@ class ClassTableViewModel @Inject constructor(
             val last = AppConstants.PeriodTimes.mapping[periods.last()] ?: return null
             return "${first.first} - ${last.second}"
         }
+
+    fun isCourseFinishedToday(course: Course): Boolean {
+        val now = Calendar.getInstance()
+        val todayWeekday = now.get(Calendar.DAY_OF_WEEK).let {
+            when (it) {
+                Calendar.MONDAY -> 1; Calendar.TUESDAY -> 2; Calendar.WEDNESDAY -> 3
+                Calendar.THURSDAY -> 4; Calendar.FRIDAY -> 5; Calendar.SATURDAY -> 6
+                else -> 7
+            }
+        }
+        val periods = course.schedule[todayWeekday]
+            ?.sortedBy { AppConstants.Periods.chronologicalOrder.indexOf(it) }
+        val lastPeriodId = periods?.lastOrNull() ?: return false
+        val endTimeStr = AppConstants.PeriodTimes.mapping[lastPeriodId]?.second ?: return false
+        val parts = endTimeStr.split(":")
+        val endMinutes = parts[0].toInt() * 60 + parts[1].toInt()
+        val nowMinutes = now.get(Calendar.HOUR_OF_DAY) * 60 + now.get(Calendar.MINUTE)
+        return nowMinutes > endMinutes
+    }
 
     fun courseAt(weekday: Int, period: String): Course? =
         _courses.value.firstOrNull { it.schedule[weekday]?.contains(period) == true }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import org.ntust.app.tigerduck.data.model.Assignment
 import org.ntust.app.tigerduck.data.model.Course
+import java.util.Date
 import org.ntust.app.tigerduck.data.model.HomeSection
 import org.ntust.app.tigerduck.ui.AppState
 import org.ntust.app.tigerduck.ui.component.*
@@ -41,6 +42,7 @@ fun HomeScreen(
     val isLoading by viewModel.isLoading.collectAsState()
     val selectedCourse by viewModel.selectedCourse.collectAsState()
     val hasSynced by viewModel.hasSynced.collectAsState()
+    val skippedDates by viewModel.skippedDates.collectAsState()
     var showComingSoon by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { viewModel.load() }
@@ -104,8 +106,10 @@ fun HomeScreen(
                     showAbsoluteTime = appState.showAbsoluteAssignmentTime,
                     sliderStyle = appState.timeSliderStyle,
                     invertDirection = appState.invertSliderDirection,
+                    skippedDates = skippedDates,
                     onCourseClick = { viewModel.selectCourse(it) },
                     onAssignmentClick = { openAssignmentInMoodle(context, it) },
+                    onSkipCourse = { course, date -> viewModel.toggleSkip(course, date) },
                     onWidgetClick = { showComingSoon = true }
                 )
             }
@@ -142,8 +146,10 @@ private fun HomeSectionContent(
     showAbsoluteTime: Boolean,
     sliderStyle: String,
     invertDirection: Boolean,
+    skippedDates: Map<String, List<String>>,
     onCourseClick: (Course) -> Unit,
     onAssignmentClick: (Assignment) -> Unit,
+    onSkipCourse: (Course, Date) -> Unit,
     onWidgetClick: () -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -153,6 +159,8 @@ private fun HomeSectionContent(
                     courses = allCourses,
                     sliderStyle = sliderStyle,
                     invertDirection = invertDirection,
+                    skippedDates = skippedDates,
+                    onSkipCourse = onSkipCourse,
                     onSelectCourse = onCourseClick
                 )
             }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -12,6 +12,8 @@ import org.ntust.app.tigerduck.network.MoodleService
 import org.ntust.app.tigerduck.notification.AssignmentNotificationScheduler
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -54,6 +56,16 @@ class HomeViewModel @Inject constructor(
 
     private val _skippedDates = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     val skippedDates: StateFlow<Map<String, List<String>>> = _skippedDates
+
+    private val saveSkipChannel = Channel<Map<String, List<String>>>(Channel.CONFLATED)
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            for (data in saveSkipChannel) {
+                dataCache.saveSkippedDates(data)
+            }
+        }
+    }
 
     private var hasLoaded = false
 
@@ -213,9 +225,7 @@ class HomeViewModel @Inject constructor(
         if (key in dates) dates.remove(key) else dates.add(key)
         current[course.courseNo] = dates
         _skippedDates.value = current
-        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
-            dataCache.saveSkippedDates(current)
-        }
+        saveSkipChannel.trySend(current)
     }
 
     fun removeSection(sectionId: String) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -15,7 +15,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
+import java.util.Locale
 import javax.inject.Inject
 
 @HiltViewModel
@@ -49,11 +52,16 @@ class HomeViewModel @Inject constructor(
     private val _hasSynced = MutableStateFlow(false)
     val hasSynced: StateFlow<Boolean> = _hasSynced
 
+    private val _skippedDates = MutableStateFlow<Map<String, List<String>>>(emptyMap())
+    val skippedDates: StateFlow<Map<String, List<String>>> = _skippedDates
+
     private var hasLoaded = false
 
     fun load() {
         if (hasLoaded) return
         hasLoaded = true
+
+        _skippedDates.value = dataCache.loadSkippedDates()
 
         // Load cached data immediately
         val cachedCourses = dataCache.loadCourses()
@@ -198,6 +206,16 @@ class HomeViewModel @Inject constructor(
         _selectedCourse.value = course
     }
 
+    fun toggleSkip(course: Course, date: Date) {
+        val key = skipDateFmt.format(date)
+        val current = _skippedDates.value.toMutableMap()
+        val dates = (current[course.courseNo] ?: emptyList()).toMutableList()
+        if (key in dates) dates.remove(key) else dates.add(key)
+        current[course.courseNo] = dates
+        _skippedDates.value = current
+        dataCache.saveSkippedDates(current)
+    }
+
     fun removeSection(sectionId: String) {
         _sections.value = _sections.value.filter { it.id != sectionId }
             .mapIndexed { i, s -> s.copy(sortOrder = i) }
@@ -208,6 +226,10 @@ class HomeViewModel @Inject constructor(
         val item = list.removeAt(from)
         list.add(to, item)
         _sections.value = list.mapIndexed { i, s -> s.copy(sortOrder = i) }
+    }
+
+    companion object {
+        private val skipDateFmt = SimpleDateFormat("yyyy-MM-dd", Locale.US)
     }
 
     fun addSection(type: HomeSection.HomeSectionType, title: String) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -213,7 +213,9 @@ class HomeViewModel @Inject constructor(
         if (key in dates) dates.remove(key) else dates.add(key)
         current[course.courseNo] = dates
         _skippedDates.value = current
-        dataCache.saveSkippedDates(current)
+        viewModelScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+            dataCache.saveSkippedDates(current)
+        }
     }
 
     fun removeSection(sectionId: String) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -177,6 +177,7 @@ private fun CourseTimeCard(
                     SlotCard(
                         slot = it, alpha = 0.5f,
                         isSkipped = isSkippedFor(it),
+                        onSkipToggle = { onSkipCourse(it.course, it.date) },
                         onClick = { onSelect(it.course) },
                         modifier = Modifier.weight(1f)
                     )
@@ -185,6 +186,7 @@ private fun CourseTimeCard(
                     SlotCard(
                         slot = it, alpha = 0.5f,
                         isSkipped = isSkippedFor(it),
+                        onSkipToggle = { onSkipCourse(it.course, it.date) },
                         onClick = { onSelect(it.course) },
                         modifier = Modifier.weight(1f)
                     )
@@ -194,6 +196,7 @@ private fun CourseTimeCard(
                 SlotCard(
                     slot = state.next, alpha = 0.5f,
                     isSkipped = isSkippedFor(state.next),
+                    onSkipToggle = { onSkipCourse(state.next.course, state.next.date) },
                     onClick = { onSelect(state.next.course) },
                     modifier = Modifier.fillMaxWidth()
                 )
@@ -202,6 +205,7 @@ private fun CourseTimeCard(
                 SlotCard(
                     slot = state.previous, alpha = 0.5f,
                     isSkipped = isSkippedFor(state.previous),
+                    onSkipToggle = { onSkipCourse(state.previous.course, state.previous.date) },
                     onClick = { onSelect(state.previous.course) },
                     modifier = Modifier.fillMaxWidth()
                 )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -1,21 +1,27 @@
 package org.ntust.app.tigerduck.ui.screen.home
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -25,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.ntust.app.tigerduck.data.model.Course
@@ -33,12 +40,17 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.launch
 
 @Composable
 fun TimeSliderSection(
     courses: List<Course>,
     sliderStyle: String,
     invertDirection: Boolean,
+    skippedDates: Map<String, List<String>> = emptyMap(),
+    onSkipCourse: (Course, Date) -> Unit = { _, _ -> },
     onSelectCourse: (Course) -> Unit
 ) {
     val sliderScope = rememberCoroutineScope()
@@ -90,6 +102,8 @@ fun TimeSliderSection(
                 // Course card
                 CourseTimeCard(
                     state = viewModel.currentCourseState,
+                    skippedDates = skippedDates,
+                    onSkipCourse = onSkipCourse,
                     onSelect = onSelectCourse
                 )
 
@@ -133,34 +147,64 @@ fun TimeSliderSection(
 @Composable
 private fun CourseTimeCard(
     state: CourseState,
+    skippedDates: Map<String, List<String>>,
+    onSkipCourse: (Course, Date) -> Unit,
     onSelect: (Course) -> Unit
 ) {
+    val isoFmt = remember { SimpleDateFormat("yyyy-MM-dd", Locale.US) }
+    val isSkippedFor: (CourseTimeSlot) -> Boolean = { slot ->
+        val dateKey = isoFmt.format(slot.date)
+        skippedDates[slot.course.courseNo]?.contains(dateKey) == true
+    }
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         modifier = Modifier.fillMaxWidth()
     ) {
         when (state) {
             is CourseState.InClass -> {
-                SlotCard(slot = state.slot, alpha = 1f, onClick = { onSelect(state.slot.course) },
-                    modifier = Modifier.fillMaxWidth())
+                SlotCard(
+                    slot = state.slot,
+                    alpha = 1f,
+                    isSkipped = isSkippedFor(state.slot),
+                    onSkipToggle = { onSkipCourse(state.slot.course, state.slot.date) },
+                    onClick = { onSelect(state.slot.course) },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
             is CourseState.Between -> {
                 state.previous?.let {
-                    SlotCard(slot = it, alpha = 0.5f, onClick = { onSelect(it.course) },
-                        modifier = Modifier.weight(1f))
+                    SlotCard(
+                        slot = it, alpha = 0.5f,
+                        isSkipped = isSkippedFor(it),
+                        onClick = { onSelect(it.course) },
+                        modifier = Modifier.weight(1f)
+                    )
                 }
                 state.next?.let {
-                    SlotCard(slot = it, alpha = 0.5f, onClick = { onSelect(it.course) },
-                        modifier = Modifier.weight(1f))
+                    SlotCard(
+                        slot = it, alpha = 0.5f,
+                        isSkipped = isSkippedFor(it),
+                        onClick = { onSelect(it.course) },
+                        modifier = Modifier.weight(1f)
+                    )
                 }
             }
             is CourseState.BeforeFirst -> {
-                SlotCard(slot = state.next, alpha = 0.5f, onClick = { onSelect(state.next.course) },
-                    modifier = Modifier.fillMaxWidth())
+                SlotCard(
+                    slot = state.next, alpha = 0.5f,
+                    isSkipped = isSkippedFor(state.next),
+                    onClick = { onSelect(state.next.course) },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
             is CourseState.AfterLast -> {
-                SlotCard(slot = state.previous, alpha = 0.5f, onClick = { onSelect(state.previous.course) },
-                    modifier = Modifier.fillMaxWidth())
+                SlotCard(
+                    slot = state.previous, alpha = 0.5f,
+                    isSkipped = isSkippedFor(state.previous),
+                    onClick = { onSelect(state.previous.course) },
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         }
     }
@@ -170,6 +214,8 @@ private fun CourseTimeCard(
 private fun SlotCard(
     slot: CourseTimeSlot,
     alpha: Float,
+    isSkipped: Boolean = false,
+    onSkipToggle: (() -> Unit)? = null,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -198,42 +244,115 @@ private fun SlotCard(
         today == cal.get(Calendar.DAY_OF_YEAR) && it.get(Calendar.YEAR) == cal.get(Calendar.YEAR)
     }
 
-    Card(
-        onClick = onClick,
-        modifier = modifier,
-        shape = RoundedCornerShape(16.dp),
-        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.15f * alpha))
-    ) {
-        Column(modifier = Modifier.padding(14.dp)) {
-            Row {
-                Text(
-                    timeRange,
-                    style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-                )
-                Spacer(Modifier.weight(1f))
-                if (!isToday) {
+    val density = LocalDensity.current
+    val thresholdPx = with(density) { 100.dp.toPx() }
+    val swipeOffset = remember { Animatable(0f) }
+    val coroutineScope = rememberCoroutineScope()
+
+    Box(modifier = modifier) {
+        // Skip action indicator shown behind the card while swiping
+        if (onSkipToggle != null) {
+            val progress = (abs(swipeOffset.value) / thresholdPx).coerceIn(0f, 1f)
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .padding(end = 20.dp),
+                contentAlignment = Alignment.CenterEnd
+            ) {
+                Column(
+                    modifier = Modifier
+                        .alpha(progress)
+                        .scale(0.5f + 0.5f * progress),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Icon(
+                        imageVector = if (isSkipped) Icons.AutoMirrored.Filled.Undo else Icons.AutoMirrored.Filled.DirectionsWalk,
+                        contentDescription = null,
+                        tint = if (isSkipped) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                               else Color(0xFFFF2D55),
+                        modifier = Modifier.size(22.dp)
+                    )
+                    Spacer(Modifier.height(2.dp))
                     Text(
-                        formatDateLabel(slot.date),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        text = if (isSkipped) "取消翹課" else "翹課",
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                        color = if (isSkipped) MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                                else Color(0xFFFF2D55),
+                        fontSize = 11.sp
                     )
                 }
             }
-            Spacer(Modifier.height(4.dp))
-            Text(
-                slot.course.courseName,
-                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-            Text(
-                "${slot.course.classroom} · ${slot.course.instructor}",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+        }
+
+        val cardModifier = if (onSkipToggle != null) {
+            Modifier
+                .fillMaxWidth()
+                .offset { IntOffset(swipeOffset.value.roundToInt(), 0) }
+                .pointerInput(Unit) {
+                    detectHorizontalDragGestures(
+                        onDragEnd = {
+                            coroutineScope.launch {
+                                if (swipeOffset.value <= -thresholdPx) {
+                                    swipeOffset.animateTo(-2000f, animationSpec = tween(durationMillis = 200))
+                                    onSkipToggle()
+                                    swipeOffset.snapTo(0f)
+                                } else {
+                                    swipeOffset.animateTo(0f, animationSpec = spring())
+                                }
+                            }
+                        },
+                        onDragCancel = {
+                            coroutineScope.launch { swipeOffset.animateTo(0f, animationSpec = spring()) }
+                        },
+                        onHorizontalDrag = { _, delta ->
+                            coroutineScope.launch {
+                                swipeOffset.snapTo((swipeOffset.value + delta * 0.6f).coerceAtMost(0f))
+                            }
+                        }
+                    )
+                }
+        } else {
+            Modifier.fillMaxWidth()
+        }
+
+        Card(
+            onClick = onClick,
+            modifier = cardModifier,
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.15f * alpha))
+        ) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Row {
+                    Text(
+                        timeRange,
+                        style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                    Spacer(Modifier.weight(1f))
+                    if (!isToday) {
+                        Text(
+                            formatDateLabel(slot.date),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        )
+                    }
+                }
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    slot.course.courseName,
+                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                    color = if (isSkipped) Color(0xFFFF2D55) else Color.Unspecified,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    "${slot.course.classroom} · ${slot.course.instructor}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -246,7 +246,7 @@ private fun SlotCard(
 
     val density = LocalDensity.current
     val thresholdPx = with(density) { 100.dp.toPx() }
-    val swipeOffset = remember { Animatable(0f) }
+    val swipeOffset = remember(slot.course.courseNo, slot.date) { Animatable(0f) }
     val coroutineScope = rememberCoroutineScope()
 
     Box(modifier = modifier) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -248,6 +248,7 @@ private fun SlotCard(
         today == cal.get(Calendar.DAY_OF_YEAR) && it.get(Calendar.YEAR) == cal.get(Calendar.YEAR)
     }
 
+    val latestOnSkipToggle by rememberUpdatedState(onSkipToggle)
     val density = LocalDensity.current
     val thresholdPx = with(density) { 100.dp.toPx() }
     val swipeOffset = remember(slot.course.courseNo, slot.date) { Animatable(0f) }
@@ -298,7 +299,7 @@ private fun SlotCard(
                             coroutineScope.launch {
                                 if (swipeOffset.value <= -thresholdPx) {
                                     swipeOffset.animateTo(-2000f, animationSpec = tween(durationMillis = 200))
-                                    onSkipToggle()
+                                    latestOnSkipToggle?.invoke()
                                     swipeOffset.snapTo(0f)
                                 } else {
                                     swipeOffset.animateTo(0f, animationSpec = spring())


### PR DESCRIPTION
#2 #3 

This pull request introduces a "skip course" feature that allows users to mark a course as skipped for a specific date, and visually reflects skipped or finished courses in the UI. The changes span data caching, UI components, and view model logic to support this new functionality and improve course sorting and display.

**Skip Course Feature Implementation:**

* Added methods to `DataCache` for persisting skipped course dates per course in `skipped_dates.json`.
* `HomeViewModel` now loads, exposes, and updates skipped course dates through new state and a `toggleSkip` function. [[1]](diffhunk://#diff-9176e2dae0a55c2fdae624500fe98076402f9928f5d16b29f3d8bfb92f11cc24R55-R65) [[2]](diffhunk://#diff-9176e2dae0a55c2fdae624500fe98076402f9928f5d16b29f3d8bfb92f11cc24R209-R218) [[3]](diffhunk://#diff-9176e2dae0a55c2fdae624500fe98076402f9928f5d16b29f3d8bfb92f11cc24R231-R234)
* The `TimeSliderSection` and related UI components now accept and use `skippedDates`, passing skip actions up to the view model. [[1]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R43-R53) [[2]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R105-R106) [[3]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R150-R207) [[4]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R217-R218) [[5]](diffhunk://#diff-459574dc4fa9bec4e07f991315008b9c2c4017ab26a585a3d3737c7a7b05a731R109-R112) [[6]](diffhunk://#diff-459574dc4fa9bec4e07f991315008b9c2c4017ab26a585a3d3737c7a7b05a731R149-R152) [[7]](diffhunk://#diff-459574dc4fa9bec4e07f991315008b9c2c4017ab26a585a3d3737c7a7b05a731R162-R163)

**UI/UX Enhancements:**

* `CourseCard` now visually distinguishes finished courses by adjusting alpha values for background, accent, and text colors. [[1]](diffhunk://#diff-9ce50f931f42c7f04fd15b3e74b593da54e852b67f54b8f8c5267940a7dc2623R25-R39) [[2]](diffhunk://#diff-9ce50f931f42c7f04fd15b3e74b593da54e852b67f54b8f8c5267940a7dc2623L45-R70) [[3]](diffhunk://#diff-9ce50f931f42c7f04fd15b3e74b593da54e852b67f54b8f8c5267940a7dc2623L79-R84)
* The class table sorts today's courses by their start period for more logical ordering.

**Course State Logic:**

* Added `isCourseFinishedToday` to `ClassTableViewModel` to determine if a course has ended for the day, and passed this state to `CourseCard`. [[1]](diffhunk://#diff-c8416fc23a597274e2d62d351a16637c2198bf24adc25324d29ce559067b5ebbR118-R136) [[2]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R100)

These changes collectively provide users with the ability to skip courses on specific dates, see which courses are finished or skipped, and experience improved course ordering and clarity in the UI.… in 課表

- Swipe left on the class tile in 首頁 to toggle 翹課; skipped course name turns pink, swipe shows 取消翹課 when already skipped. Skip state is persisted to disk via DataCache (skipped_dates.json).
- 今日課程 tiles in 課表 are greyed out when the class has already ended today.
- 今日課程 tiles are now sorted in chronological order (early → late, left → right).