### PR TITLE
Update CI detection logic and versioning in build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3
-        versionName = "1.1.1"
+        versionCode = 4
+        versionName = "1.1.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -1,6 +1,7 @@
 package org.ntust.app.tigerduck.ui.screen.settings
 
 import android.content.Intent
+import org.ntust.app.tigerduck.BuildConfig
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.animation.core.*
@@ -67,14 +68,7 @@ fun SettingsScreen(
     var showLibraryWarning by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
-    val appVersion = remember {
-        try {
-            val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            pInfo.versionName ?: "1.1.2"
-        } catch (_: Exception) {
-            "1.1.2"
-        }
-    }
+    val appVersion = remember { BuildConfig.VERSION_NAME }
 
     // Show network error as snackbar
     LaunchedEffect(ntustLoginError) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -70,9 +70,9 @@ fun SettingsScreen(
     val appVersion = remember {
         try {
             val pInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            pInfo.versionName ?: "1.1.1"
+            pInfo.versionName ?: "1.1.2"
         } catch (_: Exception) {
-            "1.1.1"
+            "1.1.2"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
+// F-Droid buildserver runs `unset CI` before building, so also check for /home/vagrant
 val isCI = System.getenv("CI") != null || System.getProperty("user.home") == "/home/vagrant"
 if (!isCI) {
     val localBuildRoot = file("${System.getProperty("user.home")}/.tigerduck-build")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
     alias(libs.plugins.ksp) apply false
 }
 
-if (System.getenv("CI") == null) {
+val isCI = System.getenv("CI") != null || System.getProperty("user.home") == "/home/vagrant"
+if (!isCI) {
     val localBuildRoot = file("${System.getProperty("user.home")}/.tigerduck-build")
     rootProject.layout.buildDirectory.set(localBuildRoot.resolve(rootProject.name))
     subprojects {

--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -19,14 +19,14 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.1.1
-    versionCode: 3
-    commit: v1.1.1
+  - versionName: 1.1.2
+    versionCode: 4
+    commit: v1.1.2
     subdir: app
     gradle:
       - yes
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.1.1
-CurrentVersionCode: 3
+CurrentVersion: 1.1.2
+CurrentVersionCode: 4


### PR DESCRIPTION
This pull request updates the app version from 1.1.1 to 1.1.2, incrementing the version code and updating version references throughout the codebase and metadata. These changes ensure consistency across the build configuration, app UI, and repository metadata.

Version update:

* Increased `versionCode` from 3 to 4 and `versionName` from 1.1.1 to 1.1.2 in `app/build.gradle.kts` to prepare for a new app release.
* Updated the displayed app version in the `SettingsScreen` UI to 1.1.2, ensuring the user sees the correct version.
* Updated version information in `metadata/org.ntust.app.tigerduck.yml`, including `versionName`, `versionCode`, associated commit, and current version fields, to reflect the new release.