### PR TITLE
Add write permissions to release workflows

### DIFF
--- a/.github/workflows/release-manual-playstore.yml
+++ b/.github/workflows/release-manual-playstore.yml
@@ -7,6 +7,9 @@ on:
         description: 'Tag to release (e.g. v1.1.0)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -7,6 +7,9 @@ on:
         description: 'Tag to release (e.g. v1.1.0)'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: ['v*']
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for manual and automated releases by explicitly setting the required permissions for the workflows to write to repository contents. This change ensures that the workflows have the necessary access to perform release operations.

Workflow permissions updates:

* Added `permissions: contents: write` to `.github/workflows/release.yml` to allow the workflow to write release assets and tags.
* Added `permissions: contents: write` to `.github/workflows/release-manual.yml` for manual release workflows.
* Added `permissions: contents: write` to `.github/workflows/release-manual-playstore.yml` for Play Store manual release workflows.