### PR TITLE
Implement customizable schedule tile colors with Tailwind palette

### DIFF
--- a/app/schemas/org.ntust.app.tigerduck.data.local.AppDatabase/3.json
+++ b/app/schemas/org.ntust.app.tigerduck.data.local.AppDatabase/3.json
@@ -1,0 +1,255 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "5fd3015ef385c607b2da1880cad4b4f0",
+    "entities": [
+      {
+        "tableName": "courses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`courseNo` TEXT NOT NULL, `courseName` TEXT NOT NULL, `instructor` TEXT NOT NULL, `credits` INTEGER NOT NULL, `classroom` TEXT NOT NULL, `enrolledCount` INTEGER NOT NULL, `maxCount` INTEGER NOT NULL, `scheduleJson` TEXT NOT NULL, `moodleIdNumber` TEXT, `customColorHex` TEXT, PRIMARY KEY(`courseNo`))",
+        "fields": [
+          {
+            "fieldPath": "courseNo",
+            "columnName": "courseNo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseName",
+            "columnName": "courseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructor",
+            "columnName": "instructor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "credits",
+            "columnName": "credits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classroom",
+            "columnName": "classroom",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enrolledCount",
+            "columnName": "enrolledCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCount",
+            "columnName": "maxCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduleJson",
+            "columnName": "scheduleJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodleIdNumber",
+            "columnName": "moodleIdNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customColorHex",
+            "columnName": "customColorHex",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "courseNo"
+          ]
+        }
+      },
+      {
+        "tableName": "assignments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`assignmentId` TEXT NOT NULL, `courseNo` TEXT NOT NULL, `courseName` TEXT NOT NULL, `title` TEXT NOT NULL, `dueDate` INTEGER NOT NULL, `isCompleted` INTEGER NOT NULL, `moodleUrl` TEXT, PRIMARY KEY(`assignmentId`))",
+        "fields": [
+          {
+            "fieldPath": "assignmentId",
+            "columnName": "assignmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseNo",
+            "columnName": "courseNo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseName",
+            "columnName": "courseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueDate",
+            "columnName": "dueDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodleUrl",
+            "columnName": "moodleUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "assignmentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_assignments_dueDate",
+            "unique": false,
+            "columnNames": [
+              "dueDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_assignments_dueDate` ON `${TABLE_NAME}` (`dueDate`)"
+          },
+          {
+            "name": "index_assignments_courseNo",
+            "unique": false,
+            "columnNames": [
+              "courseNo"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_assignments_courseNo` ON `${TABLE_NAME}` (`courseNo`)"
+          }
+        ]
+      },
+      {
+        "tableName": "calendar_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventId` TEXT NOT NULL, `title` TEXT NOT NULL, `date` INTEGER NOT NULL, `sourceRaw` TEXT NOT NULL, PRIMARY KEY(`eventId`))",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRaw",
+            "columnName": "sourceRaw",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventId"
+          ]
+        }
+      },
+      {
+        "tableName": "announcements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`announcementId` TEXT NOT NULL, `title` TEXT NOT NULL, `summary` TEXT NOT NULL, `department` TEXT NOT NULL, `publishDate` INTEGER NOT NULL, `detailUrl` TEXT, `htmlContent` TEXT, PRIMARY KEY(`announcementId`))",
+        "fields": [
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "department",
+            "columnName": "department",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishDate",
+            "columnName": "publishDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailUrl",
+            "columnName": "detailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "htmlContent",
+            "columnName": "htmlContent",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "announcementId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_announcements_publishDate",
+            "unique": false,
+            "columnNames": [
+              "publishDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announcements_publishDate` ON `${TABLE_NAME}` (`publishDate`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5fd3015ef385c607b2da1880cad4b4f0')"
+    ]
+  }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
@@ -1,0 +1,80 @@
+package org.ntust.app.tigerduck.data
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.BufferOverflow
+import org.ntust.app.tigerduck.data.cache.DataCache
+import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
+import org.ntust.app.tigerduck.ui.theme.courseColorPalette
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+/**
+ * Cross-ViewModel coordinator for schedule tile colors. Settings can invoke
+ * [resetAllColors] to randomize every course's color; all active ViewModels
+ * subscribe to [changeEvent] and reload their course state when it fires.
+ */
+@Singleton
+class CourseColorStore @Inject constructor(
+    private val dataCache: DataCache
+) {
+    private val _changeEvent = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val changeEvent: SharedFlow<Unit> = _changeEvent.asSharedFlow()
+
+    /**
+     * Assigns a fresh random preset color to every course. Distinct presets
+     * are drawn first; any course beyond the 18-color palette receives a
+     * random non-palette color. Persists to the cache and rebuilds the
+     * shared color map before broadcasting [changeEvent].
+     */
+    suspend fun resetAllColors() {
+        val courses = dataCache.loadCourses()
+        if (courses.isEmpty()) return
+
+        val palette = courseColorPalette.shuffled()
+        val paletteArgbs = palette.mapTo(mutableSetOf()) { it.toArgb() }
+        val used = mutableSetOf<Int>()
+
+        val updated = courses.mapIndexed { idx, course ->
+            val color = if (idx < palette.size) {
+                palette[idx].also { used.add(it.toArgb()) }
+            } else {
+                randomNonPaletteColor(paletteArgbs, used).also { used.add(it.toArgb()) }
+            }
+            course.copy(customColorHex = formatHex(color))
+        }
+
+        dataCache.saveCourses(updated)
+        TigerDuckTheme.buildCourseColorMap(updated)
+        _changeEvent.tryEmit(Unit)
+    }
+
+    private fun formatHex(color: Color): String =
+        "#" + String.format("%06X", color.toArgb() and 0xFFFFFF)
+
+    private fun randomNonPaletteColor(
+        paletteArgbs: Set<Int>,
+        alreadyUsed: Set<Int>
+    ): Color {
+        repeat(32) {
+            val h = Random.nextFloat() * 360f
+            val s = 0.55f + Random.nextFloat() * 0.4f
+            val v = 0.55f + Random.nextFloat() * 0.3f
+            val c = Color(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v)))
+            val argb = c.toArgb()
+            if (argb !in paletteArgbs && argb !in alreadyUsed) return c
+        }
+        return Color(
+            android.graphics.Color.HSVToColor(
+                floatArrayOf(Random.nextFloat() * 360f, 0.7f, 0.7f)
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/data/local/AppDatabase.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import org.ntust.app.tigerduck.data.model.*
 
 @Database(
     entities = [Course::class, Assignment::class, CalendarEvent::class, Announcement::class],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -31,10 +31,16 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE courses ADD COLUMN customColorHex TEXT")
+            }
+        }
+
         fun create(context: Context): AppDatabase =
             Room.databaseBuilder(context, AppDatabase::class.java, "tigerduck.db")
                 .apply {
-                    addMigrations(MIGRATION_1_2)
+                    addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     if (BuildConfig.DEBUG) {
                         fallbackToDestructiveMigration(true)
                     }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/Course.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/Course.kt
@@ -17,7 +17,9 @@ data class Course(
     val maxCount: Int = 0,
     /** JSON: {"1":["3","4"],"3":["6","7"]} — keys = weekday (1=Mon..7=Sun) */
     val scheduleJson: String = "{}",
-    val moodleIdNumber: String? = null
+    val moodleIdNumber: String? = null,
+    /** User-picked tile color as "#RRGGBB". Null means hash-based palette assignment. */
+    val customColorHex: String? = null
 ) {
     @Ignore
     @Transient

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
@@ -1,0 +1,375 @@
+package org.ntust.app.tigerduck.ui.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.ntust.app.tigerduck.ui.theme.ContentAlpha
+
+/**
+ * Bottom sheet that lets the user assign a tile color to a class.
+ * Shows a curated preset grid plus an HSV fine-tune panel for custom colors.
+ *
+ * @param usedByOthers maps preset colors that are currently assigned to OTHER
+ *                     courses — used only to show a small indicator dot so the
+ *                     user knows picking it will displace that course.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ColorPickerSheet(
+    courseName: String,
+    currentColor: Color,
+    presetPalette: List<Color>,
+    usedByOthers: Set<Int>,
+    onApply: (Color) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val initialHsv = remember(currentColor) {
+        FloatArray(3).also { android.graphics.Color.colorToHSV(currentColor.toArgb(), it) }
+    }
+    var hue by remember { mutableFloatStateOf(initialHsv[0]) }
+    var sat by remember { mutableFloatStateOf(initialHsv[1]) }
+    var value by remember { mutableFloatStateOf(initialHsv[2]) }
+    var showCustom by remember { mutableStateOf(false) }
+
+    val selectedColor = remember(hue, sat, value) {
+        Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, sat, value)))
+    }
+    val selectedArgb = selectedColor.toArgb() or 0xFF000000.toInt()
+
+    fun setHsvFrom(color: Color) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(color.toArgb(), hsv)
+        hue = hsv[0]; sat = hsv[1]; value = hsv[2]
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            Text(
+                text = "選擇顏色",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = courseName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            // Preview — matches the alpha used on the schedule grid tile.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(selectedColor.copy(alpha = 0.85f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = courseName.ifBlank { "預覽" },
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+
+            Spacer(Modifier.height(22.dp))
+
+            SectionLabel(text = "預設（設選擇與它科重複顏色會導致該科顏色重新分配）")
+            Spacer(Modifier.height(10.dp))
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                maxItemsInEachRow = 6
+            ) {
+                presetPalette.forEach { preset ->
+                    val presetArgb = preset.toArgb() or 0xFF000000.toInt()
+                    ColorSwatch(
+                        color = preset,
+                        selected = presetArgb == selectedArgb,
+                        usedByOther = presetArgb in usedByOthers && presetArgb != selectedArgb,
+                        onClick = { setHsvFrom(preset) }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(18.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable { showCustom = !showCustom }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SectionLabel(text = "自訂顏色", modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = if (showCustom) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY)
+                )
+            }
+
+            if (showCustom) {
+                Spacer(Modifier.height(8.dp))
+                SatValSquare(
+                    hue = hue,
+                    sat = sat,
+                    value = value,
+                    onSatValChange = { s, v -> sat = s; value = v }
+                )
+                Spacer(Modifier.height(12.dp))
+                HueSlider(
+                    hue = hue,
+                    onHueChange = { hue = it }
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "#" + String.format("%06X", selectedArgb and 0xFFFFFF),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+
+            Spacer(Modifier.height(22.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f)
+                ) { Text("取消") }
+                Button(
+                    onClick = { onApply(selectedColor) },
+                    modifier = Modifier.weight(1f)
+                ) { Text("套用") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun ColorSwatch(
+    color: Color,
+    selected: Boolean,
+    usedByOther: Boolean,
+    onClick: () -> Unit
+) {
+    val surface = MaterialTheme.colorScheme.surface
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    Box(
+        modifier = Modifier.size(44.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .align(Alignment.Center)
+                .clip(CircleShape)
+                .background(color)
+                .clickable(onClick = onClick)
+                .then(
+                    if (selected) Modifier.border(3.dp, Color.White, CircleShape)
+                    else Modifier
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            if (selected) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = "已選",
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        if (usedByOther) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .align(Alignment.TopEnd)
+                    .clip(CircleShape)
+                    .background(surface)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .align(Alignment.Center)
+                        .clip(CircleShape)
+                        .background(onSurface.copy(alpha = 0.55f))
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SatValSquare(
+    hue: Float,
+    sat: Float,
+    value: Float,
+    onSatValChange: (sat: Float, value: Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val pureHueColor = remember(hue) {
+        Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, 1f, 1f)))
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .pointerInput(Unit) {
+                detectDragGestures { change, _ ->
+                    val s = (change.position.x / size.width).coerceIn(0f, 1f)
+                    val v = 1f - (change.position.y / size.height).coerceIn(0f, 1f)
+                    onSatValChange(s, v)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val s = (offset.x / size.width).coerceIn(0f, 1f)
+                    val v = 1f - (offset.y / size.height).coerceIn(0f, 1f)
+                    onSatValChange(s, v)
+                }
+            }
+    ) {
+        drawRect(color = pureHueColor)
+        drawRect(brush = Brush.horizontalGradient(listOf(Color.White, Color.Transparent)))
+        drawRect(brush = Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+
+        val cx = sat * size.width
+        val cy = (1f - value) * size.height
+        val inner = 8.dp.toPx()
+        drawCircle(
+            color = Color.Black.copy(alpha = 0.4f),
+            radius = inner + 2.dp.toPx(),
+            center = Offset(cx, cy),
+            style = Stroke(width = 1.dp.toPx())
+        )
+        drawCircle(
+            color = Color.White,
+            radius = inner,
+            center = Offset(cx, cy),
+            style = Stroke(width = 2.dp.toPx())
+        )
+    }
+}
+
+@Composable
+private fun HueSlider(
+    hue: Float,
+    onHueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hueStops = remember {
+        listOf(
+            Color(0xFFFF0000),
+            Color(0xFFFFFF00),
+            Color(0xFF00FF00),
+            Color(0xFF00FFFF),
+            Color(0xFF0000FF),
+            Color(0xFFFF00FF),
+            Color(0xFFFF0000)
+        )
+    }
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(28.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .pointerInput(Unit) {
+                detectDragGestures { change, _ ->
+                    val h = (change.position.x / size.width * 360f).coerceIn(0f, 360f)
+                    onHueChange(h)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val h = (offset.x / size.width * 360f).coerceIn(0f, 360f)
+                    onHueChange(h)
+                }
+            }
+    ) {
+        drawRect(brush = Brush.horizontalGradient(hueStops))
+        val cx = (hue / 360f) * size.width
+        val cy = size.height / 2
+        val r = size.height / 2 - 2.dp.toPx()
+        drawCircle(
+            color = Color.Black.copy(alpha = 0.4f),
+            radius = r + 2.dp.toPx(),
+            center = Offset(cx, cy),
+            style = Stroke(width = 1.dp.toPx())
+        )
+        drawCircle(
+            color = Color.White,
+            radius = r,
+            center = Offset(cx, cy),
+            style = Stroke(width = 2.dp.toPx())
+        )
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -28,14 +28,17 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Book
+import androidx.compose.ui.graphics.toArgb
 import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.data.model.Course
+import org.ntust.app.tigerduck.ui.component.ColorPickerSheet
 import org.ntust.app.tigerduck.ui.component.CourseCard
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SectionHeader
 import org.ntust.app.tigerduck.ui.component.SyncIndicator
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
+import org.ntust.app.tigerduck.ui.theme.courseColorPalette
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +55,7 @@ fun ClassTableScreen(
     var showAddCourse by remember { mutableStateOf(false) }
     var courseToRename by remember { mutableStateOf<Course?>(null) }
     var renameText by remember { mutableStateOf("") }
+    var courseToRecolor by remember { mutableStateOf<Course?>(null) }
     var showCheckmark by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -164,6 +168,9 @@ fun ClassTableScreen(
                     },
                     onDelete = { course ->
                         viewModel.deleteCourse(course.courseNo)
+                    },
+                    onPickColor = { course ->
+                        courseToRecolor = course
                     }
                 )
             }
@@ -230,6 +237,30 @@ fun ClassTableScreen(
         )
     }
 
+    courseToRecolor?.let { course ->
+        val currentColor = TigerDuckTheme.courseColor(course.courseNo)
+        val usedByOthers = remember(courses, course.courseNo) {
+            courses
+                .asSequence()
+                .filter { it.courseNo != course.courseNo }
+                .map { TigerDuckTheme.courseColor(it.courseNo).toArgb() or 0xFF000000.toInt() }
+                .toSet()
+        }
+        ColorPickerSheet(
+            courseName = course.courseName,
+            currentColor = currentColor,
+            presetPalette = courseColorPalette,
+            usedByOthers = usedByOthers,
+            onApply = { picked ->
+                val argb = picked.toArgb()
+                val hex = "#" + String.format("%06X", argb and 0xFFFFFF)
+                viewModel.updateCourseColor(course.courseNo, hex)
+                courseToRecolor = null
+            },
+            onDismiss = { courseToRecolor = null }
+        )
+    }
+
     if (showAddCourse) {
         ModalBottomSheet(
             onDismissRequest = { showAddCourse = false }
@@ -253,7 +284,8 @@ private fun TimetableGrid(
     weekdays: List<Int>,
     periods: List<org.ntust.app.tigerduck.data.model.TimetablePeriod>,
     onRename: (Course) -> Unit = {},
-    onDelete: (Course) -> Unit = {}
+    onDelete: (Course) -> Unit = {},
+    onPickColor: (Course) -> Unit = {}
 ) {
     val haptic = LocalHapticFeedback.current
     val dayLabels = listOf("", "一", "二", "三", "四", "五", "六", "日")
@@ -382,6 +414,13 @@ private fun TimetableGrid(
                                             onClick = {
                                                 showMenu = false
                                                 onRename(role.course)
+                                            }
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text("選擇顏色") },
+                                            onClick = {
+                                                showMenu = false
+                                                onPickColor(role.course)
                                             }
                                         )
                                         DropdownMenuItem(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.cache.DataCache
 import android.util.Log
 import org.ntust.app.tigerduck.data.model.Assignment
@@ -35,7 +36,8 @@ class ClassTableViewModel @Inject constructor(
     private val authService: AuthService,
     internal val courseService: CourseService,
     private val moodleService: MoodleService,
-    private val dataCache: DataCache
+    private val dataCache: DataCache,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     private val _courses = MutableStateFlow<List<Course>>(emptyList())
@@ -70,6 +72,17 @@ class ClassTableViewModel @Inject constructor(
             while (true) {
                 kotlinx.coroutines.delay(60_000)
                 _currentDayTime.value = currentDayTime()
+            }
+        }
+        viewModelScope.launch {
+            // Reload course state whenever Settings resets tile colors so
+            // our in-memory _courses doesn't fight the freshly-written cache.
+            courseColorStore.changeEvent.collect {
+                val fresh = dataCache.loadCourses()
+                if (fresh.isNotEmpty()) {
+                    _courses.value = fresh
+                    TigerDuckTheme.buildCourseColorMap(fresh)
+                }
             }
         }
     }
@@ -185,7 +198,7 @@ class ClassTableViewModel @Inject constructor(
         val updated = _courses.value + course
         _courses.value = updated
         viewModelScope.launch { dataCache.saveCourses(updated) }
-        TigerDuckTheme.buildCourseColorMap(updated.map { it.courseNo })
+        TigerDuckTheme.buildCourseColorMap(updated)
     }
 
     fun renameCourse(courseNo: String, newName: String) {
@@ -199,6 +212,28 @@ class ClassTableViewModel @Inject constructor(
     fun deleteCourse(courseNo: String) {
         val updated = _courses.value.filter { it.courseNo != courseNo }
         _courses.value = updated
+        viewModelScope.launch { dataCache.saveCourses(updated) }
+        TigerDuckTheme.buildCourseColorMap(updated)
+    }
+
+    /**
+     * Assigns [newHex] to [courseNo]. Pass null to clear the user-picked color
+     * and fall back to hash-based assignment. Any other course whose custom
+     * color matches [newHex] is automatically cleared so it gets reassigned
+     * through the palette probe logic.
+     */
+    fun updateCourseColor(courseNo: String, newHex: String?) {
+        val normalized = newHex?.uppercase()
+        val updated = _courses.value.map { course ->
+            when {
+                course.courseNo == courseNo -> course.copy(customColorHex = normalized)
+                normalized != null && course.customColorHex?.uppercase() == normalized ->
+                    course.copy(customColorHex = null)
+                else -> course
+            }
+        }
+        _courses.value = updated
+        TigerDuckTheme.buildCourseColorMap(updated)
         viewModelScope.launch { dataCache.saveCourses(updated) }
     }
 
@@ -238,7 +273,7 @@ class ClassTableViewModel @Inject constructor(
             if (cached.isNotEmpty()) {
                 _courses.value = cached
                 _assignments.value = cachedA
-                TigerDuckTheme.buildCourseColorMap(cached.map { it.courseNo })
+                TigerDuckTheme.buildCourseColorMap(cached)
             }
             fetchData()
         }
@@ -309,9 +344,14 @@ class ClassTableViewModel @Inject constructor(
                     }.awaitAll().filterNotNull()
                 }
                 if (courses.isNotEmpty()) {
-                    _courses.value = courses
-                    dataCache.saveCourses(courses)
-                    TigerDuckTheme.buildCourseColorMap(courses.map { it.courseNo })
+                    // Preserve user-picked tile colors across network refresh.
+                    val existingColors = _courses.value.associate { it.courseNo to it.customColorHex }
+                    val merged = courses.map { c ->
+                        c.copy(customColorHex = existingColors[c.courseNo])
+                    }
+                    _courses.value = merged
+                    dataCache.saveCourses(merged)
+                    TigerDuckTheme.buildCourseColorMap(merged)
                 }
             }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.model.*
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
@@ -35,7 +36,8 @@ class HomeViewModel @Inject constructor(
     private val courseService: CourseService,
     private val moodleService: MoodleService,
     private val notificationScheduler: AssignmentNotificationScheduler,
-    private val prefs: AppPreferences
+    private val prefs: AppPreferences,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     private val _sections = MutableStateFlow(prefs.homeSections)
@@ -73,6 +75,16 @@ class HomeViewModel @Inject constructor(
                 dataCache.saveSkippedDates(data)
             }
         }
+        viewModelScope.launch {
+            // Pick up color changes triggered from Settings (e.g. "重設課表顏色").
+            courseColorStore.changeEvent.collect {
+                val fresh = dataCache.loadCourses()
+                if (fresh.isNotEmpty()) {
+                    TigerDuckTheme.buildCourseColorMap(fresh)
+                    updateCoursesAndAssignments(fresh, _upcomingAssignments.value)
+                }
+            }
+        }
     }
 
     private var hasLoaded = false
@@ -88,7 +100,7 @@ class HomeViewModel @Inject constructor(
             val cachedCourses = dataCache.loadCourses()
             val cachedAssignments = dataCache.loadAssignments()
             if (cachedCourses.isNotEmpty() || cachedAssignments.isNotEmpty()) {
-                TigerDuckTheme.buildCourseColorMap(cachedCourses.map { it.courseNo })
+                TigerDuckTheme.buildCourseColorMap(cachedCourses)
                 updateCoursesAndAssignments(cachedCourses, cachedAssignments)
             }
 
@@ -120,8 +132,12 @@ class HomeViewModel @Inject constructor(
                     if (authenticated) {
                         val remoteCourses = fetchCourses(studentId, password)
                         if (!remoteCourses.isNullOrEmpty()) {
-                            courses = remoteCourses
-                            dataCache.saveCourses(remoteCourses)
+                            // Preserve user-picked tile colors across refresh.
+                            val pinned = courses.associate { it.courseNo to it.customColorHex }
+                            courses = remoteCourses.map { c ->
+                                c.copy(customColorHex = pinned[c.courseNo])
+                            }
+                            dataCache.saveCourses(courses)
                         }
 
                         val remoteAssignments = fetchAssignments(studentId, password)
@@ -133,7 +149,7 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
-            TigerDuckTheme.buildCourseColorMap(courses.map { it.courseNo })
+            TigerDuckTheme.buildCourseColorMap(courses)
             updateCoursesAndAssignments(courses, assignments)
             if (forceRemote && authService.isNtustAuthenticated) {
                 _syncCompleteEvent.tryEmit(Unit)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -66,6 +66,7 @@ fun SettingsScreen(
     val libraryEnabled = viewModel.appState.libraryFeatureEnabled
 
     var showLibraryWarning by remember { mutableStateOf(false) }
+    var showResetColorsConfirm by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     val appVersion = remember { BuildConfig.VERSION_NAME }
@@ -239,38 +240,47 @@ fun SettingsScreen(
             }
         }
 
-        // MARK: Theme
+        // MARK: Custom
         item { SectionHeader("自訂") }
         item {
             ContentCard {
-                Column(modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text("主題色", style = MaterialTheme.typography.bodyMedium)
-                    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                        AppPreferences.themeColors.forEach { (_, hex) ->
-                            val color = Color(0xFF000000 or hex.toLong())
-                            Box(
-                                modifier = Modifier
-                                    .size(32.dp)
-                                    .clip(CircleShape)
-                                    .background(color)
-                                    .clickable { viewModel.appState.accentColorHex = hex },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                if (accentColorHex == hex) {
-                                    Text("\u2713", color = Color.White, style = MaterialTheme.typography.labelSmall)
+                Column {
+                    SettingsLinkRow("Tab 編輯器") { onNavigateToTabEditor() }
+                    HorizontalDivider()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showResetColorsConfirm = true }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("重設課表顏色", style = MaterialTheme.typography.bodyMedium)
+                    }
+                    HorizontalDivider()
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("主題色", style = MaterialTheme.typography.bodyMedium)
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            AppPreferences.themeColors.forEach { (_, hex) ->
+                                val color = Color(0xFF000000 or hex.toLong())
+                                Box(
+                                    modifier = Modifier
+                                        .size(32.dp)
+                                        .clip(CircleShape)
+                                        .background(color)
+                                        .clickable { viewModel.appState.accentColorHex = hex },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (accentColorHex == hex) {
+                                        Text("\u2713", color = Color.White, style = MaterialTheme.typography.labelSmall)
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        }
-
-        // Tab Editor link
-        item {
-            ContentCard {
-                SettingsLinkRow("Tab 編輯器") { onNavigateToTabEditor() }
             }
         }
 
@@ -372,6 +382,23 @@ fun SettingsScreen(
                 showLibraryWarning = false
             },
             onDismiss = { showLibraryWarning = false }
+        )
+    }
+
+    if (showResetColorsConfirm) {
+        AlertDialog(
+            onDismissRequest = { showResetColorsConfirm = false },
+            title = { Text("確定要重設課表顏色？") },
+            text = { Text("這將會把課表的顏色依照預設顏色隨機重新分配") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.resetCourseColors()
+                    showResetColorsConfirm = false
+                }) { Text("確定") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetColorsConfirm = false }) { Text("取消") }
+            }
         )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package org.ntust.app.tigerduck.ui.screen.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import org.ntust.app.tigerduck.network.LibraryService
@@ -21,7 +22,8 @@ class SettingsViewModel @Inject constructor(
     private val libraryService: LibraryService,
     private val credentials: CredentialManager,
     val prefs: AppPreferences,
-    private val notificationScheduler: AssignmentNotificationScheduler
+    private val notificationScheduler: AssignmentNotificationScheduler,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     val isNtustLoggingIn = authService.isLoggingIn
@@ -81,4 +83,8 @@ class SettingsViewModel @Inject constructor(
     val ntustStudentId: String? get() = authService.storedStudentId
 
     fun cancelAllAssignmentNotifications() = notificationScheduler.cancelAllTracked()
+
+    fun resetCourseColors() {
+        viewModelScope.launch { courseColorStore.resetAllColors() }
+    }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
@@ -6,45 +6,102 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import org.ntust.app.tigerduck.data.model.Course
+import kotlin.random.Random
 
 val courseColorPalette: List<Color> = listOf(
-    Color(0xFFFF6B6B), // 珊瑚紅
-    Color(0xFF4ECDC4), // 青綠
-    Color(0xFF45B7D1), // 天藍
-    Color(0xFFF39C12), // 橘橙
-    Color(0xFFDDA0DD), // 梅紫
-    Color(0xFF2ECC71), // 翡翠綠
-    Color(0xFFE74C3C), // 磚紅
-    Color(0xFF3498DB), // 寶藍
-    Color(0xFFF7DC6F), // 金黃
-    Color(0xFF9B59B6), // 紫羅蘭
-    Color(0xFF1ABC9C), // 碧綠
-    Color(0xFFE67E22), // 南瓜橘
-    Color(0xFF85C1E9), // 淺藍
-    Color(0xFFD35400), // 焦橙
-    Color(0xFF27AE60), // 森林綠
-    Color(0xFFC0392B), // 酒紅
-    Color(0xFF8E44AD), // 深紫
-    Color(0xFF16A085), // 松綠
-    Color(0xFFF1C40F), // 向日葵黃
-    Color(0xFF2980B9), // 鈷藍
+    Color(0xFFDC2626), // Red
+    Color(0xFFEA580C), // Orange
+    Color(0xFFD97706), // Amber
+    Color(0xFFCA8A04), // Ochre
+    Color(0xFF65A30D), // Lime
+    Color(0xFF16A34A), // Green
+    Color(0xFF059669), // Emerald
+    Color(0xFF0D9488), // Teal
+    Color(0xFF0891B2), // Cyan
+    Color(0xFF0284C7), // Sky
+    Color(0xFF2563EB), // Blue
+    Color(0xFF4F46E5), // Indigo
+    Color(0xFF7C3AED), // Violet
+    Color(0xFF9333EA), // Purple
+    Color(0xFFC026D3), // Fuchsia
+    Color(0xFFDB2777), // Pink
+    Color(0xFFE11D48), // Rose
+    Color(0xFF475569), // Slate
 )
 
 object TigerDuckTheme {
     @Volatile
     private var courseColorMap: Map<String, Color> = emptyMap()
 
-    fun buildCourseColorMap(courseNos: List<String>) {
-        courseColorMap = courseNos.associateWith { courseNo -> stableColor(courseNo) }
+    fun buildCourseColorMap(courses: List<Course>) {
+        val map = mutableMapOf<String, Color>()
+        val taken = mutableSetOf<Color>()
+
+        // Pinned (user-picked) colors claim their slots first.
+        courses.forEach { course ->
+            val pinned = parseHexOrNull(course.customColorHex) ?: return@forEach
+            map[course.courseNo] = pinned
+            taken.add(pinned)
+        }
+
+        // Remaining courses fall back to hash-based assignment, probing forward
+        // through the palette to avoid colliding with pinned/already-assigned slots.
+        // When the palette is exhausted (more than 18 distinct courses), we fall
+        // back to a deterministic-random color outside the palette.
+        courses.filter { map[it.courseNo] == null }
+            .sortedBy { it.courseNo }
+            .forEach { course ->
+                val color = pickFreeColor(course.courseNo, taken)
+                map[course.courseNo] = color
+                taken.add(color)
+            }
+
+        courseColorMap = map
     }
 
     fun courseColor(courseNo: String): Color {
-        return courseColorMap[courseNo] ?: stableColor(courseNo)
+        courseColorMap[courseNo]?.let { return it }
+        return courseColorPalette[courseHashIndex(courseNo)]
     }
 
-    private fun stableColor(courseNo: String): Color {
+    private fun pickFreeColor(courseNo: String, taken: Set<Color>): Color {
+        val base = courseHashIndex(courseNo)
+        var idx = base
+        var probes = 0
+        while (probes < courseColorPalette.size && courseColorPalette[idx] in taken) {
+            idx = (idx + 1) % courseColorPalette.size
+            probes++
+        }
+        if (probes < courseColorPalette.size) return courseColorPalette[idx]
+
+        // Palette fully taken. Pick a deterministic-random color not in the
+        // palette, seeded by courseNo so the same class keeps a stable color.
+        val paletteArgbs = courseColorPalette.mapTo(mutableSetOf()) { it.toArgb() }
+        val rng = Random(courseNo.hashCode())
+        repeat(32) {
+            val h = rng.nextFloat() * 360f
+            val s = 0.55f + rng.nextFloat() * 0.4f
+            val v = 0.55f + rng.nextFloat() * 0.3f
+            val c = Color(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v)))
+            if (c.toArgb() !in paletteArgbs && c !in taken) return c
+        }
+        return Color(android.graphics.Color.HSVToColor(floatArrayOf(rng.nextFloat() * 360f, 0.7f, 0.7f)))
+    }
+
+    private fun courseHashIndex(courseNo: String): Int {
         val hash = courseNo.fold(0) { acc, c -> (acc * 31 + c.code) and 0x7FFFFFFF }
-        return courseColorPalette[hash % courseColorPalette.size]
+        return hash % courseColorPalette.size
+    }
+
+    private fun parseHexOrNull(hex: String?): Color? {
+        if (hex.isNullOrBlank()) return null
+        return try {
+            Color(android.graphics.Color.parseColor(hex))
+        } catch (_: IllegalArgumentException) {
+            null
+        }
     }
 }
 


### PR DESCRIPTION
This pull request introduces a new feature that enables user-customizable colors for courses and adds infrastructure to support coordinated color resets across the app. It includes a database schema migration, updates to the `Course` data model, and a new `CourseColorStore` for managing color assignments and broadcasting changes.

**Database schema and data model changes:**

- Added a new nullable field `customColorHex` to the `Course` entity and corresponding database table, allowing each course to store a user-picked color as a hex string. This required a schema migration from version 2 to 3. [[1]](diffhunk://#diff-741fd8c7b405817621ee20f867700e75550c0703fa182e1be1849780a0f995c0L15-R15) [[2]](diffhunk://#diff-0db8c623aa393d0c952d7c1c80af7f07c3902323fd74a9b91fc9942355cb924dL20-R22) [[3]](diffhunk://#diff-741fd8c7b405817621ee20f867700e75550c0703fa182e1be1849780a0f995c0R34-R43) [[4]](diffhunk://#diff-458d8eeeae1fa3654c162603404fed73389ba8e17a10285d5a950f0bb5a08ef9R1-R255)

**Color management infrastructure:**

- Introduced the `CourseColorStore` singleton, which coordinates course color assignments across ViewModels. It provides a method to reset all course colors (randomizing them from a palette or generating new colors as needed), persists the changes, and notifies subscribers via a shared flow.Replace the saturated 20-color schedule palette with 18 Tailwind-600 hues and add collision-free assignment so no two classes share a color until the palette is exhausted. Courses beyond 18 fall back to a deterministic-random HSV color outside the palette, stable per courseNo.

Long-pressing a class tile now exposes a 選擇顏色 option that opens a bottom sheet with preset swatches (current pick highlighted, slots already used by another class flagged) and a collapsible HSV fine-tune panel. Picking a color that another class holds as its custom pick clears that class's override so the probe logic can reassign it cleanly.

Custom picks persist via a new Course.customColorHex column (Room migration 2→3) and are preserved across network refresh in both ClassTableViewModel and HomeViewModel.

Settings 自訂 section is regrouped into a single card — Tab 編輯器, 重設課表顏色, 主題色 — with no gap between rows. The new reset entry prompts a confirmation dialog before calling CourseColorStore, a shared singleton that shuffles the palette across all classes and broadcasts a change event so the schedule and home screens reload in sync.