### PR TITLE
Display all upcoming assignments on HomeScreen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 26
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.1.4"
+        versionCode = 7
+        versionName = "1.1.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -168,14 +168,13 @@ private fun HomeSectionContent(
                             containerColor = MaterialTheme.colorScheme.surface
                         )
                     ) {
-                        val displayedAssignments = upcomingAssignments.take(5)
-                        displayedAssignments.forEachIndexed { index, assignment ->
+                        upcomingAssignments.forEachIndexed { index, assignment ->
                             AssignmentItem(
                                 assignment = assignment,
                                 showAbsoluteTime = showAbsoluteTime,
                                 onClick = { onAssignmentClick(assignment) }
                             )
-                            if (index < displayedAssignments.lastIndex) {
+                            if (index < upcomingAssignments.lastIndex) {
                                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                             }
                         }

--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -14,7 +14,7 @@ Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 Builds:
   - versionName: 1.1.5
     versionCode: 7
-    commit: replace-me-with-commit-hash
+    commit: 1.1.5
     subdir: app
     gradle:
       - yes

--- a/metadata/org.ntust.app.tigerduck.yml
+++ b/metadata/org.ntust.app.tigerduck.yml
@@ -7,26 +7,19 @@ SourceCode: https://github.com/tigerduck-app/tigerduck-app-android
 IssueTracker: https://github.com/tigerduck-app/tigerduck-app-android/issues
 
 AutoName: TigerDuck
-Description: |
-  TigerDuck 是專為臺灣科技大學學生打造的校園生活助手 App。
-
-  功能包含：
-  * 課表查詢
-  * Moodle 作業截止日查詢、提醒
-  * 行事曆整合
 
 RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.1.4
-    versionCode: 6
-    commit: v1.1.4
+  - versionName: 1.1.5
+    versionCode: 7
+    commit: replace-me-with-commit-hash
     subdir: app
     gradle:
       - yes
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.1.4
-CurrentVersionCode: 6
+CurrentVersion: 1.1.5
+CurrentVersionCode: 7


### PR DESCRIPTION
This pull request updates the way assignments are displayed in the `HomeScreen`. Instead of limiting the list to only the first five upcoming assignments, it now shows all upcoming assignments in the UI.

**Assignment display logic:**

* The `HomeSectionContent` composable now iterates over the full `upcomingAssignments` list, displaying all assignments instead of just the first five.
* The divider logic is updated to correctly show dividers between all assignments except after the last one in the full list.
This pull request updates the TigerDuck app to version 1.1.5, increasing the version code and making a UI change to the home screen assignments list. The most important changes are:

Version update:

* Bumped `versionCode` to 7 and `versionName` to 1.1.5 in `app/build.gradle.kts` and updated metadata in `metadata/org.ntust.app.tigerduck.yml` to reflect the new version. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L16-R17) [[2]](diffhunk://#diff-48926210b9a57b5f0316b70d6729c014541662858db5ffba1e8dc26daa32a496L10-R25)

Home screen UI improvement:

* Modified the assignments list in `HomeScreen.kt` to display all upcoming assignments instead of limiting to five, ensuring users see the full list.