### PR TITLE
Fix Hilt imports, improve course abbreviation handling, and enhance LiveActivity transitions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:exported="false" />
 
         <receiver
+            android:name="org.ntust.app.tigerduck.liveactivity.LiveActivityBoundaryReceiver"
+            android:exported="false" />
+
+        <receiver
             android:name="org.ntust.app.tigerduck.notification.BootReceiver"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
@@ -1,0 +1,34 @@
+package org.ntust.app.tigerduck.liveactivity
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LiveActivityBoundaryReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var liveActivityManager: LiveActivityManager
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pending = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope.launch {
+            try {
+                withTimeout(10_000) { liveActivityManager.refreshAndWait() }
+            } catch (t: Throwable) {
+                android.util.Log.w("LiveActivityBoundary", "boundary refresh failed", t)
+            } finally {
+                pending.finish()
+                scope.cancel()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryScheduler.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryScheduler.kt
@@ -1,0 +1,65 @@
+package org.ntust.app.tigerduck.liveactivity
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules a single AlarmManager exact alarm at the next Live Activity
+ * scenario boundary (e.g. class start / end, assignment lead-time crossing).
+ * Replaces the in-process `coroutineScope.launch { delay(...); refresh() }`
+ * pattern, which silently dies when Android kills the app process — leaving
+ * the ongoing notification stuck on the prior scenario (e.g. CLASS_PREPARING)
+ * even after the boundary has passed.
+ */
+@Singleton
+class LiveActivityBoundaryScheduler @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    private val alarmManager = context.getSystemService(AlarmManager::class.java)
+
+    fun scheduleAt(triggerAtMillis: Long) {
+        val pi = makePendingIntent()
+        alarmManager.cancel(pi)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+            } else {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+            }
+        } catch (_: SecurityException) {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+        }
+    }
+
+    fun cancel() {
+        val pi = PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            Intent(context, LiveActivityBoundaryReceiver::class.java).setAction(ACTION_BOUNDARY),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+        pi?.let { alarmManager.cancel(it) }
+    }
+
+    private fun makePendingIntent(): PendingIntent {
+        val intent = Intent(context, LiveActivityBoundaryReceiver::class.java)
+            .setAction(ACTION_BOUNDARY)
+        return PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    companion object {
+        internal const val ACTION_BOUNDARY = "org.ntust.app.tigerduck.LIVE_ACTIVITY_BOUNDARY"
+        internal const val REQUEST_CODE = 9101
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityManager.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityManager.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.auth.AuthService
@@ -31,10 +30,10 @@ class LiveActivityManager @Inject constructor(
     private val authService: AuthService,
     private val appPrefs: AppPreferences,
     private val classPreparingScheduler: ClassPreparingNotificationScheduler,
+    private val boundaryScheduler: LiveActivityBoundaryScheduler,
 ) {
     private val resolver = LiveActivityResolver()
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    private var boundaryJob: Job? = null
     private var refreshJob: Job? = null
     // Hold a reference so `stop()` can halt preference-driven refreshes too;
     // otherwise a `preferences.changeEvent` arriving after `stop()` would
@@ -68,7 +67,7 @@ class LiveActivityManager @Inject constructor(
     fun stop() {
         prefsCollectorJob?.cancel()
         prefsCollectorJob = null
-        boundaryJob?.cancel()
+        boundaryScheduler.cancel()
         refreshJob?.cancel()
         notifier.cancel()
         classPreparingScheduler.cancelAllTracked()
@@ -82,7 +81,7 @@ class LiveActivityManager @Inject constructor(
         if (!preferences.isEnabled || !authService.isNtustAuthenticated) {
             notifier.cancel()
             classPreparingScheduler.cancelAllTracked()
-            boundaryJob?.cancel()
+            boundaryScheduler.cancel()
             return
         }
         val now = Date()
@@ -122,12 +121,16 @@ class LiveActivityManager @Inject constructor(
         assignments: List<org.ntust.app.tigerduck.data.model.Assignment>,
         now: Date,
     ) {
-        boundaryJob?.cancel()
         val candidates = mutableListOf<Long>()
         snapshot?.countdownTarget?.time?.let { candidates += it }
 
-        val classPrep = preferences.classPreparingLeadTimeSec * 1000
+        val classPrepLead = preferences.classPreparingLeadTimeSec * 1000
         val assignmentLead = preferences.assignmentLeadTimeSec * 1000
+
+        // Cover the CLASS_PREPARING → IN_CLASS → (idle) progression for the
+        // upcoming class even if it isn't currently the snapshot scenario,
+        // so the boundary fires once a class enters the lead-time window.
+        nextClassBoundaries(courses, now, classPrepLead).forEach { candidates += it }
 
         assignments.asSequence()
             .filter { !it.isCompleted && it.dueDate.after(now) }
@@ -136,18 +139,29 @@ class LiveActivityManager @Inject constructor(
                 candidates += a.dueDate.time
             }
 
-        // Class-related boundaries are approximated: trigger 1 min after "now"
-        // so we catch period transitions without needing to duplicate the full
-        // timeline here. The resolver is cheap enough to re-run.
         val nowMs = now.time
-        val futureCandidates = candidates.filter { it > nowMs }
-        val nextBoundary = futureCandidates.minOrNull() ?: (nowMs + 60_000L)
-        val delayMs = (nextBoundary - nowMs).coerceAtLeast(30_000L)
+        // Pad by 1s to make sure we land *after* the boundary tick, not on it,
+        // so the resolver sees the new state instead of the prior one.
+        val futureCandidates = candidates.filter { it > nowMs }.map { it + 1_000L }
+        // Floor at 30s so a near-instant boundary doesn't burn battery, and
+        // ceil at 30 min so a long-idle stretch still gets a watchdog refresh.
+        val nextBoundary = futureCandidates.minOrNull() ?: (nowMs + 30 * 60_000L)
+        val triggerAt = nextBoundary.coerceAtLeast(nowMs + 30_000L)
 
-        if (!scope.isActive) return
-        boundaryJob = scope.launch {
-            delay(delayMs)
-            refresh()
-        }
+        boundaryScheduler.scheduleAt(triggerAt)
+    }
+
+    private fun nextClassBoundaries(
+        courses: List<org.ntust.app.tigerduck.data.model.Course>,
+        now: Date,
+        classPrepLeadMs: Long,
+    ): List<Long> {
+        val slots = resolver.todaySlotsAfter(courses, now)
+        val first = slots.firstOrNull() ?: return emptyList()
+        return listOfNotNull(
+            (first.start.time - classPrepLeadMs).takeIf { it > now.time },
+            first.start.time.takeIf { it > now.time },
+            first.end.time.takeIf { it > now.time },
+        )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
@@ -66,6 +66,14 @@ class LiveActivityResolver {
         return null
     }
 
+    /**
+     * Today's class slots whose end is still after [now], sorted by start.
+     * Used by the boundary scheduler so it can wake the manager at the
+     * preparing-window crossing / class-start / class-end of the next slot.
+     */
+    fun todaySlotsAfter(courses: List<Course>, now: Date): List<Slot> =
+        buildTodaySlots(courses, now).filter { it.end.after(now) }
+
     data class Slot(
         val course: Course,
         val periods: List<String>,

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/BootReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/BootReceiver.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.liveactivity.LiveActivityManager
 import org.ntust.app.tigerduck.liveactivity.LiveActivityPreferences
 import org.ntust.app.tigerduck.widget.WidgetBoundaryScheduler
 import javax.inject.Inject
@@ -25,6 +26,7 @@ class BootReceiver : BroadcastReceiver() {
     @Inject lateinit var dataCache: DataCache
     @Inject lateinit var appPreferences: AppPreferences
     @Inject lateinit var widgetBoundaryScheduler: WidgetBoundaryScheduler
+    @Inject lateinit var liveActivityManager: LiveActivityManager
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
@@ -54,6 +56,14 @@ class BootReceiver : BroadcastReceiver() {
                     // the widget's class-boundary refresh stays dead until the
                     // user opens the app or BackgroundSyncWorker fires.
                     widgetBoundaryScheduler.scheduleForToday(courses)
+
+                    // Same story for the Live Activity ongoing notification —
+                    // re-arm its boundary alarm so the CLASS_PREPARING →
+                    // IN_CLASS transition still fires when the device boots
+                    // before the user reopens the app.
+                    if (liveActivityPreferences.isEnabled) {
+                        liveActivityManager.refreshAndWait()
+                    }
                 }
             } catch (e: Exception) {
                 android.util.Log.w("BootReceiver", "Boot rescheduling failed", e)


### PR DESCRIPTION
This pull request introduces a new robust scheduling mechanism for Live Activity notifications, replacing the previous in-process timer approach with an AlarmManager-based system that is resilient to app process death. It also adds a new broadcast receiver and scheduler to support this, updates the Android manifest, and makes several dependency injection and cleanup improvements. Additionally, the PR standardizes network response handling and updates Hilt imports to match current Compose best practices. Documentation for GitHub Actions workflows is also added.

**Live Activity boundary scheduling and notification improvements:**

* Introduced `LiveActivityBoundaryScheduler` and `LiveActivityBoundaryReceiver` using AlarmManager to schedule and trigger Live Activity scenario boundary updates, ensuring notifications stay accurate even if the app process is killed. This replaces the previous coroutine-based delay mechanism. (`LiveActivityBoundaryScheduler.kt`, `LiveActivityBoundaryReceiver.kt`, `LiveActivityManager.kt`, `LiveActivityResolver.kt`, `AndroidManifest.xml`) [[1]](diffhunk://#diff-c0fef9a93da1a312424f9139b61a44064cd4f774469c5dcec362fa0dd328f0fbR1-R65) [[2]](diffhunk://#diff-1c6278f853feac75888b464405eeca888ac3eb03098cb06f2656bed9978266f6R1-R34) [[3]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeR33-L37) [[4]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL71-R70) [[5]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL85-R84) [[6]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL125-R165) [[7]](diffhunk://#diff-0312e09217b0d46982d406c072f64710289d4d5b2258c9e2b4e193eb30a717fdR69-R76) [[8]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR52-R55)

* Updated `LiveActivityManager` to use the new scheduler, remove coroutine-based boundary jobs, and ensure boundaries are scheduled for both class and assignment transitions. (`LiveActivityManager.kt`) [[1]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeR33-L37) [[2]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL71-R70) [[3]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL85-R84) [[4]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL125-R165)

**Dependency injection and Compose best practices:**

* Changed Hilt ViewModel import statements in Compose screens to use `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel` for improved compatibility and correctness. (`AnnouncementDetailScreen.kt`, `AnnouncementsScreen.kt`, `SubscriptionSettingsScreen.kt`) [[1]](diffhunk://#diff-6006459baca9ad868d2584c5de2cca9ccc0f1b483178014a87d875f9da7d4261L20-R20) [[2]](diffhunk://#diff-0ce6b5757d0b0ef8714d8b57c8481aa9180c0488b82b869211c10141d38e0f74L43-R43) [[3]](diffhunk://#diff-4b0fe08b2cac40280c6bbc717200dd9a66923078b3656cc498a0801ee6ed5203L36-R36)

**Network response handling improvements:**

* Standardized network response body reading by replacing nullable `response.body?.string()` with non-nullable `response.body.string()` across API clients and services, improving reliability and clarity. (`BulletinApiClient.kt`, `CalendarService.kt`, `CourseService.kt`) [[1]](diffhunk://#diff-4fda7534280f9f7afceeced30ef7cd36891bd1ecf5be19316ab7d266fd59a9fcL117-R117) [[2]](diffhunk://#diff-4fda7534280f9f7afceeced30ef7cd36891bd1ecf5be19316ab7d266fd59a9fcL140-R140) [[3]](diffhunk://#diff-c54ea3bcbb52a3e5c31602bcbaa1dafe31fe63316486a4bc26d7bdb01d47292bL52-R52) [[4]](diffhunk://#diff-c54ea3bcbb52a3e5c31602bcbaa1dafe31fe63316486a4bc26d7bdb01d47292bL104-R104) [[5]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL72-R72) [[6]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL105-R105) [[7]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL147-R147)

**GitHub Actions workflows documentation and workflow input simplification:**

* Added a comprehensive `README.md` documenting all GitHub Actions workflows, including release and PR check workflows. (`.github/workflows/README.md`)
* Simplified the `release-manual.yaml` workflow by removing the `ref` input and always tagging from `main` if the tag does not exist. (`.github/workflows/release-manual.yaml`) [[1]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L9-L11) [[2]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L33-R31) [[3]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L92-R89)