### PR TITLE
Display all upcoming assignments on HomeScreen

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -168,14 +168,13 @@ private fun HomeSectionContent(
                             containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
-                        val displayedAssignments = upcomingAssignments.take(5)
-                        displayedAssignments.forEachIndexed { index, assignment ->
+                        upcomingAssignments.forEachIndexed { index, assignment ->
                             AssignmentItem(
                                 assignment = assignment,
                                 showAbsoluteTime = showAbsoluteTime,
                                 onClick = { onAssignmentClick(assignment) }
                             )
-                            if (index < displayedAssignments.lastIndex) {
+                            if (index < upcomingAssignments.lastIndex) {
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }


### PR DESCRIPTION
This pull request makes a minor update to the `HomeScreen.kt` UI logic by changing how upcoming assignments are displayed in the home section. Instead of limiting the displayed assignments to the first five, it now shows all upcoming assignments.

- Assignment List Display:
  * The `HomeSectionContent` function now displays all items from `upcomingAssignments` instead of only the first five, ensuring users see the full list of upcoming assignments. (`app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt`)