### PR TITLE
chore: update version code to 3 for release 1.1.1

### DIFF
--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -20,7 +20,7 @@ Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
   - versionName: 1.1.1
-    versionCode: 2
+    versionCode: 3
     commit: v1.1.1
     subdir: app
     gradle:
@@ -29,4 +29,4 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 CurrentVersion: 1.1.1
-CurrentVersionCode: 2
+CurrentVersionCode: 3


### PR DESCRIPTION
This pull request updates the build metadata for the app to increment the version code from 2 to 3, ensuring the build system and update checks recognize the latest version.

Build metadata updates:

* Incremented `versionCode` from 2 to 3 in the `Builds` section of `metadata/org.ntust.app.tigerduck.yml` to reflect a new build.
* Updated `CurrentVersionCode` from 2 to 3 to match the new build version code.