### PR TITLE
Display all upcoming assignments on HomeScreen

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -168,14 +168,13 @@ private fun HomeSectionContent(
                             containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
-                        val displayedAssignments = upcomingAssignments.take(5)
-                        displayedAssignments.forEachIndexed { index, assignment ->
+                        upcomingAssignments.forEachIndexed { index, assignment ->
                             AssignmentItem(
                                 assignment = assignment,
                                 showAbsoluteTime = showAbsoluteTime,
                                 onClick = { onAssignmentClick(assignment) }
                             )
-                            if (index < displayedAssignments.lastIndex) {
+                            if (index < upcomingAssignments.lastIndex) {
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }


### PR DESCRIPTION
This pull request updates the assignment display logic in the `HomeScreen`. Instead of limiting the list to only the first five upcoming assignments, it now displays all upcoming assignments in the list.

**Assignment display updates:**

* The `HomeSectionContent` composable in `HomeScreen.kt` now iterates over all `upcomingAssignments` instead of just the first five, ensuring that all upcoming assignments are shown to the user.