### PR TITLE
Enhance UI with customizable schedule colors and unified styling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 5
-        versionName = "1.1.3"
+        versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 26
         targetSdk = 36
-        versionCode = 5
+        versionCode = 6
         versionName = "1.1.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/schemas/org.ntust.app.tigerduck.data.local.AppDatabase/3.json
+++ b/app/schemas/org.ntust.app.tigerduck.data.local.AppDatabase/3.json
@@ -1,0 +1,255 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "5fd3015ef385c607b2da1880cad4b4f0",
+    "entities": [
+      {
+        "tableName": "courses",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`courseNo` TEXT NOT NULL, `courseName` TEXT NOT NULL, `instructor` TEXT NOT NULL, `credits` INTEGER NOT NULL, `classroom` TEXT NOT NULL, `enrolledCount` INTEGER NOT NULL, `maxCount` INTEGER NOT NULL, `scheduleJson` TEXT NOT NULL, `moodleIdNumber` TEXT, `customColorHex` TEXT, PRIMARY KEY(`courseNo`))",
+        "fields": [
+          {
+            "fieldPath": "courseNo",
+            "columnName": "courseNo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseName",
+            "columnName": "courseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructor",
+            "columnName": "instructor",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "credits",
+            "columnName": "credits",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "classroom",
+            "columnName": "classroom",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enrolledCount",
+            "columnName": "enrolledCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "maxCount",
+            "columnName": "maxCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "scheduleJson",
+            "columnName": "scheduleJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodleIdNumber",
+            "columnName": "moodleIdNumber",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customColorHex",
+            "columnName": "customColorHex",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "courseNo"
+          ]
+        }
+      },
+      {
+        "tableName": "assignments",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`assignmentId` TEXT NOT NULL, `courseNo` TEXT NOT NULL, `courseName` TEXT NOT NULL, `title` TEXT NOT NULL, `dueDate` INTEGER NOT NULL, `isCompleted` INTEGER NOT NULL, `moodleUrl` TEXT, PRIMARY KEY(`assignmentId`))",
+        "fields": [
+          {
+            "fieldPath": "assignmentId",
+            "columnName": "assignmentId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseNo",
+            "columnName": "courseNo",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "courseName",
+            "columnName": "courseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dueDate",
+            "columnName": "dueDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "moodleUrl",
+            "columnName": "moodleUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "assignmentId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_assignments_dueDate",
+            "unique": false,
+            "columnNames": [
+              "dueDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_assignments_dueDate` ON `${TABLE_NAME}` (`dueDate`)"
+          },
+          {
+            "name": "index_assignments_courseNo",
+            "unique": false,
+            "columnNames": [
+              "courseNo"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_assignments_courseNo` ON `${TABLE_NAME}` (`courseNo`)"
+          }
+        ]
+      },
+      {
+        "tableName": "calendar_events",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`eventId` TEXT NOT NULL, `title` TEXT NOT NULL, `date` INTEGER NOT NULL, `sourceRaw` TEXT NOT NULL, PRIMARY KEY(`eventId`))",
+        "fields": [
+          {
+            "fieldPath": "eventId",
+            "columnName": "eventId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceRaw",
+            "columnName": "sourceRaw",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "eventId"
+          ]
+        }
+      },
+      {
+        "tableName": "announcements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`announcementId` TEXT NOT NULL, `title` TEXT NOT NULL, `summary` TEXT NOT NULL, `department` TEXT NOT NULL, `publishDate` INTEGER NOT NULL, `detailUrl` TEXT, `htmlContent` TEXT, PRIMARY KEY(`announcementId`))",
+        "fields": [
+          {
+            "fieldPath": "announcementId",
+            "columnName": "announcementId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "summary",
+            "columnName": "summary",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "department",
+            "columnName": "department",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "publishDate",
+            "columnName": "publishDate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "detailUrl",
+            "columnName": "detailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "htmlContent",
+            "columnName": "htmlContent",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "announcementId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_announcements_publishDate",
+            "unique": false,
+            "columnNames": [
+              "publishDate"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_announcements_publishDate` ON `${TABLE_NAME}` (`publishDate`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '5fd3015ef385c607b2da1880cad4b4f0')"
+    ]
+  }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
@@ -1,7 +1,14 @@
 package org.ntust.app.tigerduck
 
+import java.time.ZoneId
+import java.util.TimeZone
+
 object AppConstants {
     const val APP_NAME = "TigerDuck"
+
+    /** All "what day/time is it?" logic must use Taipei time, not the device timezone. */
+    val TAIPEI_TZ: TimeZone = TimeZone.getTimeZone("Asia/Taipei")
+    val TAIPEI_ZONE: ZoneId = ZoneId.of("Asia/Taipei")
 
     object Periods {
         val defaultVisible = listOf("1", "2", "3", "4", "6", "7", "8", "9")

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -4,15 +4,15 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import org.ntust.app.tigerduck.ui.AppState
 import org.ntust.app.tigerduck.ui.navigation.AppNavigation
 import org.ntust.app.tigerduck.ui.theme.TigerDuckAppTheme
+import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -27,7 +27,15 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
-            TigerDuckAppTheme(accentColor = appState.accentColor) {
+            val systemDark = isSystemInDarkTheme()
+            val dark = when (appState.themeMode) {
+                "dark" -> true
+                "light" -> false
+                else -> systemDark
+            }
+            SideEffect { TigerDuckTheme.setDarkMode(dark) }
+
+            TigerDuckAppTheme(darkTheme = dark, accentColor = appState.accentColor) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     AppNavigation(appState = appState)
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : ComponentActivity() {
             }
             SideEffect { TigerDuckTheme.setDarkMode(dark) }
 
-            TigerDuckAppTheme(darkTheme = dark, accentColor = appState.accentColor) {
+            TigerDuckAppTheme(darkTheme = dark, accentColor = appState.accentColor(dark)) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     AppNavigation(appState = appState)
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import org.ntust.app.tigerduck.ui.AppState
 import org.ntust.app.tigerduck.ui.navigation.AppNavigation
@@ -33,7 +32,7 @@ class MainActivity : ComponentActivity() {
                 "light" -> false
                 else -> systemDark
             }
-            SideEffect { TigerDuckTheme.setDarkMode(dark) }
+            TigerDuckTheme.setDarkMode(dark)
 
             TigerDuckAppTheme(darkTheme = dark, accentColor = appState.accentColor(dark)) {
                 Surface(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
@@ -61,7 +61,7 @@ class CourseColorStore @Inject constructor(
         paletteArgbs: Set<Int>,
         alreadyUsed: Set<Int>
     ): Color {
-        repeat(32) {
+        while (true) {
             val h = Random.nextFloat() * 360f
             val s = 0.55f + Random.nextFloat() * 0.4f
             val v = 0.55f + Random.nextFloat() * 0.3f
@@ -69,10 +69,5 @@ class CourseColorStore @Inject constructor(
             val argb = c.toArgb()
             if (argb !in paletteArgbs && argb !in alreadyUsed) return c
         }
-        return Color(
-            android.graphics.Color.HSVToColor(
-                floatArrayOf(Random.nextFloat() * 360f, 0.7f, 0.7f)
-            )
-        )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.channels.BufferOverflow
 import org.ntust.app.tigerduck.data.cache.DataCache
-import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import org.ntust.app.tigerduck.ui.theme.courseColorPalette
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -52,7 +51,6 @@ class CourseColorStore @Inject constructor(
         }
 
         dataCache.saveCourses(updated)
-        TigerDuckTheme.buildCourseColorMap(updated)
         _changeEvent.tryEmit(Unit)
     }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/CourseColorStore.kt
@@ -1,0 +1,80 @@
+package org.ntust.app.tigerduck.data
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.BufferOverflow
+import org.ntust.app.tigerduck.data.cache.DataCache
+import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
+import org.ntust.app.tigerduck.ui.theme.courseColorPalette
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.random.Random
+
+/**
+ * Cross-ViewModel coordinator for schedule tile colors. Settings can invoke
+ * [resetAllColors] to randomize every course's color; all active ViewModels
+ * subscribe to [changeEvent] and reload their course state when it fires.
+ */
+@Singleton
+class CourseColorStore @Inject constructor(
+    private val dataCache: DataCache
+) {
+    private val _changeEvent = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val changeEvent: SharedFlow<Unit> = _changeEvent.asSharedFlow()
+
+    /**
+     * Assigns a fresh random preset color to every course. Distinct presets
+     * are drawn first; any course beyond the 18-color palette receives a
+     * random non-palette color. Persists to the cache and rebuilds the
+     * shared color map before broadcasting [changeEvent].
+     */
+    suspend fun resetAllColors() {
+        val courses = dataCache.loadCourses()
+        if (courses.isEmpty()) return
+
+        val palette = courseColorPalette.shuffled()
+        val paletteArgbs = palette.mapTo(mutableSetOf()) { it.toArgb() }
+        val used = mutableSetOf<Int>()
+
+        val updated = courses.mapIndexed { idx, course ->
+            val color = if (idx < palette.size) {
+                palette[idx].also { used.add(it.toArgb()) }
+            } else {
+                randomNonPaletteColor(paletteArgbs, used).also { used.add(it.toArgb()) }
+            }
+            course.copy(customColorHex = formatHex(color))
+        }
+
+        dataCache.saveCourses(updated)
+        TigerDuckTheme.buildCourseColorMap(updated)
+        _changeEvent.tryEmit(Unit)
+    }
+
+    private fun formatHex(color: Color): String =
+        "#" + String.format("%06X", color.toArgb() and 0xFFFFFF)
+
+    private fun randomNonPaletteColor(
+        paletteArgbs: Set<Int>,
+        alreadyUsed: Set<Int>
+    ): Color {
+        repeat(32) {
+            val h = Random.nextFloat() * 360f
+            val s = 0.55f + Random.nextFloat() * 0.4f
+            val v = 0.55f + Random.nextFloat() * 0.3f
+            val c = Color(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v)))
+            val argb = c.toArgb()
+            if (argb !in paletteArgbs && argb !in alreadyUsed) return c
+        }
+        return Color(
+            android.graphics.Color.HSVToColor(
+                floatArrayOf(Random.nextFloat() * 360f, 0.7f, 0.7f)
+            )
+        )
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/data/local/AppDatabase.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/local/AppDatabase.kt
@@ -12,7 +12,7 @@ import org.ntust.app.tigerduck.data.model.*
 
 @Database(
     entities = [Course::class, Assignment::class, CalendarEvent::class, Announcement::class],
-    version = 2,
+    version = 3,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -31,10 +31,16 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE courses ADD COLUMN customColorHex TEXT")
+            }
+        }
+
         fun create(context: Context): AppDatabase =
             Room.databaseBuilder(context, AppDatabase::class.java, "tigerduck.db")
                 .apply {
-                    addMigrations(MIGRATION_1_2)
+                    addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     if (BuildConfig.DEBUG) {
                         fallbackToDestructiveMigration(true)
                     }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/Course.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/Course.kt
@@ -17,7 +17,9 @@ data class Course(
     val maxCount: Int = 0,
     /** JSON: {"1":["3","4"],"3":["6","7"]} — keys = weekday (1=Mon..7=Sun) */
     val scheduleJson: String = "{}",
-    val moodleIdNumber: String? = null
+    val moodleIdNumber: String? = null,
+    /** User-picked tile color as "#RRGGBB". Null means hash-based palette assignment. */
+    val customColorHex: String? = null
 ) {
     @Ignore
     @Transient

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/HomeSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/HomeSection.kt
@@ -1,5 +1,6 @@
 package org.ntust.app.tigerduck.data.model
 
+// TODO: Add user adjustment of the order and visibility of sections
 data class HomeSection(
     val id: String,
     val type: HomeSectionType,
@@ -11,7 +12,8 @@ data class HomeSection(
     enum class HomeSectionType(val defaultTitle: String) {
         TODAY_COURSES("今日課程"),
         UPCOMING_ASSIGNMENTS("待辦作業"),
-        QUICK_WIDGETS("快速功能"),
+        // TODO: 快速功能
+//        QUICK_WIDGETS("快速功能"),
         CUSTOM("自訂區塊");
     }
 
@@ -19,15 +21,16 @@ data class HomeSection(
         fun defaults(): List<HomeSection> = listOf(
             HomeSection("today-courses", HomeSectionType.TODAY_COURSES, "今日課程", 0, true),
             HomeSection("upcoming-assignments", HomeSectionType.UPCOMING_ASSIGNMENTS, "待辦作業", 1, true),
-            HomeSection(
-                "quick-widgets", HomeSectionType.QUICK_WIDGETS, "快速功能", 2, true,
-                widgets = listOf(
-                    WidgetItem("w1", AppFeature.FREE_LUNCH),
-                    WidgetItem("w2", AppFeature.EMPTY_CLASSROOM),
-                    WidgetItem("w3", AppFeature.SCHOLARSHIP),
-                    WidgetItem("w4", AppFeature.GPA),
-                )
-            )
+            // TODO: 快速功能
+//            HomeSection(
+//                "quick-widgets", HomeSectionType.QUICK_WIDGETS, "快速功能", 2, true,
+//                widgets = listOf(
+//                    WidgetItem("w1", AppFeature.FREE_LUNCH),
+//                    WidgetItem("w2", AppFeature.EMPTY_CLASSROOM),
+//                    WidgetItem("w3", AppFeature.SCHOLARSHIP),
+//                    WidgetItem("w4", AppFeature.GPA),
+//                )
+//            )
         )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/HomeSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/HomeSection.kt
@@ -12,8 +12,8 @@ data class HomeSection(
     enum class HomeSectionType(val defaultTitle: String) {
         TODAY_COURSES("今日課程"),
         UPCOMING_ASSIGNMENTS("待辦作業"),
-        // TODO: 快速功能
-//        QUICK_WIDGETS("快速功能"),
+        @Deprecated("Feature temporarily disabled")
+        QUICK_WIDGETS("快速功能"),
         CUSTOM("自訂區塊");
     }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -47,6 +47,11 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
         get() = prefs.getString("browserPreference", "system") ?: "system"
         set(value) = prefs.edit().putString("browserPreference", value).apply()
 
+    /** One of "system", "dark", "light". */
+    var themeMode: String
+        get() = prefs.getString("themeMode", "system") ?: "system"
+        set(value) = prefs.edit().putString("themeMode", value).apply()
+
     var showAbsoluteAssignmentTime: Boolean
         get() = prefs.getBoolean("showAbsoluteAssignmentTime", false)
         set(value) = prefs.edit().putBoolean("showAbsoluteAssignmentTime", value).apply()
@@ -107,6 +112,11 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
+        /**
+         * Accent color palette — canonical (light-mode) hex. The user's pick
+         * is always stored as the light hex; [themeColorsDark] provides the
+         * paired dark variant at the same index so themes swap in-place.
+         */
         val themeColors: List<Pair<String, Int>> = listOf(
             "藍" to 0x007AFF,
             "紫" to 0xAF52DE,
@@ -117,5 +127,22 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
             "青" to 0x5AC8FA,
             "靛" to 0x5856D6,
         )
+
+        val themeColorsDark: List<Pair<String, Int>> = listOf(
+            "藍" to 0x0A84FF,
+            "紫" to 0xBF5AF2,
+            "粉" to 0xFF375F,
+            "紅" to 0xFF453A,
+            "橘" to 0xFF9F0A,
+            "綠" to 0x32D74B,
+            "青" to 0x64D2FF,
+            "靛" to 0x5E5CE6,
+        )
+
+        /** Look up the dark-mode companion for a given light-mode accent hex. */
+        fun accentDarkVariant(lightHex: Int): Int {
+            val idx = themeColors.indexOfFirst { it.second == lightHex }
+            return if (idx >= 0) themeColorsDark[idx].second else lightHex
+        }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -142,6 +142,15 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
             "靛" to 0x5E5CE6,
         )
 
+        init {
+            require(themeColors.size == themeColorsDark.size) {
+                "themeColors and themeColorsDark must be the same size"
+            }
+            require(themeColors.map { it.first } == themeColorsDark.map { it.first }) {
+                "themeColors and themeColorsDark must share names in the same order"
+            }
+        }
+
         /** Look up the dark-mode companion for a given light-mode accent hex. */
         fun accentDarkVariant(lightHex: Int): Int {
             val idx = themeColors.indexOfFirst { it.second == lightHex }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -93,7 +93,10 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
             val json = prefs.getString("homeSections", null) ?: return HomeSection.defaults()
             return try {
                 val type = object : TypeToken<List<HomeSection>>() {}.type
-                gson.fromJson<List<HomeSection>>(json, type)?.ifEmpty { HomeSection.defaults() }
+                @Suppress("DEPRECATION")
+                gson.fromJson<List<HomeSection>>(json, type)
+                    ?.filter { it.type != HomeSection.HomeSectionType.QUICK_WIDGETS }
+                    ?.ifEmpty { HomeSection.defaults() }
                     ?: HomeSection.defaults()
             } catch (e: Exception) {
                 HomeSection.defaults()

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CalendarService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CalendarService.kt
@@ -83,7 +83,7 @@ class CalendarService @Inject constructor() {
 
     private val currentRocYear: Int
         get() {
-            val cal = Calendar.getInstance()
+            val cal = Calendar.getInstance(TimeZone.getTimeZone("Asia/Taipei"))
             val year = cal.get(Calendar.YEAR) - 1911
             val month = cal.get(Calendar.MONTH) + 1
             return if (month >= 8) year else year - 1
@@ -153,12 +153,12 @@ class CalendarService @Inject constructor() {
                     if (title != null && start != null) {
                         val eventId = uid ?: "school-$title-${start.time}"
                         val end = dtEnd
-                        val cal = Calendar.getInstance()
+                        val taipeiTz = TimeZone.getTimeZone("Asia/Taipei")
 
                         if (end != null) {
                             // Check if multi-day
-                            val startCal = Calendar.getInstance().apply { time = start }
-                            val endCal = Calendar.getInstance().apply { time = Date(end.time - 1) }
+                            val startCal = Calendar.getInstance(taipeiTz).apply { time = start }
+                            val endCal = Calendar.getInstance(taipeiTz).apply { time = Date(end.time - 1) }
                             val isMultiDay = startCal.get(Calendar.DAY_OF_YEAR) != endCal.get(Calendar.DAY_OF_YEAR) ||
                                             startCal.get(Calendar.YEAR) != endCal.get(Calendar.YEAR)
 
@@ -169,7 +169,7 @@ class CalendarService @Inject constructor() {
                                 while (!current.after(lastDay) && daysAdded < 365) {
                                     val dayId = "$eventId-${current.time}"
                                     events.add(CalendarEvent(dayId, title, current, EventSource.SCHOOL.raw))
-                                    val next = Calendar.getInstance().apply {
+                                    val next = Calendar.getInstance(taipeiTz).apply {
                                         time = current
                                         add(Calendar.DAY_OF_YEAR, 1)
                                     }

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
@@ -127,7 +127,7 @@ class CourseService @Inject constructor(
     }
 
     fun currentSemesterCode(): String {
-        val cal = Calendar.getInstance()
+        val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ)
         val year = cal.get(Calendar.YEAR)
         val month = cal.get(Calendar.MONTH) + 1
         val rocYear = year - 1911

--- a/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
@@ -53,7 +53,7 @@ class MoodleService @Inject constructor(
                 ?: throw MoodleServiceError.SesskeyNotFound
 
             // Step 3: Call Moodle calendar API
-            val cal = Calendar.getInstance().apply {
+            val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply {
                 set(Calendar.HOUR_OF_DAY, 0)
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
@@ -15,6 +15,7 @@ import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import org.ntust.app.tigerduck.network.CalendarService
 import org.ntust.app.tigerduck.network.LoadingState
 import org.ntust.app.tigerduck.network.NtustSessionManager
+import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -62,8 +63,20 @@ class AppState @Inject constructor(
             prefs.accentColorHex = value
         }
 
+    /**
+     * Accent color resolved for the current theme mode. [accentColorHex] always
+     * stores the canonical (light) hex; in dark mode we return the paired
+     * dark variant so the tint stays vibrant against dark surfaces.
+     */
     val accentColor: Color
-        get() = Color(0xFF000000L or (accentColorHex.toLong() and 0xFFFFFFL))
+        get() {
+            val hex = if (TigerDuckTheme.isDarkMode) {
+                AppPreferences.accentDarkVariant(accentColorHex)
+            } else {
+                accentColorHex
+            }
+            return Color(0xFF000000L or (hex.toLong() and 0xFFFFFFL))
+        }
 
     private var rememberAnnouncementFilterState by mutableStateOf(prefs.rememberAnnouncementFilter)
 
@@ -98,6 +111,17 @@ class AppState @Inject constructor(
             if (browserPreferenceState == value) return
             browserPreferenceState = value
             prefs.browserPreference = value
+        }
+
+    private var themeModeState by mutableStateOf(prefs.themeMode)
+
+    /** One of "system", "dark", "light". */
+    var themeMode: String
+        get() = themeModeState
+        set(value) {
+            if (themeModeState == value) return
+            themeModeState = value
+            prefs.themeMode = value
         }
 
     private var timeSliderStyleState by mutableStateOf(prefs.timeSliderStyle)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
@@ -68,15 +68,14 @@ class AppState @Inject constructor(
      * stores the canonical (light) hex; in dark mode we return the paired
      * dark variant so the tint stays vibrant against dark surfaces.
      */
-    val accentColor: Color
-        get() {
-            val hex = if (TigerDuckTheme.isDarkMode) {
-                AppPreferences.accentDarkVariant(accentColorHex)
-            } else {
-                accentColorHex
-            }
-            return Color(0xFF000000L or (hex.toLong() and 0xFFFFFFL))
+    fun accentColor(isDark: Boolean = TigerDuckTheme.isDarkMode): Color {
+        val hex = if (isDark) {
+            AppPreferences.accentDarkVariant(accentColorHex)
+        } else {
+            accentColorHex
         }
+        return Color(0xFF000000L or (hex.toLong() and 0xFFFFFFL))
+    }
 
     private var rememberAnnouncementFilterState by mutableStateOf(prefs.rememberAnnouncementFilter)
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/AssignmentItem.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/AssignmentItem.kt
@@ -23,7 +23,7 @@ fun AssignmentItem(
     showAbsoluteTime: Boolean = false,
     onClick: (() -> Unit)? = null
 ) {
-    val courseColor = TigerDuckTheme.courseColor(assignment.courseNo)
+    val courseColor = TigerDuckTheme.courseColorVibrant(assignment.courseNo)
 
     Row(
         modifier = modifier

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
@@ -1,0 +1,375 @@
+package org.ntust.app.tigerduck.ui.component
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.ntust.app.tigerduck.ui.theme.ContentAlpha
+
+/**
+ * Bottom sheet that lets the user assign a tile color to a class.
+ * Shows a curated preset grid plus an HSV fine-tune panel for custom colors.
+ *
+ * @param usedByOthers maps preset colors that are currently assigned to OTHER
+ *                     courses — used only to show a small indicator dot so the
+ *                     user knows picking it will displace that course.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ColorPickerSheet(
+    courseName: String,
+    currentColor: Color,
+    presetPalette: List<Color>,
+    usedByOthers: Set<Int>,
+    onApply: (Color) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    val initialHsv = remember(currentColor) {
+        FloatArray(3).also { android.graphics.Color.colorToHSV(currentColor.toArgb(), it) }
+    }
+    var hue by remember { mutableFloatStateOf(initialHsv[0]) }
+    var sat by remember { mutableFloatStateOf(initialHsv[1]) }
+    var value by remember { mutableFloatStateOf(initialHsv[2]) }
+    var showCustom by remember { mutableStateOf(false) }
+
+    val selectedColor = remember(hue, sat, value) {
+        Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, sat, value)))
+    }
+    val selectedArgb = selectedColor.toArgb() or 0xFF000000.toInt()
+
+    fun setHsvFrom(color: Color) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.colorToHSV(color.toArgb(), hsv)
+        hue = hsv[0]; sat = hsv[1]; value = hsv[2]
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .padding(bottom = 24.dp)
+        ) {
+            Text(
+                text = "選擇顏色",
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = courseName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(Modifier.height(20.dp))
+
+            // Preview — matches the alpha used on the schedule grid tile.
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(selectedColor.copy(alpha = 0.85f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = courseName.ifBlank { "預覽" },
+                    color = Color.White,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+
+            Spacer(Modifier.height(22.dp))
+
+            SectionLabel(text = "預設（設選擇與它科重複顏色會導致該科顏色重新分配）")
+            Spacer(Modifier.height(10.dp))
+
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                maxItemsInEachRow = 6
+            ) {
+                presetPalette.forEach { preset ->
+                    val presetArgb = preset.toArgb() or 0xFF000000.toInt()
+                    ColorSwatch(
+                        color = preset,
+                        selected = presetArgb == selectedArgb,
+                        usedByOther = presetArgb in usedByOthers && presetArgb != selectedArgb,
+                        onClick = { setHsvFrom(preset) }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(18.dp))
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable { showCustom = !showCustom }
+                    .padding(vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SectionLabel(text = "自訂顏色", modifier = Modifier.weight(1f))
+                Icon(
+                    imageVector = if (showCustom) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY)
+                )
+            }
+
+            if (showCustom) {
+                Spacer(Modifier.height(8.dp))
+                SatValSquare(
+                    hue = hue,
+                    sat = sat,
+                    value = value,
+                    onSatValChange = { s, v -> sat = s; value = v }
+                )
+                Spacer(Modifier.height(12.dp))
+                HueSlider(
+                    hue = hue,
+                    onHueChange = { hue = it }
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "#" + String.format("%06X", selectedArgb and 0xFFFFFF),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+                    modifier = Modifier.align(Alignment.End)
+                )
+            }
+
+            Spacer(Modifier.height(22.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedButton(
+                    onClick = onDismiss,
+                    modifier = Modifier.weight(1f)
+                ) { Text("取消") }
+                Button(
+                    onClick = { onApply(selectedColor) },
+                    modifier = Modifier.weight(1f)
+                ) { Text("套用") }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String, modifier: Modifier = Modifier) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun ColorSwatch(
+    color: Color,
+    selected: Boolean,
+    usedByOther: Boolean,
+    onClick: () -> Unit
+) {
+    val surface = MaterialTheme.colorScheme.surface
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    Box(
+        modifier = Modifier.size(44.dp)
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .align(Alignment.Center)
+                .clip(CircleShape)
+                .background(color)
+                .clickable(onClick = onClick)
+                .then(
+                    if (selected) Modifier.border(3.dp, Color.White, CircleShape)
+                    else Modifier
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            if (selected) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = "已選",
+                    tint = Color.White,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+        if (usedByOther) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .align(Alignment.TopEnd)
+                    .clip(CircleShape)
+                    .background(surface)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .align(Alignment.Center)
+                        .clip(CircleShape)
+                        .background(onSurface.copy(alpha = 0.55f))
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SatValSquare(
+    hue: Float,
+    sat: Float,
+    value: Float,
+    onSatValChange: (sat: Float, value: Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val pureHueColor = remember(hue) {
+        Color(android.graphics.Color.HSVToColor(floatArrayOf(hue, 1f, 1f)))
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .pointerInput(Unit) {
+                detectDragGestures { change, _ ->
+                    val s = (change.position.x / size.width).coerceIn(0f, 1f)
+                    val v = 1f - (change.position.y / size.height).coerceIn(0f, 1f)
+                    onSatValChange(s, v)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val s = (offset.x / size.width).coerceIn(0f, 1f)
+                    val v = 1f - (offset.y / size.height).coerceIn(0f, 1f)
+                    onSatValChange(s, v)
+                }
+            }
+    ) {
+        drawRect(color = pureHueColor)
+        drawRect(brush = Brush.horizontalGradient(listOf(Color.White, Color.Transparent)))
+        drawRect(brush = Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+
+        val cx = sat * size.width
+        val cy = (1f - value) * size.height
+        val inner = 8.dp.toPx()
+        drawCircle(
+            color = Color.Black.copy(alpha = 0.4f),
+            radius = inner + 2.dp.toPx(),
+            center = Offset(cx, cy),
+            style = Stroke(width = 1.dp.toPx())
+        )
+        drawCircle(
+            color = Color.White,
+            radius = inner,
+            center = Offset(cx, cy),
+            style = Stroke(width = 2.dp.toPx())
+        )
+    }
+}
+
+@Composable
+private fun HueSlider(
+    hue: Float,
+    onHueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val hueStops = remember {
+        listOf(
+            Color(0xFFFF0000),
+            Color(0xFFFFFF00),
+            Color(0xFF00FF00),
+            Color(0xFF00FFFF),
+            Color(0xFF0000FF),
+            Color(0xFFFF00FF),
+            Color(0xFFFF0000)
+        )
+    }
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(28.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .pointerInput(Unit) {
+                detectDragGestures { change, _ ->
+                    val h = (change.position.x / size.width * 360f).coerceIn(0f, 360f)
+                    onHueChange(h)
+                }
+            }
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val h = (offset.x / size.width * 360f).coerceIn(0f, 360f)
+                    onHueChange(h)
+                }
+            }
+    ) {
+        drawRect(brush = Brush.horizontalGradient(hueStops))
+        val cx = (hue / 360f) * size.width
+        val cy = size.height / 2
+        val r = size.height / 2 - 2.dp.toPx()
+        drawCircle(
+            color = Color.Black.copy(alpha = 0.4f),
+            radius = r + 2.dp.toPx(),
+            center = Offset(cx, cy),
+            style = Stroke(width = 1.dp.toPx())
+        )
+        drawCircle(
+            color = Color.White,
+            radius = r,
+            center = Offset(cx, cy),
+            style = Stroke(width = 2.dp.toPx())
+        )
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
@@ -113,7 +113,8 @@ fun ColorPickerSheet(
             ) {
                 Text(
                     text = courseName.ifBlank { "預覽" },
-                    color = Color.White,
+                    color = if (selectedColor.red * 0.299f + selectedColor.green * 0.587f + selectedColor.blue * 0.114f > 0.5f)
+                        Color(0xFF1C1C1E) else Color.White,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ColorPickerSheet.kt
@@ -124,7 +124,7 @@ fun ColorPickerSheet(
 
             Spacer(Modifier.height(22.dp))
 
-            SectionLabel(text = "預設（設選擇與它科重複顏色會導致該科顏色重新分配）")
+            SectionLabel(text = "預設（若選擇與它科重複顏色會導致該科顏色重新分配）")
             Spacer(Modifier.height(10.dp))
 
             FlowRow(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ContentCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ContentCard.kt
@@ -17,7 +17,7 @@ fun ContentCard(
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
         colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = MaterialTheme.colorScheme.surface
         )
     ) {
         content()

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
@@ -20,6 +20,7 @@ import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 @Composable
 fun CourseCard(
     course: Course,
+    timeRange: String? = null,
     hasAssignment: Boolean = false,
     isFinished: Boolean = false,
     onClick: () -> Unit,
@@ -56,16 +57,22 @@ fun CourseCard(
                         overflow = TextOverflow.Ellipsis
                     )
                     Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = course.instructor,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY * textAlpha)
-                    )
                     if (course.classroom.isNotEmpty()) {
                         Text(
                             text = course.classroom,
                             style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY * textAlpha)
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY * textAlpha),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    if (timeRange != null) {
+                        Text(
+                            text = timeRange,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY * textAlpha),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
                         )
                     }
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
@@ -1,7 +1,5 @@
 package org.ntust.app.tigerduck.ui.component
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -10,8 +8,8 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -27,9 +25,16 @@ fun CourseCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val color = TigerDuckTheme.courseColor(course.courseNo)
-    val cardAlpha = if (isFinished) 0.08f else 0.15f
-    val accentAlpha = if (isFinished) 0.3f else 1f
+    // Vibrant (light-palette) color so the tint stays visible in dark mode.
+    val color = TigerDuckTheme.courseColorVibrant(course.courseNo)
+    val surface = MaterialTheme.colorScheme.surface
+    val lightAlpha = if (isFinished) 0.35f else 0.50f
+    val darkAlpha = if (isFinished) 0.35f else 0.55f
+    val cardColor = if (TigerDuckTheme.isDarkMode) {
+        color.copy(alpha = darkAlpha).compositeOver(surface)
+    } else {
+        color.copy(alpha = lightAlpha)
+    }
     val textAlpha = if (isFinished) 0.4f else 1f
 
     Card(
@@ -37,19 +42,11 @@ fun CourseCard(
         modifier = modifier
             .width(160.dp),
         shape = RoundedCornerShape(12.dp),
-        colors = CardDefaults.cardColors(containerColor = color.copy(alpha = cardAlpha)),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        colors = CardDefaults.cardColors(containerColor = cardColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
     ) {
         Box {
             Row(modifier = Modifier.padding(12.dp)) {
-                Box(
-                    modifier = Modifier
-                        .width(4.dp)
-                        .height(48.dp)
-                        .clip(RoundedCornerShape(2.dp))
-                        .background(color.copy(alpha = accentAlpha))
-                )
-                Spacer(Modifier.width(8.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = course.courseName,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
@@ -86,7 +86,7 @@ fun MainNavigation(appState: AppState) {
             Column {
                 if (isNonTaipeiTz) {
                     Text(
-                        text = "您目前不在臺灣時區，此 APP 已自動使用臺灣時區，請注意日期與時間！",
+                        text = "您目前不在臺灣時區，此 APP 已自動使用臺灣時區。\n請注意日期與時間，並敬祝您旅途平安！",
                         modifier = Modifier
                             .fillMaxWidth()
                             .background(Color(0xFFFFF3B0))

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
@@ -5,12 +5,20 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import org.ntust.app.tigerduck.AppConstants
+import java.time.Instant
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
@@ -67,9 +75,28 @@ fun MainNavigation(appState: AppState) {
     val bottomItems = configuredTabs + listOf(AppFeature.MORE)
     val startDest = remember { configuredTabs.firstOrNull()?.toRoute() ?: Screen.Home.route }
 
+    val isNonTaipeiTz = remember {
+        val now = Instant.now()
+        java.util.TimeZone.getDefault().getOffset(now.toEpochMilli()) !=
+            AppConstants.TAIPEI_TZ.getOffset(now.toEpochMilli())
+    }
+
     Scaffold(
         bottomBar = {
-            NavigationBar {
+            Column {
+                if (isNonTaipeiTz) {
+                    Text(
+                        text = "您目前不在臺灣時區，此 APP 已自動使用臺灣時區，請注意日期與時間！",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFFFFF3B0))
+                            .padding(horizontal = 12.dp, vertical = 8.dp),
+                        color = Color(0xFF5C4A00),
+                        style = MaterialTheme.typography.labelMedium,
+                        textAlign = TextAlign.Center
+                    )
+                }
+                NavigationBar {
                 bottomItems.forEach { feature ->
                     val route = feature.toRoute()
                     NavigationBarItem(
@@ -88,6 +115,7 @@ fun MainNavigation(appState: AppState) {
                         }
                     )
                 }
+            }
             }
         }
     ) { innerPadding ->

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsScreen.kt
@@ -145,7 +145,7 @@ private fun AnnouncementCard(announcement: Announcement, onClick: () -> Unit) {
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 6.dp)
             .clickable { onClick() },
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarScreen.kt
@@ -138,12 +138,13 @@ private fun MonthCalendar(
     onNextMonth: () -> Unit
 ) {
     val monthFmt = SimpleDateFormat("yyyy年M月", Locale.CHINESE)
-    val cal = Calendar.getInstance().apply { time = displayedMonth }
+    val taipeiTz = org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ
+    val cal = Calendar.getInstance(taipeiTz).apply { time = displayedMonth }
     val year = cal.get(Calendar.YEAR)
     val month = cal.get(Calendar.MONTH)
 
     // Build days
-    val firstDay = Calendar.getInstance().apply { set(year, month, 1) }
+    val firstDay = Calendar.getInstance(taipeiTz).apply { set(year, month, 1) }
     val daysInMonth = firstDay.getActualMaximum(Calendar.DAY_OF_MONTH)
     // Sunday = 1, Monday = 2... adjust to Mon-first
     val startDow = ((firstDay.get(Calendar.DAY_OF_WEEK) - 2 + 7) % 7)
@@ -193,7 +194,7 @@ private fun MonthCalendar(
                     if (dayNum < 1 || dayNum > daysInMonth) {
                         Box(modifier = Modifier.weight(1f).height(40.dp))
                     } else {
-                        val dayDate = Calendar.getInstance().apply {
+                        val dayDate = Calendar.getInstance(taipeiTz).apply {
                             set(year, month, dayNum, 0, 0, 0)
                             set(Calendar.MILLISECOND, 0)
                         }.time
@@ -282,8 +283,8 @@ private fun EventRow(event: CalendarEvent) {
 }
 
 private fun isSameDay(a: Date, b: Date): Boolean {
-    val ca = Calendar.getInstance().apply { time = a }
-    val cb = Calendar.getInstance().apply { time = b }
+    val ca = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply { time = a }
+    val cb = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply { time = b }
     return ca.get(Calendar.YEAR) == cb.get(Calendar.YEAR) &&
            ca.get(Calendar.DAY_OF_YEAR) == cb.get(Calendar.DAY_OF_YEAR)
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarViewModel.kt
@@ -65,7 +65,7 @@ class CalendarViewModel @Inject constructor(
     }
 
     fun previousMonth() {
-        val cal = Calendar.getInstance().apply {
+        val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply {
             time = _displayedMonth.value
             add(Calendar.MONTH, -1)
         }
@@ -73,7 +73,7 @@ class CalendarViewModel @Inject constructor(
     }
 
     fun nextMonth() {
-        val cal = Calendar.getInstance().apply {
+        val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply {
             time = _displayedMonth.value
             add(Calendar.MONTH, 1)
         }
@@ -177,8 +177,8 @@ class CalendarViewModel @Inject constructor(
         }
 
     private fun Date.isSameDay(other: Date): Boolean {
-        val cal1 = Calendar.getInstance().apply { time = this@isSameDay }
-        val cal2 = Calendar.getInstance().apply { time = other }
+        val cal1 = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply { time = this@isSameDay }
+        val cal2 = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).apply { time = other }
         return cal1.get(Calendar.YEAR) == cal2.get(Calendar.YEAR) &&
                cal1.get(Calendar.DAY_OF_YEAR) == cal2.get(Calendar.DAY_OF_YEAR)
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -36,9 +36,11 @@ import org.ntust.app.tigerduck.ui.component.CourseCard
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SectionHeader
 import org.ntust.app.tigerduck.ui.component.SyncIndicator
+import androidx.compose.ui.graphics.compositeOver
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import org.ntust.app.tigerduck.ui.theme.courseColorPalette
+import org.ntust.app.tigerduck.ui.theme.courseColorPaletteDark
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -238,8 +240,10 @@ fun ClassTableScreen(
     }
 
     courseToRecolor?.let { course ->
+        val isDark = TigerDuckTheme.isDarkMode
+        val displayPalette = if (isDark) courseColorPaletteDark else courseColorPalette
         val currentColor = TigerDuckTheme.courseColor(course.courseNo)
-        val usedByOthers = remember(courses, course.courseNo) {
+        val usedByOthers = remember(courses, course.courseNo, isDark) {
             courses
                 .asSequence()
                 .filter { it.courseNo != course.courseNo }
@@ -249,11 +253,22 @@ fun ClassTableScreen(
         ColorPickerSheet(
             courseName = course.courseName,
             currentColor = currentColor,
-            presetPalette = courseColorPalette,
+            presetPalette = displayPalette,
             usedByOthers = usedByOthers,
             onApply = { picked ->
-                val argb = picked.toArgb()
-                val hex = "#" + String.format("%06X", argb and 0xFFFFFF)
+                val pickedArgb = picked.toArgb() or 0xFF000000.toInt()
+                val displayIdx = displayPalette.indexOfFirst {
+                    (it.toArgb() or 0xFF000000.toInt()) == pickedArgb
+                }
+                // Preset picks are stored as the canonical (light) hex so
+                // switching theme later swaps automatically. Custom HSV picks
+                // keep the exact color in both modes.
+                val storedArgb = if (displayIdx >= 0) {
+                    courseColorPalette[displayIdx].toArgb()
+                } else {
+                    picked.toArgb()
+                }
+                val hex = "#" + String.format("%06X", storedArgb and 0xFFFFFF)
                 viewModel.updateCourseColor(course.courseNo, hex)
                 courseToRecolor = null
             },
@@ -363,7 +378,18 @@ private fun TimetableGrid(
                                 )
                             }
                             is ClassTableViewModel.CellRole.BlockStart -> {
-                                val color = TigerDuckTheme.courseColor(role.course.courseNo)
+                                val vibrantColor = TigerDuckTheme.courseColorVibrant(role.course.courseNo)
+                                val cellSurface = MaterialTheme.colorScheme.surface
+                                val cellBg = if (TigerDuckTheme.isDarkMode) {
+                                    vibrantColor.copy(alpha = 0.55f).compositeOver(cellSurface)
+                                } else {
+                                    vibrantColor.copy(alpha = 0.50f)
+                                }
+                                val cellTextColor = if (TigerDuckTheme.isDarkMode) {
+                                    Color.White
+                                } else {
+                                    Color(0xFF1C1C1E)
+                                }
                                 val hasBadge = viewModel.hasAssignment(role.course.courseNo)
                                 var showMenu by remember { mutableStateOf(false) }
                                 Box(
@@ -373,7 +399,7 @@ private fun TimetableGrid(
                                         .absoluteOffset(x = x, y = y)
                                         .padding(1.dp)
                                         .clip(RoundedCornerShape(6.dp))
-                                        .background(color.copy(alpha = 0.85f))
+                                        .background(cellBg)
                                         .combinedClickable(
                                             onClick = {
                                                 viewModel.selectCourse(role.course, weekday, period.id)
@@ -387,7 +413,7 @@ private fun TimetableGrid(
                                     Text(
                                         text = role.course.courseName,
                                         style = MaterialTheme.typography.labelSmall,
-                                        color = Color.White,
+                                        color = cellTextColor,
                                         textAlign = TextAlign.Center,
                                         maxLines = if (role.spanCount >= 2) 3 else 2,
                                         overflow = TextOverflow.Ellipsis,
@@ -402,7 +428,7 @@ private fun TimetableGrid(
                                                 .align(Alignment.BottomEnd)
                                                 .padding(3.dp)
                                                 .size(12.dp),
-                                            tint = Color.White.copy(alpha = 0.7f)
+                                            tint = cellTextColor.copy(alpha = 0.7f)
                                         )
                                     }
                                     DropdownMenu(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -116,7 +116,7 @@ fun ClassTableScreen(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     modifier = Modifier.padding(bottom = 12.dp)
                 ) {
-                    val today = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_WEEK)
+                    val today = java.util.Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).get(java.util.Calendar.DAY_OF_WEEK)
                     val dayIndex = when (today) {
                         java.util.Calendar.MONDAY -> 1; java.util.Calendar.TUESDAY -> 2
                         java.util.Calendar.WEDNESDAY -> 3; java.util.Calendar.THURSDAY -> 4

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -28,14 +28,17 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Book
+import androidx.compose.ui.graphics.toArgb
 import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.data.model.Course
+import org.ntust.app.tigerduck.ui.component.ColorPickerSheet
 import org.ntust.app.tigerduck.ui.component.CourseCard
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SectionHeader
 import org.ntust.app.tigerduck.ui.component.SyncIndicator
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
+import org.ntust.app.tigerduck.ui.theme.courseColorPalette
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +55,7 @@ fun ClassTableScreen(
     var showAddCourse by remember { mutableStateOf(false) }
     var courseToRename by remember { mutableStateOf<Course?>(null) }
     var renameText by remember { mutableStateOf("") }
+    var courseToRecolor by remember { mutableStateOf<Course?>(null) }
     var showCheckmark by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -164,6 +168,9 @@ fun ClassTableScreen(
                     },
                     onDelete = { course ->
                         viewModel.deleteCourse(course.courseNo)
+                    },
+                    onPickColor = { course ->
+                        courseToRecolor = course
                     }
                 )
             }
@@ -230,6 +237,30 @@ fun ClassTableScreen(
         )
     }
 
+    courseToRecolor?.let { course ->
+        val currentColor = TigerDuckTheme.courseColor(course.courseNo)
+        val usedByOthers = remember(courses, course.courseNo) {
+            courses
+                .asSequence()
+                .filter { it.courseNo != course.courseNo }
+                .map { TigerDuckTheme.courseColor(it.courseNo).toArgb() or 0xFF000000.toInt() }
+                .toSet()
+        }
+        ColorPickerSheet(
+            courseName = course.courseName,
+            currentColor = currentColor,
+            presetPalette = courseColorPalette,
+            usedByOthers = usedByOthers,
+            onApply = { picked ->
+                val argb = picked.toArgb()
+                val hex = "#" + String.format("%06X", argb and 0xFFFFFF)
+                viewModel.updateCourseColor(course.courseNo, hex)
+                courseToRecolor = null
+            },
+            onDismiss = { courseToRecolor = null }
+        )
+    }
+
     if (showAddCourse) {
         ModalBottomSheet(
             onDismissRequest = { showAddCourse = false }
@@ -253,7 +284,8 @@ private fun TimetableGrid(
     weekdays: List<Int>,
     periods: List<org.ntust.app.tigerduck.data.model.TimetablePeriod>,
     onRename: (Course) -> Unit = {},
-    onDelete: (Course) -> Unit = {}
+    onDelete: (Course) -> Unit = {},
+    onPickColor: (Course) -> Unit = {}
 ) {
     val haptic = LocalHapticFeedback.current
     val dayLabels = listOf("", "一", "二", "三", "四", "五", "六", "日")
@@ -382,6 +414,13 @@ private fun TimetableGrid(
                                             onClick = {
                                                 showMenu = false
                                                 onRename(role.course)
+                                            }
+                                        )
+                                        DropdownMenuItem(
+                                            text = { Text("選擇顏色") },
+                                            onClick = {
+                                                showMenu = false
+                                                onPickColor(role.course)
                                             }
                                         )
                                         DropdownMenuItem(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -116,19 +116,29 @@ fun ClassTableScreen(
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     modifier = Modifier.padding(bottom = 12.dp)
                 ) {
+                    val today = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_WEEK)
+                    val dayIndex = when (today) {
+                        java.util.Calendar.MONDAY -> 1; java.util.Calendar.TUESDAY -> 2
+                        java.util.Calendar.WEDNESDAY -> 3; java.util.Calendar.THURSDAY -> 4
+                        java.util.Calendar.FRIDAY -> 5; java.util.Calendar.SATURDAY -> 6
+                        else -> 7
+                    }
                     items(todayCourses) { course ->
+                        val timeRange = remember(course, dayIndex) {
+                            val periods = course.schedule[dayIndex]
+                                ?.sortedBy { AppConstants.Periods.chronologicalOrder.indexOf(it) }
+                            if (!periods.isNullOrEmpty()) {
+                                val first = AppConstants.PeriodTimes.mapping[periods.first()]
+                                val last = AppConstants.PeriodTimes.mapping[periods.last()]
+                                if (first != null && last != null) "${first.first}-${last.second}" else null
+                            } else null
+                        }
                         CourseCard(
                             course = course,
+                            timeRange = timeRange,
                             hasAssignment = viewModel.hasAssignment(course.courseNo),
                             isFinished = viewModel.isCourseFinishedToday(course),
                             onClick = {
-                                val today = java.util.Calendar.getInstance().get(java.util.Calendar.DAY_OF_WEEK)
-                                val dayIndex = when (today) {
-                                    java.util.Calendar.MONDAY -> 1; java.util.Calendar.TUESDAY -> 2
-                                    java.util.Calendar.WEDNESDAY -> 3; java.util.Calendar.THURSDAY -> 4
-                                    java.util.Calendar.FRIDAY -> 5; java.util.Calendar.SATURDAY -> 6
-                                    else -> 7
-                                }
                                 val firstPeriod = course.schedule[dayIndex]
                                     ?.minByOrNull { AppConstants.Periods.chronologicalOrder.indexOf(it) } ?: ""
                                 viewModel.selectCourse(course, dayIndex, firstPeriod)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -443,7 +443,8 @@ private fun TimetableGrid(
                                     }
                                     DropdownMenu(
                                         expanded = showMenu,
-                                        onDismissRequest = { showMenu = false }
+                                        onDismissRequest = { showMenu = false },
+                                        shape = RoundedCornerShape(12.dp)
                                     ) {
                                         DropdownMenuItem(
                                             text = { Text("重新命名") },

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.cache.DataCache
 import android.util.Log
 import org.ntust.app.tigerduck.data.model.Assignment
@@ -35,7 +36,8 @@ class ClassTableViewModel @Inject constructor(
     private val authService: AuthService,
     internal val courseService: CourseService,
     private val moodleService: MoodleService,
-    private val dataCache: DataCache
+    private val dataCache: DataCache,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     private val _courses = MutableStateFlow<List<Course>>(emptyList())
@@ -70,6 +72,17 @@ class ClassTableViewModel @Inject constructor(
             while (true) {
                 kotlinx.coroutines.delay(60_000)
                 _currentDayTime.value = currentDayTime()
+            }
+        }
+        viewModelScope.launch {
+            // Reload course state whenever Settings resets tile colors so
+            // our in-memory _courses doesn't fight the freshly-written cache.
+            courseColorStore.changeEvent.collect {
+                val fresh = dataCache.loadCourses()
+                if (fresh.isNotEmpty()) {
+                    _courses.value = fresh
+                    TigerDuckTheme.buildCourseColorMap(fresh)
+                }
             }
         }
     }
@@ -185,7 +198,7 @@ class ClassTableViewModel @Inject constructor(
         val updated = _courses.value + course
         _courses.value = updated
         viewModelScope.launch { dataCache.saveCourses(updated) }
-        TigerDuckTheme.buildCourseColorMap(updated.map { it.courseNo })
+        TigerDuckTheme.buildCourseColorMap(updated)
     }
 
     fun renameCourse(courseNo: String, newName: String) {
@@ -199,6 +212,28 @@ class ClassTableViewModel @Inject constructor(
     fun deleteCourse(courseNo: String) {
         val updated = _courses.value.filter { it.courseNo != courseNo }
         _courses.value = updated
+        viewModelScope.launch { dataCache.saveCourses(updated) }
+        TigerDuckTheme.buildCourseColorMap(updated)
+    }
+
+    /**
+     * Assigns [newHex] to [courseNo]. Pass null to clear the user-picked color
+     * and fall back to hash-based assignment. Any other course whose custom
+     * color matches [newHex] is automatically cleared so it gets reassigned
+     * through the palette probe logic.
+     */
+    fun updateCourseColor(courseNo: String, newHex: String?) {
+        val normalized = newHex?.uppercase()
+        val updated = _courses.value.map { course ->
+            when {
+                course.courseNo == courseNo -> course.copy(customColorHex = normalized)
+                normalized != null && course.customColorHex?.uppercase() == normalized ->
+                    course.copy(customColorHex = null)
+                else -> course
+            }
+        }
+        _courses.value = updated
+        TigerDuckTheme.buildCourseColorMap(updated)
         viewModelScope.launch { dataCache.saveCourses(updated) }
     }
 
@@ -238,7 +273,7 @@ class ClassTableViewModel @Inject constructor(
             if (cached.isNotEmpty()) {
                 _courses.value = cached
                 _assignments.value = cachedA
-                TigerDuckTheme.buildCourseColorMap(cached.map { it.courseNo })
+                TigerDuckTheme.buildCourseColorMap(cached)
             }
             fetchData()
         }
@@ -309,9 +344,14 @@ class ClassTableViewModel @Inject constructor(
                     }.awaitAll().filterNotNull()
                 }
                 if (courses.isNotEmpty()) {
-                    _courses.value = courses
-                    dataCache.saveCourses(courses)
-                    TigerDuckTheme.buildCourseColorMap(courses.map { it.courseNo })
+                    // Preserve user-picked tile colors across network refresh.
+                    val existingColors = _courses.value.associate { it.courseNo to it.customColorHex }
+                    val merged = courses.map { c ->
+                        c.copy(customColorHex = existingColors[c.courseNo])
+                    }
+                    _courses.value = merged
+                    dataCache.saveCourses(merged)
+                    TigerDuckTheme.buildCourseColorMap(merged)
                 }
             }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -232,11 +232,9 @@ class ClassTableViewModel @Inject constructor(
                 else -> course
             }
         }
-        viewModelScope.launch {
-            dataCache.saveCourses(updated)
-            _courses.value = updated
-            TigerDuckTheme.buildCourseColorMap(updated)
-        }
+        _courses.value = updated
+        TigerDuckTheme.buildCourseColorMap(updated)
+        viewModelScope.launch { dataCache.saveCourses(updated) }
     }
 
     sealed class CellRole {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -345,7 +345,7 @@ class ClassTableViewModel @Inject constructor(
                 }
                 if (courses.isNotEmpty()) {
                     // Preserve user-picked tile colors across network refresh.
-                    val existingColors = _courses.value.associate { it.courseNo to it.customColorHex }
+                    val existingColors = dataCache.loadCourses().associate { it.courseNo to it.customColorHex }
                     val merged = courses.map { c ->
                         c.copy(customColorHex = existingColors[c.courseNo])
                     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -88,7 +88,7 @@ class ClassTableViewModel @Inject constructor(
     }
 
     private fun currentDayTime(): DayTime {
-        val c = Calendar.getInstance()
+        val c = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ)
         val wd = when (c.get(Calendar.DAY_OF_WEEK)) {
             Calendar.MONDAY -> 1; Calendar.TUESDAY -> 2; Calendar.WEDNESDAY -> 3
             Calendar.THURSDAY -> 4; Calendar.FRIDAY -> 5; Calendar.SATURDAY -> 6

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -232,9 +232,11 @@ class ClassTableViewModel @Inject constructor(
                 else -> course
             }
         }
-        _courses.value = updated
-        TigerDuckTheme.buildCourseColorMap(updated)
-        viewModelScope.launch { dataCache.saveCourses(updated) }
+        viewModelScope.launch {
+            dataCache.saveCourses(updated)
+            _courses.value = updated
+            TigerDuckTheme.buildCourseColorMap(updated)
+        }
     }
 
     sealed class CellRole {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/CourseTimeSlot.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/CourseTimeSlot.kt
@@ -6,6 +6,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Calendar
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 data class CourseTimeSlot(
     val id: String,
@@ -18,7 +19,7 @@ data class CourseTimeSlot(
         private val dayKeyFormatter = DateTimeFormatter.ofPattern("yyyyMMdd", Locale.US)
 
         fun buildSlots(courses: List<Course>, weekday: Int, on: Date = Date()): List<CourseTimeSlot> {
-            val cal = Calendar.getInstance()
+            val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
             val slots = mutableListOf<CourseTimeSlot>()
 
             for (course in courses) {
@@ -32,7 +33,7 @@ data class CourseTimeSlot(
                 val startDate = dateFromTimeString(firstTime.first, on, cal) ?: continue
                 val endDate = dateFromTimeString(lastTime.second, on, cal) ?: continue
 
-                val dayKey = dayKeyFormatter.format(on.toInstant().atZone(java.time.ZoneId.systemDefault()))
+                val dayKey = dayKeyFormatter.format(on.toInstant().atZone(AppConstants.TAIPEI_ZONE))
                 slots.add(CourseTimeSlot(
                     id = "${course.courseNo}_$dayKey",
                     course = course,
@@ -49,7 +50,7 @@ data class CourseTimeSlot(
             centerDate: Date,
             dayRadius: Int = 28
         ): List<CourseTimeSlot> {
-            val cal = Calendar.getInstance()
+            val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
             val allSlots = mutableListOf<CourseTimeSlot>()
 
             for (offset in -dayRadius..dayRadius) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -259,6 +259,7 @@ private fun CourseDetailDialog(
 private fun greetingText(): String {
     val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
     return when {
+        hour < 6 -> "清晨好"
         hour < 12 -> "早安"
         hour < 18 -> "午安"
         else -> "晚安"

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -68,46 +68,46 @@ fun HomeScreen(
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-    PullToRefreshBox(
-        state = pullRefreshState,
-        isRefreshing = pullRefreshing,
-        onRefresh = {
-            pullRefreshing = true
-            viewModel.refresh()
-        },
-        modifier = Modifier.fillMaxSize()
-    ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+        PullToRefreshBox(
+            state = pullRefreshState,
+            isRefreshing = pullRefreshing,
+            onRefresh = {
+                pullRefreshing = true
+                viewModel.refresh()
+            },
+            modifier = Modifier.fillMaxSize()
         ) {
-            item {
-                PageHeader(title = greetingText()) {
-                    SyncIndicator(isLoading = isLoading, showCheckmark = showCheckmark)
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item {
+                    PageHeader(title = greetingText()) {
+                        SyncIndicator(isLoading = isLoading, showCheckmark = showCheckmark)
+                    }
+                }
+
+                items(sections) { section ->
+                    HomeSectionContent(
+                        section = section,
+                        allCourses = allCourses,
+                        upcomingAssignments = upcomingAssignments,
+                        hasUnfinishedAssignment = viewModel::hasUnfinishedAssignment,
+                        showAbsoluteTime = appState.showAbsoluteAssignmentTime,
+                        sliderStyle = appState.timeSliderStyle,
+                        invertDirection = appState.invertSliderDirection,
+                        skippedDates = skippedDates,
+                        onCourseClick = { viewModel.selectCourse(it) },
+                        onAssignmentClick = { openAssignmentInMoodle(context, it) },
+                        onSkipCourse = { course, date -> viewModel.toggleSkip(course, date) },
+                        onWidgetClick = { showComingSoon = true }
+                    )
                 }
             }
 
-            items(sections) { section ->
-                HomeSectionContent(
-                    section = section,
-                    allCourses = allCourses,
-                    upcomingAssignments = upcomingAssignments,
-                    hasUnfinishedAssignment = viewModel::hasUnfinishedAssignment,
-                    showAbsoluteTime = appState.showAbsoluteAssignmentTime,
-                    sliderStyle = appState.timeSliderStyle,
-                    invertDirection = appState.invertSliderDirection,
-                    skippedDates = skippedDates,
-                    onCourseClick = { viewModel.selectCourse(it) },
-                    onAssignmentClick = { openAssignmentInMoodle(context, it) },
-                    onSkipCourse = { course, date -> viewModel.toggleSkip(course, date) },
-                    onWidgetClick = { showComingSoon = true }
-                )
-            }
         }
-
-    }
-    SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
+        SnackbarHost(snackbarHostState, modifier = Modifier.align(Alignment.BottomCenter))
     } // Box
 
     if (showComingSoon) {
@@ -160,7 +160,6 @@ private fun HomeSectionContent(
                         message = "沒有待辦作業"
                     )
                 } else {
-                    val topAssignments = upcomingAssignments.take(5)
                     Card(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -169,21 +168,21 @@ private fun HomeSectionContent(
                             containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
-                        topAssignments.forEachIndexed { index, assignment ->
+                        upcomingAssignments.forEachIndexed { index, assignment ->
                             AssignmentItem(
                                 assignment = assignment,
                                 showAbsoluteTime = showAbsoluteTime,
                                 onClick = { onAssignmentClick(assignment) }
                             )
-                            if (index < topAssignments.lastIndex) {
+                            if (index < upcomingAssignments.lastIndex) {
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }
                     }
                 }
             }
-
-            HomeSection.HomeSectionType.QUICK_WIDGETS,
+            // TODO: 快速功能
+//            HomeSection.HomeSectionType.QUICK_WIDGETS,
             HomeSection.HomeSectionType.CUSTOM -> {
                 SectionHeader(title = section.title)
                 if (section.widgets.isNotEmpty()) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -257,7 +257,7 @@ private fun CourseDetailDialog(
 }
 
 private fun greetingText(): String {
-    val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
+    val hour = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ).get(Calendar.HOUR_OF_DAY)
     return when {
         hour < 6 -> "還不睡？"
         hour < 12 -> "早安"

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -166,7 +166,7 @@ private fun HomeSectionContent(
                             .fillMaxWidth()
                             .padding(horizontal = 16.dp),
                         colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                            containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
                         topAssignments.forEachIndexed { index, assignment ->
@@ -197,7 +197,7 @@ private fun HomeSectionContent(
                                     .size(80.dp)
                                     .clickable { onWidgetClick() },
                                 colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                    containerColor = MaterialTheme.colorScheme.surface
                                 )
                             ) {
                                 Column(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -182,8 +182,8 @@ private fun HomeSectionContent(
                     }
                 }
             }
-            // TODO: 快速功能
-//            HomeSection.HomeSectionType.QUICK_WIDGETS,
+            @Suppress("DEPRECATION")
+            HomeSection.HomeSectionType.QUICK_WIDGETS,
             HomeSection.HomeSectionType.CUSTOM -> {
                 SectionHeader(title = section.title)
                 if (section.widgets.isNotEmpty()) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -168,13 +168,14 @@ private fun HomeSectionContent(
                             containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
-                        upcomingAssignments.forEachIndexed { index, assignment ->
+                        val displayedAssignments = upcomingAssignments.take(5)
+                        displayedAssignments.forEachIndexed { index, assignment ->
                             AssignmentItem(
                                 assignment = assignment,
                                 showAbsoluteTime = showAbsoluteTime,
                                 onClick = { onAssignmentClick(assignment) }
                             )
-                            if (index < upcomingAssignments.lastIndex) {
+                            if (index < displayedAssignments.lastIndex) {
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -259,7 +259,6 @@ private fun CourseDetailDialog(
 private fun greetingText(): String {
     val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
     return when {
-        hour < 6 -> "深夜好"
         hour < 12 -> "早安"
         hour < 18 -> "午安"
         else -> "晚安"

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -259,7 +259,7 @@ private fun CourseDetailDialog(
 private fun greetingText(): String {
     val hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY)
     return when {
-        hour < 6 -> "清晨好"
+        hour < 6 -> "還不睡？"
         hour < 12 -> "早安"
         hour < 18 -> "午安"
         else -> "晚安"

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.model.*
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
@@ -35,7 +36,8 @@ class HomeViewModel @Inject constructor(
     private val courseService: CourseService,
     private val moodleService: MoodleService,
     private val notificationScheduler: AssignmentNotificationScheduler,
-    private val prefs: AppPreferences
+    private val prefs: AppPreferences,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     private val _sections = MutableStateFlow(prefs.homeSections)
@@ -73,6 +75,16 @@ class HomeViewModel @Inject constructor(
                 dataCache.saveSkippedDates(data)
             }
         }
+        viewModelScope.launch {
+            // Pick up color changes triggered from Settings (e.g. "重設課表顏色").
+            courseColorStore.changeEvent.collect {
+                val fresh = dataCache.loadCourses()
+                if (fresh.isNotEmpty()) {
+                    TigerDuckTheme.buildCourseColorMap(fresh)
+                    updateCoursesAndAssignments(fresh, _upcomingAssignments.value)
+                }
+            }
+        }
     }
 
     private var hasLoaded = false
@@ -88,7 +100,7 @@ class HomeViewModel @Inject constructor(
             val cachedCourses = dataCache.loadCourses()
             val cachedAssignments = dataCache.loadAssignments()
             if (cachedCourses.isNotEmpty() || cachedAssignments.isNotEmpty()) {
-                TigerDuckTheme.buildCourseColorMap(cachedCourses.map { it.courseNo })
+                TigerDuckTheme.buildCourseColorMap(cachedCourses)
                 updateCoursesAndAssignments(cachedCourses, cachedAssignments)
             }
 
@@ -120,8 +132,12 @@ class HomeViewModel @Inject constructor(
                     if (authenticated) {
                         val remoteCourses = fetchCourses(studentId, password)
                         if (!remoteCourses.isNullOrEmpty()) {
-                            courses = remoteCourses
-                            dataCache.saveCourses(remoteCourses)
+                            // Preserve user-picked tile colors across refresh.
+                            val pinned = courses.associate { it.courseNo to it.customColorHex }
+                            courses = remoteCourses.map { c ->
+                                c.copy(customColorHex = pinned[c.courseNo])
+                            }
+                            dataCache.saveCourses(courses)
                         }
 
                         val remoteAssignments = fetchAssignments(studentId, password)
@@ -133,7 +149,7 @@ class HomeViewModel @Inject constructor(
                 }
             }
 
-            TigerDuckTheme.buildCourseColorMap(courses.map { it.courseNo })
+            TigerDuckTheme.buildCourseColorMap(courses)
             updateCoursesAndAssignments(courses, assignments)
             if (forceRemote && authService.isNtustAuthenticated) {
                 _syncCompleteEvent.tryEmit(Unit)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package org.ntust.app.tigerduck.ui.screen.home
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import org.ntust.app.tigerduck.AppConstants
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.auth.AuthService
 import org.ntust.app.tigerduck.data.CourseColorStore
@@ -219,7 +220,7 @@ class HomeViewModel @Inject constructor(
 
     private fun updateCoursesAndAssignments(courses: List<Course>, assignments: List<Assignment>) {
         _allCourses.value = courses
-        val todayIndex = Calendar.getInstance().get(Calendar.DAY_OF_WEEK).let {
+        val todayIndex = Calendar.getInstance(AppConstants.TAIPEI_TZ).get(Calendar.DAY_OF_WEEK).let {
             // Android: Sun=1, Mon=2..Sat=7. We need Mon=1..Sun=7
             when (it) {
                 Calendar.MONDAY -> 1
@@ -258,7 +259,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun toggleSkip(course: Course, date: Date) {
-        val key = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate().format(SKIP_DATE_FMT)
+        val key = date.toInstant().atZone(AppConstants.TAIPEI_ZONE).toLocalDate().format(SKIP_DATE_FMT)
         _skippedDates.update { current ->
             val map = current.toMutableMap()
             val dates = (map[course.courseNo] ?: emptyList()).toMutableList()

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -132,10 +132,11 @@ class HomeViewModel @Inject constructor(
                     if (authenticated) {
                         val remoteCourses = fetchCourses(studentId, password)
                         if (!remoteCourses.isNullOrEmpty()) {
-                            // Preserve user-picked tile colors across refresh.
-                            val pinned = courses.associate { it.courseNo to it.customColorHex }
+                            // Re-read cache so a concurrent color change isn't erased.
+                            val latestColors = dataCache.loadCourses()
+                                .associate { it.courseNo to it.customColorHex }
                             courses = remoteCourses.map { c ->
-                                c.copy(customColorHex = pinned[c.courseNo])
+                                c.copy(customColorHex = latestColors[c.courseNo])
                             }
                             dataCache.saveCourses(courses)
                         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -92,7 +92,7 @@ fun TimeSliderSection(
                     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
                     modifier = Modifier.height(32.dp)
                 ) {
-                    Text("回到現在", style = MaterialTheme.typography.labelMedium)
+                    Text("現在", style = MaterialTheme.typography.labelMedium)
                 }
             }
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.data.model.Course
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
@@ -227,7 +228,7 @@ private fun SlotCard(
     modifier: Modifier = Modifier
 ) {
     val color = TigerDuckTheme.courseColorVibrant(slot.course.courseNo)
-    val cal = Calendar.getInstance()
+    val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
     val weekday = run {
         cal.time = slot.date
         when (cal.get(Calendar.DAY_OF_WEEK)) {
@@ -245,7 +246,7 @@ private fun SlotCard(
         if (first != null && last != null) "${first.first} - ${last.second}" else ""
     } else ""
 
-    val isToday = Calendar.getInstance().let {
+    val isToday = Calendar.getInstance(AppConstants.TAIPEI_TZ).let {
         val today = it.get(Calendar.DAY_OF_YEAR)
         cal.time = slot.date
         today == cal.get(Calendar.DAY_OF_YEAR) && it.get(Calendar.YEAR) == cal.get(Calendar.YEAR)
@@ -587,8 +588,8 @@ private val dateTimeFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEE
 private val dateLabelFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEE)", Locale.TRADITIONAL_CHINESE)
 
 private fun formatTimeLabel(date: Date): String {
-    val instant = date.toInstant().atZone(java.time.ZoneId.systemDefault())
-    val today = java.time.LocalDate.now()
+    val instant = date.toInstant().atZone(AppConstants.TAIPEI_ZONE)
+    val today = java.time.LocalDate.now(AppConstants.TAIPEI_ZONE)
     return if (instant.toLocalDate() == today) {
         timeFmt.format(instant)
     } else {
@@ -597,4 +598,4 @@ private fun formatTimeLabel(date: Date): String {
 }
 
 private fun formatDateLabel(date: Date): String =
-    dateLabelFmt.format(date.toInstant().atZone(java.time.ZoneId.systemDefault()))
+    dateLabelFmt.format(date.toInstant().atZone(AppConstants.TAIPEI_ZONE))

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -584,8 +584,8 @@ private fun SegmentedBarTrack(viewModel: TimeSliderViewModel, invertDirection: B
 }
 
 private val timeFmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
-private val dateTimeFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEE) HH:mm", Locale.TRADITIONAL_CHINESE)
-private val dateLabelFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEE)", Locale.TRADITIONAL_CHINESE)
+private val dateTimeFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEEEE) HH:mm", Locale.TRADITIONAL_CHINESE)
+private val dateLabelFmt = java.time.format.DateTimeFormatter.ofPattern("M/d (EEEEE)", Locale.TRADITIONAL_CHINESE)
 
 private fun formatTimeLabel(date: Date): String {
     val instant = date.toInstant().atZone(AppConstants.TAIPEI_ZONE)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
@@ -177,7 +178,7 @@ private fun CourseTimeCard(
             is CourseState.Between -> {
                 state.previous?.let {
                     SlotCard(
-                        slot = it, alpha = 0.5f,
+                        slot = it, alpha = 0.8f,
                         isSkipped = isSkippedFor(it),
                         onSkipToggle = { onSkipCourse(it.course, it.date) },
                         onClick = { onSelect(it.course) },
@@ -186,7 +187,7 @@ private fun CourseTimeCard(
                 }
                 state.next?.let {
                     SlotCard(
-                        slot = it, alpha = 0.5f,
+                        slot = it, alpha = 0.8f,
                         isSkipped = isSkippedFor(it),
                         onSkipToggle = { onSkipCourse(it.course, it.date) },
                         onClick = { onSelect(it.course) },
@@ -196,7 +197,7 @@ private fun CourseTimeCard(
             }
             is CourseState.BeforeFirst -> {
                 SlotCard(
-                    slot = state.next, alpha = 0.5f,
+                    slot = state.next, alpha = 0.8f,
                     isSkipped = isSkippedFor(state.next),
                     onSkipToggle = { onSkipCourse(state.next.course, state.next.date) },
                     onClick = { onSelect(state.next.course) },
@@ -205,7 +206,7 @@ private fun CourseTimeCard(
             }
             is CourseState.AfterLast -> {
                 SlotCard(
-                    slot = state.previous, alpha = 0.5f,
+                    slot = state.previous, alpha = 0.8f,
                     isSkipped = isSkippedFor(state.previous),
                     onSkipToggle = { onSkipCourse(state.previous.course, state.previous.date) },
                     onClick = { onSelect(state.previous.course) },
@@ -225,7 +226,7 @@ private fun SlotCard(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val color = TigerDuckTheme.courseColor(slot.course.courseNo)
+    val color = TigerDuckTheme.courseColorVibrant(slot.course.courseNo)
     val cal = Calendar.getInstance()
     val weekday = run {
         cal.time = slot.date
@@ -322,11 +323,20 @@ private fun SlotCard(
             Modifier.fillMaxWidth()
         }
 
+        val slotSurface = MaterialTheme.colorScheme.surface
+        val slotLightAlpha = if (alpha >= 1f) 0.50f else 0.35f
+        val slotDarkAlpha = if (alpha >= 1f) 0.55f else 0.40f
+        val slotContainer = if (TigerDuckTheme.isDarkMode) {
+            color.copy(alpha = slotDarkAlpha)
+                .compositeOver(slotSurface)
+        } else {
+            color.copy(alpha = slotLightAlpha)
+        }
         Card(
             onClick = onClick,
             modifier = cardModifier,
             shape = RoundedCornerShape(16.dp),
-            colors = CardDefaults.cardColors(containerColor = color.copy(alpha = 0.15f * alpha))
+            colors = CardDefaults.cardColors(containerColor = slotContainer)
         ) {
             Column(modifier = Modifier.padding(14.dp)) {
                 Row {
@@ -407,10 +417,12 @@ private fun FluidTrack(viewModel: TimeSliderViewModel, invertDirection: Boolean)
 
                     if (left + segW > -50 && left < size.width + 50) {
                         val isActive = viewModel.selectedTime >= slot.start && viewModel.selectedTime <= slot.end
-                        val courseColor = TigerDuckTheme.courseColor(slot.course.courseNo)
+                        val courseColor = TigerDuckTheme.courseColorVibrant(slot.course.courseNo)
 
                         drawRoundRect(
-                            color = courseColor.copy(alpha = if (isActive) 0.5f else 0.3f),
+                            color = courseColor.copy(
+                                alpha = TigerDuckTheme.tintAlpha(if (isActive) 0.5f else 0.3f)
+                            ),
                             topLeft = Offset(
                                 left,
                                 (trackH - TimeSliderViewModel.FLUID_SEGMENT_HEIGHT) / 2
@@ -466,7 +478,7 @@ private fun FluidTrack(viewModel: TimeSliderViewModel, invertDirection: Boolean)
 
                 // Glow dot
                 val glowColor = when (val s = viewModel.currentCourseState) {
-                    is CourseState.InClass -> TigerDuckTheme.courseColor(s.slot.course.courseNo)
+                    is CourseState.InClass -> TigerDuckTheme.courseColorVibrant(s.slot.course.courseNo)
                     else -> Color.White
                 }
                 val gs = TimeSliderViewModel.GLOW_DOT_SIZE
@@ -518,7 +530,16 @@ private fun SegmentedBarTrack(viewModel: TimeSliderViewModel, invertDirection: B
 
                 if (leftPx + segW > -50 && leftPx < widthPx + 50) {
                     val isSelected = viewModel.selectedTime >= slot.start && viewModel.selectedTime <= slot.end
-                    val courseColor = TigerDuckTheme.courseColor(slot.course.courseNo)
+                    val courseColor = TigerDuckTheme.courseColorVibrant(slot.course.courseNo)
+                    val segSurface = MaterialTheme.colorScheme.surface
+                    val segBaseAlpha = if (isSelected) 0.4f else 0.15f
+                    val segBg = if (TigerDuckTheme.isDarkMode) {
+                        courseColor.copy(alpha = (segBaseAlpha * 2.3f).coerceAtMost(1f))
+                            .compositeOver(segSurface)
+                    } else {
+                        courseColor.copy(alpha = segBaseAlpha)
+                    }
+                    val segTextAlpha = TigerDuckTheme.tintAlpha(if (isSelected) 1f else 0.7f)
                     val segWDp = with(density) { segW.toDp() }
                     val leftDp = with(density) { leftPx.toDp() }
 
@@ -529,7 +550,7 @@ private fun SegmentedBarTrack(viewModel: TimeSliderViewModel, invertDirection: B
                             .height(barHeightDp - 4.dp)
                             .align(Alignment.CenterStart)
                             .clip(RoundedCornerShape(12.dp))
-                            .background(courseColor.copy(alpha = if (isSelected) 0.4f else 0.15f)),
+                            .background(segBg),
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
@@ -539,7 +560,7 @@ private fun SegmentedBarTrack(viewModel: TimeSliderViewModel, invertDirection: B
                             } else {
                                 MaterialTheme.typography.labelSmall
                             },
-                            color = courseColor.copy(alpha = if (isSelected) 1f else 0.7f),
+                            color = courseColor.copy(alpha = segTextAlpha),
                             maxLines = 1,
                             overflow = TextOverflow.Clip,
                             fontSize = 10.sp

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderViewModel.kt
@@ -73,7 +73,7 @@ class TimeSliderViewModel(private val scope: CoroutineScope) {
                 val next = timeSlots[i + 1]
                 val gapMin = (next.start.time - slot.end.time) / 60_000.0
 
-                val cal = Calendar.getInstance()
+                val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ)
                 cal.time = slot.date
                 val slotDay = cal.get(Calendar.DAY_OF_YEAR)
                 cal.time = next.date

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
@@ -107,7 +107,7 @@ fun LibraryScreen(
             // QR Code section
             Card(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp).fillMaxWidth(),
@@ -165,7 +165,7 @@ fun LibraryScreen(
             // Login prompt
             Card(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
-                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
@@ -236,7 +236,7 @@ fun LibraryScreen(
 private fun FeatureCard(title: String, subtitle: String, modifier: Modifier = Modifier) {
     Card(
         modifier = modifier,
-        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
     ) {
         Column(
             modifier = Modifier.padding(16.dp).fillMaxWidth(),

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/more/MoreScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/more/MoreScreen.kt
@@ -1,5 +1,8 @@
 package org.ntust.app.tigerduck.ui.screen.more
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -10,6 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -33,9 +37,12 @@ private val implementedFeatures = setOf(
 fun MoreScreen(navController: NavController, appState: AppState) {
     var showNotImplemented by remember { mutableStateOf(false) }
 
+    val pageFeatures = listOf(AppFeature.HOME, AppFeature.CLASS_TABLE, AppFeature.CALENDAR)
+
     val grouped = AppFeature.moreFeatures
         .filter { feature ->
-            !feature.isLibraryRelated || appState.libraryFeatureEnabled
+            feature !in pageFeatures &&
+                (!feature.isLibraryRelated || appState.libraryFeatureEnabled)
         }
         .groupBy { it.category }
         .toList()
@@ -47,80 +54,121 @@ fun MoreScreen(navController: NavController, appState: AppState) {
     ) {
         item {
             PageHeader(title = "更多") {
-                IconButton(onClick = { navController.navigate(Screen.Settings.route) }) {
-                    Icon(Icons.Filled.Settings, "設定")
+                IconButton(
+                    onClick = { navController.navigate(Screen.Settings.route) }
+                ) {
+                    Icon(
+                        Icons.Filled.Settings, "設定",
+                        modifier = Modifier.size(28.dp)
+                    )
                 }
             }
+        }
+
+        // 頁面 section (first section)
+        item { SectionHeader(title = "頁面") }
+        item {
+            FeatureGrid(
+                features = pageFeatures,
+                implementedFeatures = implementedFeatures,
+                navController = navController,
+                onNotImplemented = { showNotImplemented = true }
+            )
         }
 
         grouped.forEachIndexed { index, (category, features) ->
             item {
                 SectionHeader(
                     title = category?.displayName ?: "其他",
-                    modifier = if (index > 0) Modifier.padding(top = 16.dp) else Modifier
+                    modifier = Modifier.padding(top = 16.dp)
                 )
             }
             item {
-                val rows = features.chunked(2)
-                Column(
-                    modifier = Modifier.padding(horizontal = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    rows.forEach { rowFeatures ->
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            rowFeatures.forEach { feature ->
-                                Card(
-                                    onClick = {
-                                        if (feature in implementedFeatures) {
-                                            navController.navigate(feature.toRoute())
-                                        } else {
-                                            showNotImplemented = true
-                                        }
-                                    },
-                                    modifier = Modifier
-                                        .weight(1f)
-                                        .aspectRatio(1.6f),
-                                    shape = RoundedCornerShape(12.dp),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surface
-                                    )
-                                ) {
-                                    Column(
-                                        modifier = Modifier
-                                            .fillMaxSize()
-                                            .padding(14.dp),
-                                        verticalArrangement = Arrangement.SpaceBetween
-                                    ) {
-                                        Icon(
-                                            imageVector = feature.icon,
-                                            contentDescription = null,
-                                            tint = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(24.dp)
-                                        )
-                                        Text(
-                                            text = feature.displayName,
-                                            style = MaterialTheme.typography.titleLarge.copy(
-                                                fontWeight = FontWeight.SemiBold
-                                            )
-                                        )
-                                    }
-                                }
-                            }
-                            // Pad with spacer if odd number
-                            if (rowFeatures.size == 1) {
-                                Spacer(modifier = Modifier.weight(1f))
-                            }
-                        }
-                    }
-                }
+                FeatureGrid(
+                    features = features,
+                    implementedFeatures = implementedFeatures,
+                    navController = navController,
+                    onNotImplemented = { showNotImplemented = true }
+                )
             }
         }
     }
 
     if (showNotImplemented) {
         ComingSoonDialog(onDismiss = { showNotImplemented = false })
+    }
+}
+
+@Composable
+private fun FeatureGrid(
+    features: List<AppFeature>,
+    implementedFeatures: Set<AppFeature>,
+    navController: NavController,
+    onNotImplemented: () -> Unit
+) {
+    val rows = features.chunked(2)
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        rows.forEach { rowFeatures ->
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                rowFeatures.forEach { feature ->
+                    val interactionSource = remember { MutableInteractionSource() }
+                    val isPressed by interactionSource.collectIsPressedAsState()
+                    val scale by animateFloatAsState(
+                        targetValue = if (isPressed) 0.92f else 1f,
+                        label = "cardScale"
+                    )
+                    Card(
+                        onClick = {
+                            if (feature in implementedFeatures) {
+                                navController.navigate(feature.toRoute())
+                            } else {
+                                onNotImplemented()
+                            }
+                        },
+                        interactionSource = interactionSource,
+                        modifier = Modifier
+                            .weight(1f)
+                            .aspectRatio(1.6f)
+                            .graphicsLayer {
+                                scaleX = scale
+                                scaleY = scale
+                            },
+                        shape = RoundedCornerShape(12.dp),
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surface
+                        )
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(14.dp),
+                            verticalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Icon(
+                                imageVector = feature.icon,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(32.dp)
+                            )
+                            Text(
+                                text = feature.displayName,
+                                style = MaterialTheme.typography.titleLarge.copy(
+                                    fontWeight = FontWeight.SemiBold
+                                )
+                            )
+                        }
+                    }
+                }
+                if (rowFeatures.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/more/MoreScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/more/MoreScreen.kt
@@ -85,7 +85,7 @@ fun MoreScreen(navController: NavController, appState: AppState) {
                                         .aspectRatio(1.6f),
                                     shape = RoundedCornerShape(12.dp),
                                     colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
+                                        containerColor = MaterialTheme.colorScheme.surface
                                     )
                                 ) {
                                     Column(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
@@ -502,7 +503,7 @@ private fun SettingsPickerRow(
             Text(value, style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = ContentAlpha.SECONDARY))
 
-            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }, shape = RoundedCornerShape(12.dp)) {
                 options.forEach { (key, display) ->
                     DropdownMenuItem(
                         text = { Text(display) },
@@ -510,10 +511,11 @@ private fun SettingsPickerRow(
                             onSelect(key)
                             expanded = false
                         },
-                        trailingIcon = {
-                            if (selectedKey == key) {
-                                Text("\u2713", color = MaterialTheme.colorScheme.primary)
-                            }
+                        leadingIcon = {
+                            RadioButton(
+                                selected = selectedKey == key,
+                                onClick = null
+                            )
                         }
                     )
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -35,6 +35,7 @@ import org.ntust.app.tigerduck.ui.component.ContentCard
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SectionHeader
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
+import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -64,6 +65,7 @@ fun SettingsScreen(
     val invertSlider = viewModel.appState.invertSliderDirection
     val notifyAssignments = viewModel.appState.notifyAssignments
     val libraryEnabled = viewModel.appState.libraryFeatureEnabled
+    val themeMode = viewModel.appState.themeMode
 
     var showLibraryWarning by remember { mutableStateOf(false) }
     var showResetColorsConfirm by remember { mutableStateOf(false) }
@@ -247,33 +249,32 @@ fun SettingsScreen(
                 Column {
                     SettingsLinkRow("Tab 編輯器") { onNavigateToTabEditor() }
                     HorizontalDivider()
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clickable { showResetColorsConfirm = true }
-                            .padding(horizontal = 16.dp, vertical = 14.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text("重設課表顏色", style = MaterialTheme.typography.bodyMedium)
-                    }
-                    HorizontalDivider()
                     Column(
                         modifier = Modifier.fillMaxWidth().padding(16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         Text("主題色", style = MaterialTheme.typography.bodyMedium)
+                        // Show the mode-appropriate display color but always
+                        // persist the canonical (light) hex so the pair swaps
+                        // when the user toggles 顏色主題.
+                        val accentPaletteDisplay = if (TigerDuckTheme.isDarkMode) {
+                            AppPreferences.themeColorsDark
+                        } else {
+                            AppPreferences.themeColors
+                        }
                         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                            AppPreferences.themeColors.forEach { (_, hex) ->
-                                val color = Color(0xFF000000 or hex.toLong())
+                            accentPaletteDisplay.forEachIndexed { idx, (_, displayHex) ->
+                                val canonicalHex = AppPreferences.themeColors[idx].second
+                                val color = Color(0xFF000000 or displayHex.toLong())
                                 Box(
                                     modifier = Modifier
                                         .size(32.dp)
                                         .clip(CircleShape)
                                         .background(color)
-                                        .clickable { viewModel.appState.accentColorHex = hex },
+                                        .clickable { viewModel.appState.accentColorHex = canonicalHex },
                                     contentAlignment = Alignment.Center
                                 ) {
-                                    if (accentColorHex == hex) {
+                                    if (accentColorHex == canonicalHex) {
                                         Text("\u2713", color = Color.White, style = MaterialTheme.typography.labelSmall)
                                     }
                                 }
@@ -333,6 +334,7 @@ fun SettingsScreen(
         item { SectionHeader("其他功能") }
         item {
             ContentCard {
+                Column {
                 SettingsToggleRow("圖書館及相關功能", libraryEnabled) { enabled ->
                     if (enabled) {
                         showLibraryWarning = true
@@ -342,6 +344,34 @@ fun SettingsScreen(
                             viewModel.appState.configuredTabs.filter { !it.isLibraryRelated }
                     }
                 }
+                HorizontalDivider()
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(SettingRowHeight)
+                        .clickable { showResetColorsConfirm = true }
+                        .padding(horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("重設課表顏色", style = MaterialTheme.typography.bodyMedium)
+                }
+                HorizontalDivider()
+                SettingsPickerRow(
+                    label = "顏色主題",
+                    value = when (themeMode) {
+                        "dark" -> "暗色模式"
+                        "light" -> "亮色模式"
+                        else -> "跟隨系統"
+                    },
+                    options = listOf(
+                        "system" to "跟隨系統",
+                        "dark" to "暗色模式",
+                        "light" to "亮色模式"
+                    ),
+                    selectedKey = themeMode,
+                    onSelect = { viewModel.appState.themeMode = it }
+                )
+                } // Column
             }
         }
 
@@ -403,10 +433,15 @@ fun SettingsScreen(
     }
 }
 
+private val SettingRowHeight = 56.dp
+
 @Composable
 private fun SettingsRow(label: String, value: String) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 14.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(SettingRowHeight)
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
@@ -418,11 +453,29 @@ private fun SettingsRow(label: String, value: String) {
 @Composable
 private fun SettingsToggleRow(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
     Row(
-        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(SettingRowHeight)
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
-        Switch(checked = checked, onCheckedChange = onCheckedChange)
+        // iOS-style switch colors: the default M3 unchecked thumb is `outline`
+        // which collapses to near-invisible dark gray on the dark track in
+        // dark mode. Force a white thumb and a neutral track instead.
+        val isDark = TigerDuckTheme.isDarkMode
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = MaterialTheme.colorScheme.primary,
+                checkedBorderColor = Color.Transparent,
+                uncheckedThumbColor = Color.White,
+                uncheckedTrackColor = if (isDark) Color(0xFF39393D) else Color(0xFFE9E9EB),
+                uncheckedBorderColor = Color.Transparent,
+            )
+        )
     }
 }
 
@@ -439,8 +492,9 @@ private fun SettingsPickerRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .height(SettingRowHeight)
             .clickable { expanded = true }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
@@ -473,8 +527,9 @@ private fun SettingsLinkRow(label: String, onClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .height(SettingRowHeight)
             .clickable { onClick() }
-            .padding(horizontal = 16.dp, vertical = 14.dp),
+            .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -66,6 +66,7 @@ fun SettingsScreen(
     val libraryEnabled = viewModel.appState.libraryFeatureEnabled
 
     var showLibraryWarning by remember { mutableStateOf(false) }
+    var showResetColorsConfirm by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
 
     val appVersion = remember { BuildConfig.VERSION_NAME }
@@ -239,38 +240,47 @@ fun SettingsScreen(
             }
         }
 
-        // MARK: Theme
+        // MARK: Custom
         item { SectionHeader("自訂") }
         item {
             ContentCard {
-                Column(modifier = Modifier.fillMaxWidth().padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    Text("主題色", style = MaterialTheme.typography.bodyMedium)
-                    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                        AppPreferences.themeColors.forEach { (_, hex) ->
-                            val color = Color(0xFF000000 or hex.toLong())
-                            Box(
-                                modifier = Modifier
-                                    .size(32.dp)
-                                    .clip(CircleShape)
-                                    .background(color)
-                                    .clickable { viewModel.appState.accentColorHex = hex },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                if (accentColorHex == hex) {
-                                    Text("\u2713", color = Color.White, style = MaterialTheme.typography.labelSmall)
+                Column {
+                    SettingsLinkRow("Tab 編輯器") { onNavigateToTabEditor() }
+                    HorizontalDivider()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { showResetColorsConfirm = true }
+                            .padding(horizontal = 16.dp, vertical = 14.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("重設課表顏色", style = MaterialTheme.typography.bodyMedium)
+                    }
+                    HorizontalDivider()
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Text("主題色", style = MaterialTheme.typography.bodyMedium)
+                        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            AppPreferences.themeColors.forEach { (_, hex) ->
+                                val color = Color(0xFF000000 or hex.toLong())
+                                Box(
+                                    modifier = Modifier
+                                        .size(32.dp)
+                                        .clip(CircleShape)
+                                        .background(color)
+                                        .clickable { viewModel.appState.accentColorHex = hex },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    if (accentColorHex == hex) {
+                                        Text("\u2713", color = Color.White, style = MaterialTheme.typography.labelSmall)
+                                    }
                                 }
                             }
                         }
                     }
                 }
-            }
-        }
-
-        // Tab Editor link
-        item {
-            ContentCard {
-                SettingsLinkRow("Tab 編輯器") { onNavigateToTabEditor() }
             }
         }
 
@@ -372,6 +382,23 @@ fun SettingsScreen(
                 showLibraryWarning = false
             },
             onDismiss = { showLibraryWarning = false }
+        )
+    }
+
+    if (showResetColorsConfirm) {
+        AlertDialog(
+            onDismissRequest = { showResetColorsConfirm = false },
+            title = { Text("確定要重設課表顏色？") },
+            text = { Text("這將會把課表的顏色依照預設顏色隨機重新分配") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.resetCourseColors()
+                    showResetColorsConfirm = false
+                }) { Text("確定") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showResetColorsConfirm = false }) { Text("取消") }
+            }
         )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package org.ntust.app.tigerduck.ui.screen.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.CourseColorStore
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import org.ntust.app.tigerduck.network.LibraryService
@@ -21,7 +22,8 @@ class SettingsViewModel @Inject constructor(
     private val libraryService: LibraryService,
     private val credentials: CredentialManager,
     val prefs: AppPreferences,
-    private val notificationScheduler: AssignmentNotificationScheduler
+    private val notificationScheduler: AssignmentNotificationScheduler,
+    private val courseColorStore: CourseColorStore
 ) : ViewModel() {
 
     val isNtustLoggingIn = authService.isLoggingIn
@@ -81,4 +83,8 @@ class SettingsViewModel @Inject constructor(
     val ntustStudentId: String? get() = authService.storedStudentId
 
     fun cancelAllAssignmentNotifications() = notificationScheduler.cancelAllTracked()
+
+    fun resetCourseColors() {
+        viewModelScope.launch { courseColorStore.resetAllColors() }
+    }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
@@ -5,11 +5,17 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import org.ntust.app.tigerduck.data.model.Course
 import kotlin.random.Random
 
+/**
+ * Canonical (light-mode) schedule palette. Persistence layer always stores the
+ * light-mode hex; [courseColorPaletteDark] provides the paired dark variant at
+ * the same index so switching themes keeps the "same" class color.
+ */
 val courseColorPalette: List<Color> = listOf(
     Color(0xFFDC2626), // Red
     Color(0xFFEA580C), // Orange
@@ -31,9 +37,50 @@ val courseColorPalette: List<Color> = listOf(
     Color(0xFF475569), // Slate
 )
 
+val courseColorPaletteDark: List<Color> = listOf(
+    Color(0xFFB91C1C), // Red-700
+    Color(0xFFC2410C), // Orange-700
+    Color(0xFFB45309), // Amber-700
+    Color(0xFFA16207), // Ochre-700
+    Color(0xFF4D7C0F), // Lime-700
+    Color(0xFF15803D), // Green-700
+    Color(0xFF047857), // Emerald-700
+    Color(0xFF0F766E), // Teal-700
+    Color(0xFF0E7490), // Cyan-700
+    Color(0xFF0369A1), // Sky-700
+    Color(0xFF1D4ED8), // Blue-700
+    Color(0xFF4338CA), // Indigo-700
+    Color(0xFF6D28D9), // Violet-700
+    Color(0xFF7E22CE), // Purple-700
+    Color(0xFFA21CAF), // Fuchsia-700
+    Color(0xFFBE185D), // Pink-700
+    Color(0xFFBE123C), // Rose-700
+    Color(0xFF334155), // Slate-700
+)
+
 object TigerDuckTheme {
     @Volatile
     private var courseColorMap: Map<String, Color> = emptyMap()
+
+    // Compose-observable so course tiles recompose when the app switches theme.
+    private val _isDarkMode = mutableStateOf(false)
+    val isDarkMode: Boolean get() = _isDarkMode.value
+
+    fun setDarkMode(dark: Boolean) {
+        if (_isDarkMode.value != dark) _isDarkMode.value = dark
+    }
+
+    /**
+     * If the stored color matches an entry in the canonical (light) palette,
+     * return the corresponding dark variant when dark mode is active.
+     * Custom HSV picks don't land on a palette index so they're returned as-is.
+     */
+    private fun resolveForMode(stored: Color): Color {
+        if (!_isDarkMode.value) return stored
+        val argb = stored.toArgb()
+        val idx = courseColorPalette.indexOfFirst { it.toArgb() == argb }
+        return if (idx >= 0) courseColorPaletteDark[idx] else stored
+    }
 
     fun buildCourseColorMap(courses: List<Course>) {
         val map = mutableMapOf<String, Color>()
@@ -62,8 +109,27 @@ object TigerDuckTheme {
     }
 
     fun courseColor(courseNo: String): Color {
-        courseColorMap[courseNo]?.let { return it }
-        return courseColorPalette[courseHashIndex(courseNo)]
+        val stored = courseColorMap[courseNo] ?: courseColorPalette[courseHashIndex(courseNo)]
+        return resolveForMode(stored)
+    }
+
+    /**
+     * Returns the vibrant (light-palette) color regardless of dark mode. Use
+     * this for low-alpha tints and colored text — the darker variant at low
+     * opacity disappears against dark surfaces.
+     */
+    fun courseColorVibrant(courseNo: String): Color {
+        return courseColorMap[courseNo] ?: courseColorPalette[courseHashIndex(courseNo)]
+    }
+
+    /**
+     * Multiplies a tint alpha that was tuned for light mode so it stays
+     * visible in dark mode. Dark surfaces swallow low-alpha tints, so we
+     * roughly 2.3× the opacity (capped at 1.0) when the app is in dark mode.
+     */
+    fun tintAlpha(lightModeAlpha: Float): Float {
+        return if (_isDarkMode.value) (lightModeAlpha * 2.3f).coerceAtMost(1f)
+        else lightModeAlpha
     }
 
     private fun pickFreeColor(courseNo: String, taken: Set<Color>): Color {
@@ -126,24 +192,75 @@ object CornerRadius {
     const val xl = 24
 }
 
-private val DarkColorScheme = darkColorScheme(
-    primary = Color(0xFF007AFF),
-    secondary = Color(0xFF5AC8FA),
-    background = Color(0xFF1C1C1E),
-    surface = Color(0xFF2C2C2E),
-    onPrimary = Color.White,
-    onBackground = Color.White,
-    onSurface = Color.White,
-)
-
+// iOS-inspired, Material 3 color scheme. Keeping the slots explicit (rather
+// than letting M3 derive tonal variants from `primary`) prevents the pinkish
+// tint M3 otherwise applies to surfaceVariant when primary is blue.
 private val LightColorScheme = lightColorScheme(
     primary = Color(0xFF007AFF),
-    secondary = Color(0xFF5AC8FA),
-    background = Color(0xFFF2F2F7),
-    surface = Color.White,
     onPrimary = Color.White,
+    primaryContainer = Color(0xFFDDE7FF),
+    onPrimaryContainer = Color(0xFF001A41),
+
+    secondary = Color(0xFF5B5F68),
+    onSecondary = Color.White,
+    secondaryContainer = Color(0xFFE1E2E8),
+    onSecondaryContainer = Color(0xFF181A20),
+
+    tertiary = Color(0xFF5AC8FA),
+    onTertiary = Color.White,
+
+    background = Color(0xFFF2F2F7),      // iOS systemGroupedBackground
     onBackground = Color(0xFF1C1C1E),
+
+    surface = Color.White,               // cards
     onSurface = Color(0xFF1C1C1E),
+
+    surfaceVariant = Color(0xFFE9E9EE),  // subtle fills (chips, disabled bg)
+    onSurfaceVariant = Color(0xFF5B5F68),
+
+    outline = Color(0xFFC6C6C8),         // iOS separator
+    outlineVariant = Color(0xFFE0E0E5),
+
+    error = Color(0xFFDC2626),
+    onError = Color.White,
+    errorContainer = Color(0xFFFEE2E2),
+    onErrorContainer = Color(0xFF7F1D1D),
+
+    surfaceTint = Color(0xFF007AFF),
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFF0A84FF),
+    onPrimary = Color.White,
+    primaryContainer = Color(0xFF003585),
+    onPrimaryContainer = Color(0xFFD5E4FF),
+
+    secondary = Color(0xFFAEAEB2),
+    onSecondary = Color(0xFF2C2C2E),
+    secondaryContainer = Color(0xFF2C2C2E),
+    onSecondaryContainer = Color(0xFFE5E5EA),
+
+    tertiary = Color(0xFF64D2FF),
+    onTertiary = Color.White,
+
+    background = Color(0xFF000000),      // iOS systemBackground (dark)
+    onBackground = Color.White,
+
+    surface = Color(0xFF1C1C1E),         // cards
+    onSurface = Color.White,
+
+    surfaceVariant = Color(0xFF2C2C2E),
+    onSurfaceVariant = Color(0xFFAEAEB2),
+
+    outline = Color(0xFF38383A),
+    outlineVariant = Color(0xFF2C2C2E),
+
+    error = Color(0xFFEF4444),
+    onError = Color.White,
+    errorContainer = Color(0xFF5F1B14),
+    onErrorContainer = Color(0xFFFEE2E2),
+
+    surfaceTint = Color(0xFF0A84FF),
 )
 
 @Composable
@@ -153,9 +270,9 @@ fun TigerDuckAppTheme(
     content: @Composable () -> Unit
 ) {
     val colorScheme = if (darkTheme) {
-        DarkColorScheme.copy(primary = accentColor)
+        DarkColorScheme.copy(primary = accentColor, surfaceTint = accentColor)
     } else {
-        LightColorScheme.copy(primary = accentColor)
+        LightColorScheme.copy(primary = accentColor, surfaceTint = accentColor)
     }
 
     MaterialTheme(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
@@ -6,45 +6,102 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import org.ntust.app.tigerduck.data.model.Course
+import kotlin.random.Random
 
 val courseColorPalette: List<Color> = listOf(
-    Color(0xFFFF6B6B), // 珊瑚紅
-    Color(0xFF4ECDC4), // 青綠
-    Color(0xFF45B7D1), // 天藍
-    Color(0xFFF39C12), // 橘橙
-    Color(0xFFDDA0DD), // 梅紫
-    Color(0xFF2ECC71), // 翡翠綠
-    Color(0xFFE74C3C), // 磚紅
-    Color(0xFF3498DB), // 寶藍
-    Color(0xFFF7DC6F), // 金黃
-    Color(0xFF9B59B6), // 紫羅蘭
-    Color(0xFF1ABC9C), // 碧綠
-    Color(0xFFE67E22), // 南瓜橘
-    Color(0xFF85C1E9), // 淺藍
-    Color(0xFFD35400), // 焦橙
-    Color(0xFF27AE60), // 森林綠
-    Color(0xFFC0392B), // 酒紅
-    Color(0xFF8E44AD), // 深紫
-    Color(0xFF16A085), // 松綠
-    Color(0xFFF1C40F), // 向日葵黃
-    Color(0xFF2980B9), // 鈷藍
+    Color(0xFFDC2626), // Red
+    Color(0xFFEA580C), // Orange
+    Color(0xFFD97706), // Amber
+    Color(0xFFCA8A04), // Ochre
+    Color(0xFF65A30D), // Lime
+    Color(0xFF16A34A), // Green
+    Color(0xFF059669), // Emerald
+    Color(0xFF0D9488), // Teal
+    Color(0xFF0891B2), // Cyan
+    Color(0xFF0284C7), // Sky
+    Color(0xFF2563EB), // Blue
+    Color(0xFF4F46E5), // Indigo
+    Color(0xFF7C3AED), // Violet
+    Color(0xFF9333EA), // Purple
+    Color(0xFFC026D3), // Fuchsia
+    Color(0xFFDB2777), // Pink
+    Color(0xFFE11D48), // Rose
+    Color(0xFF475569), // Slate
 )
 
 object TigerDuckTheme {
     @Volatile
     private var courseColorMap: Map<String, Color> = emptyMap()
 
-    fun buildCourseColorMap(courseNos: List<String>) {
-        courseColorMap = courseNos.associateWith { courseNo -> stableColor(courseNo) }
+    fun buildCourseColorMap(courses: List<Course>) {
+        val map = mutableMapOf<String, Color>()
+        val taken = mutableSetOf<Color>()
+
+        // Pinned (user-picked) colors claim their slots first.
+        courses.forEach { course ->
+            val pinned = parseHexOrNull(course.customColorHex) ?: return@forEach
+            map[course.courseNo] = pinned
+            taken.add(pinned)
+        }
+
+        // Remaining courses fall back to hash-based assignment, probing forward
+        // through the palette to avoid colliding with pinned/already-assigned slots.
+        // When the palette is exhausted (more than 18 distinct courses), we fall
+        // back to a deterministic-random color outside the palette.
+        courses.filter { map[it.courseNo] == null }
+            .sortedBy { it.courseNo }
+            .forEach { course ->
+                val color = pickFreeColor(course.courseNo, taken)
+                map[course.courseNo] = color
+                taken.add(color)
+            }
+
+        courseColorMap = map
     }
 
     fun courseColor(courseNo: String): Color {
-        return courseColorMap[courseNo] ?: stableColor(courseNo)
+        courseColorMap[courseNo]?.let { return it }
+        return courseColorPalette[courseHashIndex(courseNo)]
     }
 
-    private fun stableColor(courseNo: String): Color {
+    private fun pickFreeColor(courseNo: String, taken: Set<Color>): Color {
+        val base = courseHashIndex(courseNo)
+        var idx = base
+        var probes = 0
+        while (probes < courseColorPalette.size && courseColorPalette[idx] in taken) {
+            idx = (idx + 1) % courseColorPalette.size
+            probes++
+        }
+        if (probes < courseColorPalette.size) return courseColorPalette[idx]
+
+        // Palette fully taken. Pick a deterministic-random color not in the
+        // palette, seeded by courseNo so the same class keeps a stable color.
+        val paletteArgbs = courseColorPalette.mapTo(mutableSetOf()) { it.toArgb() }
+        val rng = Random(courseNo.hashCode())
+        repeat(32) {
+            val h = rng.nextFloat() * 360f
+            val s = 0.55f + rng.nextFloat() * 0.4f
+            val v = 0.55f + rng.nextFloat() * 0.3f
+            val c = Color(android.graphics.Color.HSVToColor(floatArrayOf(h, s, v)))
+            if (c.toArgb() !in paletteArgbs && c !in taken) return c
+        }
+        return Color(android.graphics.Color.HSVToColor(floatArrayOf(rng.nextFloat() * 360f, 0.7f, 0.7f)))
+    }
+
+    private fun courseHashIndex(courseNo: String): Int {
         val hash = courseNo.fold(0) { acc, c -> (acc * 31 + c.code) and 0x7FFFFFFF }
-        return courseColorPalette[hash % courseColorPalette.size]
+        return hash % courseColorPalette.size
+    }
+
+    private fun parseHexOrNull(hex: String?): Color? {
+        if (hex.isNullOrBlank()) return null
+        return try {
+            Color(android.graphics.Color.parseColor(hex))
+        } catch (_: IllegalArgumentException) {
+            null
+        }
     }
 }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/theme/TigerDuckTheme.kt
@@ -59,8 +59,8 @@ val courseColorPaletteDark: List<Color> = listOf(
 )
 
 object TigerDuckTheme {
-    @Volatile
-    private var courseColorMap: Map<String, Color> = emptyMap()
+    private val courseColorMapRef = java.util.concurrent.atomic.AtomicReference<Map<String, Color>>(emptyMap())
+    private val courseColorMap get() = courseColorMapRef.get()
 
     // Compose-observable so course tiles recompose when the app switches theme.
     private val _isDarkMode = mutableStateOf(false)
@@ -105,7 +105,7 @@ object TigerDuckTheme {
                 taken.add(color)
             }
 
-        courseColorMap = map
+        courseColorMapRef.set(map)
     }
 
     fun courseColor(courseNo: String): Color {

--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -19,14 +19,14 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.1.3
+  - versionName: 1.1.4
     versionCode: 5
-    commit: v1.1.3
+    commit: v1.1.4
     subdir: app
     gradle:
       - yes
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.1.3
+CurrentVersion: 1.1.4
 CurrentVersionCode: 5

--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -20,7 +20,7 @@ Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
   - versionName: 1.1.4
-    versionCode: 5
+    versionCode: 6
     commit: v1.1.4
     subdir: app
     gradle:
@@ -29,4 +29,4 @@ Builds:
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
 CurrentVersion: 1.1.4
-CurrentVersionCode: 5
+CurrentVersionCode: 6


### PR DESCRIPTION
This pull request introduces several enhancements and fixes focused on user customization, theming, and database schema evolution. The main highlights are the addition of user-selectable theme modes (system/dark/light), improvements to accent color handling for dark mode, support for customizable course tile colors, and a database migration to accommodate these changes. Additionally, the "Quick Widgets" home section is now deprecated and hidden.

**Theming and Accent Color Improvements**
- Added support for user-selectable theme modes ("system", "dark", "light") via `AppPreferences` and updated `MainActivity` to apply the selected mode throughout the app. Accent colors now have paired dark variants for better appearance in dark mode, and the correct variant is chosen automatically. [[1]](diffhunk://#diff-d405c7b8183f4c1be5fb398935527f85a17f8d39ab978ad006f2401b07e1a986R50-R54) [[2]](diffhunk://#diff-d405c7b8183f4c1be5fb398935527f85a17f8d39ab978ad006f2401b07e1a986R133-R149) [[3]](diffhunk://#diff-5259cae48da93f9076d4400993e2920309ffa5d47925a731b7bd2c856aefad00L65-R78) [[4]](diffhunk://#diff-ab345fb98dd0eac2a669fb2c4c0f83b4a13ff20f1b231607db81e02eefac25f1L30-R38)

**Course Color Customization**
- Introduced `CourseColorStore`, a singleton to coordinate and randomize per-course tile colors, allowing users to reset all course colors to new random values. The `Course` model now includes a `customColorHex` field for this purpose. [[1]](diffhunk://#diff-fa2fd65d2f060152285a7e2323f675d7aebf1265898b9d7762cb8ee5fb4590b8R1-R78) [[2]](diffhunk://#diff-0db8c623aa393d0c952d7c1c80af7f07c3902323fd74a9b91fc9942355cb924dL20-R22)

**Database Schema Migration**
- Migrated the Room database from version 2 to 3, adding the `customColorHex` column to the `courses` table. Includes the new migration logic and an updated schema export. [[1]](diffhunk://#diff-741fd8c7b405817621ee20f867700e75550c0703fa182e1be1849780a0f995c0L15-R15) [[2]](diffhunk://#diff-741fd8c7b405817621ee20f867700e75550c0703fa182e1be1849780a0f995c0R34-R43) [[3]](diffhunk://#diff-458d8eeeae1fa3654c162603404fed73389ba8e17a10285d5a950f0bb5a08ef9R1-R255)

**Home Section Adjustments**
- Deprecated and removed the "Quick Widgets" home section from the default and user-customizable home screen sections, ensuring it is filtered out of preferences and not shown in the UI. [[1]](diffhunk://#diff-2a8b2e22888cb99a82744101bd8ab2084b150810275d9d57e953da966b818d7eR15) [[2]](diffhunk://#diff-2a8b2e22888cb99a82744101bd8ab2084b150810275d9d57e953da966b818d7eL22-R33) [[3]](diffhunk://#diff-d405c7b8183f4c1be5fb398935527f85a17f8d39ab978ad006f2401b07e1a986L91-R99)

**Versioning**
- Bumped the app version to 1.1.4 (versionCode 6).

These changes improve user control over appearance, ensure visual consistency across themes, and lay the groundwork for further UI customization.