### PR TITLE
fix(course): apply abbreviation toggle when lookup cache not yet loaded

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
@@ -280,7 +280,8 @@ class CourseService @Inject constructor(
      * returned unchanged.
      */
     suspend fun relabelCoursesForCurrentAbbrSetting(semester: String, courses: List<Course>): List<Course> {
-        if (!lookupCacheLoaded || courses.isEmpty()) return courses
+        if (courses.isEmpty()) return courses
+        ensureLookupCacheLoaded()
         val language = preferredCourseApiLanguage()
         return courses.map { course ->
             val cached = lookupCache["${semester}_${course.courseNo}_$language"]


### PR DESCRIPTION
relabelCoursesForCurrentAbbrSetting early-returned when lookupCacheLoaded was false. The flag is only set inside lookupCourse, but on cold start the home/classtable load courses directly from dataCache, so toggling the abbreviation setting silently no-opped. Call ensureLookupCacheLoaded() first so cached lookup entries are available for relabeling.