### PR TITLE
Add conditional check for Google Play upload based on service account

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
             app/build/outputs/bundle/release/*.aab
 
       - name: Upload to Google Play
+        if: secrets.PLAY_SERVICE_ACCOUNT_JSON != ''
         uses: r0adkll/upload-google-play@935ef9c68bb393a8e6116b1575626a7f5be3a7fb # v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}


### PR DESCRIPTION
This pull request introduces a conditional check to the Google Play upload step in the release workflow, ensuring the step only runs if the required Play Store service account secret is set.

Workflow reliability improvement:

* Added a conditional (`if: secrets.PLAY_SERVICE_ACCOUNT_JSON != ''`) to the "Upload to Google Play" step in `.github/workflows/release.yml` so that it only runs when the `PLAY_SERVICE_ACCOUNT_JSON` secret is present.…count presence