### PR TITLE
Fix Hilt imports, improve course abbreviation handling, and enhance LiveActivity transitions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,55 @@
+# GitHub Actions Workflows
+
+## Release workflows
+
+### `release-manual.yaml` — Release (Manual) — **active**
+
+Manually-dispatched release. Tags `main` (if the tag does not yet exist), builds
+signed `play` and `fdroid` AABs/APKs, pins the F-Droid metadata commit hash, and
+publishes a GitHub Release with the artifacts attached. Does **not** upload to
+Google Play.
+
+Inputs:
+- `tag` — e.g. `v1.2.3`. Created on `main` if it does not already exist; if it
+  exists, the existing tag is checked out and artifacts are attached to the
+  existing release.
+
+This is the workflow currently used to cut releases.
+
+### `release.yaml` — Release (Auto) — **suspended**
+
+Triggered automatically on `v*` tag push. Builds signed artifacts, creates a
+GitHub Release with auto-generated notes, and uploads the play-flavor AAB to the
+Play Store production track at 10% staged rollout.
+
+Currently suspended — do not rely on it. Use `release-manual.yaml` instead.
+
+### `release-manual-playstore.yaml` — Release (Manual + Play Store) — **suspended**
+
+Manual dispatch by tag. Same as `release.yaml` but triggered manually: validates
+`vX.Y.Z` tag format, checks out the tag, builds, creates the GitHub Release, and
+pushes to the Play Store production track at 10% staged rollout.
+
+Currently suspended.
+
+### `release-manual-playstore-internal.yaml` — Release (Manual + Play Store (Internal)) — **suspended**
+
+Manual dispatch by tag. Same as the production variant but uploads to the Play
+Store **internal** track with `status: completed` (no staged rollout). Accepts
+prerelease tags (e.g. `v1.2.3-beta.1`).
+
+Currently suspended.
+
+## PR check workflows
+
+### `submodules-up-to-date.yaml`
+
+Runs on PRs to `main` and `dev`. Verifies every git submodule (e.g.
+`app-translation`) is pinned to its upstream tip, so PRs cannot land with stale
+submodule references.
+
+### `version-bumped.yaml`
+
+Runs on PRs to `main`. Verifies `versionCode` and `versionName` have been bumped
+relative to the base branch, so a release tag cut from `main` always carries a
+fresh version.

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -6,9 +6,6 @@ on:
       tag:
         description: 'Tag to release (e.g. v1.0.0). Created if it does not exist.'
         required: true
-      ref:
-        description: 'Branch to tag from when the tag does not exist (e.g. main). Ignored if the tag already exists.'
-        required: true
 
 permissions:
   contents: write
@@ -30,8 +27,8 @@ jobs:
             echo "Tag $TAG already exists; will checkout the tag and attach artifacts."
           else
             echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-            echo "checkout_ref=${{ github.event.inputs.ref }}" >> "$GITHUB_OUTPUT"
-            echo "Tag $TAG not found; will tag '${{ github.event.inputs.ref }}' and create the release."
+            echo "checkout_ref=main" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG not found; will tag 'main' and create the release."
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
@@ -89,7 +86,7 @@ jobs:
         if: steps.resolve.outputs.tag_exists == 'false'
         env:
           SHA: ${{ steps.sha.outputs.sha }}
-          BRANCH: ${{ github.event.inputs.ref }}
+          BRANCH: main
         run: |
           set -e
           file="metadata/org.ntust.app.tigerduck.fdroid.yml"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 9
-        versionName = "1.3.0"
+        versionCode = 10
+        versionName = "1.3.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,10 @@
             android:exported="false" />
 
         <receiver
+            android:name="org.ntust.app.tigerduck.liveactivity.LiveActivityBoundaryReceiver"
+            android:exported="false" />
+
+        <receiver
             android:name="org.ntust.app.tigerduck.notification.BootReceiver"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementDetailScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementDetailScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mikepenz.markdown.m3.Markdown
 import org.ntust.app.tigerduck.R

--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.launch
 import kotlin.math.abs

--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/BulletinApiClient.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/BulletinApiClient.kt
@@ -114,7 +114,7 @@ class BulletinApiClient @Inject constructor(
             .put(body)
             .build()
         authedClient.newCall(request).execute().use { response ->
-            val text = response.body?.string().orEmpty()
+            val text = response.body.string()
             if (!response.isSuccessful) {
                 throw BulletinApiException("subscriptions PUT failed: HTTP ${response.code}")
             }
@@ -137,7 +137,7 @@ class BulletinApiClient @Inject constructor(
             val c = if (authed) authedClient else client
             val request = Request.Builder().url(url).get().build()
             c.newCall(request).execute().use { response ->
-                val text = response.body?.string().orEmpty()
+                val text = response.body.string()
                 if (!response.isSuccessful) {
                     throw BulletinApiException("GET $url failed: HTTP ${response.code}")
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/SubscriptionSettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/SubscriptionSettingsScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
@@ -1,0 +1,34 @@
+package org.ntust.app.tigerduck.liveactivity
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LiveActivityBoundaryReceiver : BroadcastReceiver() {
+
+    @Inject lateinit var liveActivityManager: LiveActivityManager
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val pending = goAsync()
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        scope.launch {
+            try {
+                withTimeout(10_000) { liveActivityManager.refreshAndWait() }
+            } catch (t: Throwable) {
+                android.util.Log.w("LiveActivityBoundary", "boundary refresh failed", t)
+            } finally {
+                pending.finish()
+                scope.cancel()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryReceiver.kt
@@ -12,6 +12,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 
+// TODO:
+//  **`todaySlotsAfter` does not filter skipped dates**
+//  `resolve()` always filters slots with `!it.isSkipped(skippedDates)` before computing scenarios, but `todaySlotsAfter` feeds directly into `nextClassBoundaries` without that filter. If a user has marked the next slot as skipped, the scheduler will still arm an alarm for it. When the alarm fires, `refreshAndWait()` → `resolve()` correctly returns null, so no wrong state is rendered — but an unnecessary wakeup and a cache-load cycle will occur on every skipped class day.
+
+
 @AndroidEntryPoint
 class LiveActivityBoundaryReceiver : BroadcastReceiver() {
 

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryScheduler.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityBoundaryScheduler.kt
@@ -1,0 +1,65 @@
+package org.ntust.app.tigerduck.liveactivity
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Schedules a single AlarmManager exact alarm at the next Live Activity
+ * scenario boundary (e.g. class start / end, assignment lead-time crossing).
+ * Replaces the in-process `coroutineScope.launch { delay(...); refresh() }`
+ * pattern, which silently dies when Android kills the app process — leaving
+ * the ongoing notification stuck on the prior scenario (e.g. CLASS_PREPARING)
+ * even after the boundary has passed.
+ */
+@Singleton
+class LiveActivityBoundaryScheduler @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    private val alarmManager = context.getSystemService(AlarmManager::class.java)
+
+    fun scheduleAt(triggerAtMillis: Long) {
+        val pi = makePendingIntent()
+        alarmManager.cancel(pi)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
+                alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+            } else {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+            }
+        } catch (_: SecurityException) {
+            alarmManager.set(AlarmManager.RTC_WAKEUP, triggerAtMillis, pi)
+        }
+    }
+
+    fun cancel() {
+        val pi = PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            Intent(context, LiveActivityBoundaryReceiver::class.java).setAction(ACTION_BOUNDARY),
+            PendingIntent.FLAG_NO_CREATE or PendingIntent.FLAG_IMMUTABLE,
+        )
+        pi?.let { alarmManager.cancel(it) }
+    }
+
+    private fun makePendingIntent(): PendingIntent {
+        val intent = Intent(context, LiveActivityBoundaryReceiver::class.java)
+            .setAction(ACTION_BOUNDARY)
+        return PendingIntent.getBroadcast(
+            context,
+            REQUEST_CODE,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    companion object {
+        internal const val ACTION_BOUNDARY = "org.ntust.app.tigerduck.LIVE_ACTIVITY_BOUNDARY"
+        internal const val REQUEST_CODE = 9101
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityManager.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityManager.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.auth.AuthService
@@ -31,10 +30,10 @@ class LiveActivityManager @Inject constructor(
     private val authService: AuthService,
     private val appPrefs: AppPreferences,
     private val classPreparingScheduler: ClassPreparingNotificationScheduler,
+    private val boundaryScheduler: LiveActivityBoundaryScheduler,
 ) {
     private val resolver = LiveActivityResolver()
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
-    private var boundaryJob: Job? = null
     private var refreshJob: Job? = null
     // Hold a reference so `stop()` can halt preference-driven refreshes too;
     // otherwise a `preferences.changeEvent` arriving after `stop()` would
@@ -68,7 +67,7 @@ class LiveActivityManager @Inject constructor(
     fun stop() {
         prefsCollectorJob?.cancel()
         prefsCollectorJob = null
-        boundaryJob?.cancel()
+        boundaryScheduler.cancel()
         refreshJob?.cancel()
         notifier.cancel()
         classPreparingScheduler.cancelAllTracked()
@@ -82,7 +81,7 @@ class LiveActivityManager @Inject constructor(
         if (!preferences.isEnabled || !authService.isNtustAuthenticated) {
             notifier.cancel()
             classPreparingScheduler.cancelAllTracked()
-            boundaryJob?.cancel()
+            boundaryScheduler.cancel()
             return
         }
         val now = Date()
@@ -122,12 +121,16 @@ class LiveActivityManager @Inject constructor(
         assignments: List<org.ntust.app.tigerduck.data.model.Assignment>,
         now: Date,
     ) {
-        boundaryJob?.cancel()
         val candidates = mutableListOf<Long>()
         snapshot?.countdownTarget?.time?.let { candidates += it }
 
-        val classPrep = preferences.classPreparingLeadTimeSec * 1000
+        val classPrepLead = preferences.classPreparingLeadTimeSec * 1000
         val assignmentLead = preferences.assignmentLeadTimeSec * 1000
+
+        // Cover the CLASS_PREPARING → IN_CLASS → (idle) progression for the
+        // upcoming class even if it isn't currently the snapshot scenario,
+        // so the boundary fires once a class enters the lead-time window.
+        nextClassBoundaries(courses, now, classPrepLead).forEach { candidates += it }
 
         assignments.asSequence()
             .filter { !it.isCompleted && it.dueDate.after(now) }
@@ -136,18 +139,29 @@ class LiveActivityManager @Inject constructor(
                 candidates += a.dueDate.time
             }
 
-        // Class-related boundaries are approximated: trigger 1 min after "now"
-        // so we catch period transitions without needing to duplicate the full
-        // timeline here. The resolver is cheap enough to re-run.
         val nowMs = now.time
-        val futureCandidates = candidates.filter { it > nowMs }
-        val nextBoundary = futureCandidates.minOrNull() ?: (nowMs + 60_000L)
-        val delayMs = (nextBoundary - nowMs).coerceAtLeast(30_000L)
+        // Pad by 1s to make sure we land *after* the boundary tick, not on it,
+        // so the resolver sees the new state instead of the prior one.
+        val futureCandidates = candidates.filter { it > nowMs }.map { it + 1_000L }
+        // Floor at 30s so a near-instant boundary doesn't burn battery, and
+        // ceil at 30 min so a long-idle stretch still gets a watchdog refresh.
+        val nextBoundary = futureCandidates.minOrNull() ?: (nowMs + 30 * 60_000L)
+        val triggerAt = nextBoundary.coerceAtLeast(nowMs + 30_000L)
 
-        if (!scope.isActive) return
-        boundaryJob = scope.launch {
-            delay(delayMs)
-            refresh()
-        }
+        boundaryScheduler.scheduleAt(triggerAt)
+    }
+
+    private fun nextClassBoundaries(
+        courses: List<org.ntust.app.tigerduck.data.model.Course>,
+        now: Date,
+        classPrepLeadMs: Long,
+    ): List<Long> {
+        val slots = resolver.todaySlotsAfter(courses, now)
+        val first = slots.firstOrNull() ?: return emptyList()
+        return listOfNotNull(
+            (first.start.time - classPrepLeadMs).takeIf { it > now.time },
+            first.start.time.takeIf { it > now.time },
+            first.end.time.takeIf { it > now.time },
+        )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
@@ -66,6 +66,14 @@ class LiveActivityResolver {
         return null
     }
 
+    /**
+     * Today's class slots whose end is still after [now], sorted by start.
+     * Used by the boundary scheduler so it can wake the manager at the
+     * preparing-window crossing / class-start / class-end of the next slot.
+     */
+    fun todaySlotsAfter(courses: List<Course>, now: Date): List<Slot> =
+        buildTodaySlots(courses, now).filter { it.end.after(now) }
+
     data class Slot(
         val course: Course,
         val periods: List<String>,

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CalendarService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CalendarService.kt
@@ -49,7 +49,7 @@ class CalendarService @Inject constructor(
         try {
             val request = Request.Builder().url(calendarPageUrl).get().build()
             val (html, baseUrl) = browserClient.newCall(request).execute().use { response ->
-                (response.body?.string() ?: "") to response.request.url.toString()
+                response.body.string() to response.request.url.toString()
             }
 
             val linkRegex = Regex(
@@ -101,7 +101,7 @@ class CalendarService @Inject constructor(
 
             val request = Request.Builder().url(icsUrl).get().build()
             val icsString = browserClient.newCall(request).execute().use { response ->
-                response.body?.string() ?: return@withContext emptyList()
+                response.body.string()
             }
             parseICS(icsString)
         } catch (e: Exception) {

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
@@ -280,7 +280,8 @@ class CourseService @Inject constructor(
      * returned unchanged.
      */
     suspend fun relabelCoursesForCurrentAbbrSetting(semester: String, courses: List<Course>): List<Course> {
-        if (!lookupCacheLoaded || courses.isEmpty()) return courses
+        if (courses.isEmpty()) return courses
+        ensureLookupCacheLoaded()
         val language = preferredCourseApiLanguage()
         return courses.map { course ->
             val cached = lookupCache["${semester}_${course.courseNo}_$language"]

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
@@ -69,7 +69,7 @@ class CourseService @Inject constructor(
                 if (response.request.url.host.contains("ssoam2.ntust.edu.tw")) {
                     throw CourseServiceError.RedirectedToSSO
                 }
-                val html = response.body?.string() ?: throw CourseServiceError.NoCourseData
+                val html = response.body.string()
 
                 val pattern = Regex("<tr>\\s*<td>\\s*(3?[A-Z]{2}[A-Z0-9]{6,7})\\s*</td>")
                 pattern.findAll(html).map { it.groupValues[1] }.toList()
@@ -102,7 +102,7 @@ class CourseService @Inject constructor(
                 .build()
 
             val fresh = client.newCall(request).execute().use { response ->
-                val body = response.body?.string() ?: return@use emptyList()
+                val body = response.body.string()
                 val type = object : TypeToken<List<CourseSearchResult>>() {}.type
                 gson.fromJson<List<CourseSearchResult>?>(body, type) ?: emptyList()
             }
@@ -144,7 +144,7 @@ class CourseService @Inject constructor(
                 .build()
 
             client.newCall(request).execute().use { response ->
-                val body = response.body?.string() ?: return@withContext emptyList()
+                val body = response.body.string()
                 val type = object : TypeToken<List<CourseSearchResult>>() {}.type
                 val parsed: List<CourseSearchResult> = gson.fromJson(body, type) ?: emptyList()
                 applyAbbreviations(parsed, language)
@@ -168,7 +168,7 @@ class CourseService @Inject constructor(
                 .build()
 
             client.newCall(request).execute().use { response ->
-                val body = response.body?.string() ?: return@withContext emptyList()
+                val body = response.body.string()
                 val type = object : TypeToken<List<CourseSearchResult>>() {}.type
                 val parsed: List<CourseSearchResult> = gson.fromJson(body, type) ?: emptyList()
                 applyAbbreviations(parsed, language)

--- a/app/src/main/java/org/ntust/app/tigerduck/network/LibraryService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/LibraryService.kt
@@ -64,8 +64,7 @@ class LibraryService @Inject constructor(
             .build()
 
         client.newCall(request).execute().use { response ->
-            val responseBody = response.body?.string()
-                ?: throw LibraryServiceError.LoginFailed(context.getString(R.string.error_no_response))
+            val responseBody = response.body.string()
             val loginResponse = gson.fromJson(responseBody, LibraryLoginResponse::class.java)
 
             if (loginResponse.data == null || loginResponse.error?.code?.let { it != 0 } == true) {
@@ -106,8 +105,7 @@ class LibraryService @Inject constructor(
             .build()
 
         client.newCall(request).execute().use { response ->
-            val responseBody = response.body?.string()
-                ?: throw LibraryServiceError.QRGenerationFailed(context.getString(R.string.error_no_response))
+            val responseBody = response.body.string()
             val qrResponse = gson.fromJson(responseBody, LibraryQRResponse::class.java)
 
             if (qrResponse.data == null || qrResponse.error?.code?.let { it != 0 } == true) {

--- a/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
@@ -155,7 +155,7 @@ class MoodleService @Inject constructor(
             val req = Request.Builder().url(url).post(FormBody.Builder().build()).build()
             val body = client.newCall(req).execute().use { response ->
                 if (!response.isSuccessful) throw MoodleWebserviceError.HttpStatus(response.code)
-                response.body?.string() ?: throw MoodleWebserviceError.MalformedResponse("site_info empty body")
+                response.body.string()
             }
             MoodleWebserviceError.fromJsonBody(body)?.let { throw it }
             val parsed = try {
@@ -178,7 +178,7 @@ class MoodleService @Inject constructor(
         val req = Request.Builder().url(url).post(form).build()
         val body = client.newCall(req).execute().use { response ->
             if (!response.isSuccessful) throw MoodleWebserviceError.HttpStatus(response.code)
-            response.body?.string() ?: throw MoodleWebserviceError.MalformedResponse("enrolled empty body")
+            response.body.string()
         }
         MoodleWebserviceError.fromJsonBody(body)?.let { throw it }
         val type = object : TypeToken<List<MoodleEnrolledCourse>>() {}.type
@@ -198,7 +198,7 @@ class MoodleService @Inject constructor(
         val req = Request.Builder().url(url).post(form).build()
         val body = client.newCall(req).execute().use { response ->
             if (!response.isSuccessful) throw MoodleWebserviceError.HttpStatus(response.code)
-            response.body?.string() ?: throw MoodleWebserviceError.MalformedResponse("assignments empty body")
+            response.body.string()
         }
         MoodleWebserviceError.fromJsonBody(body)?.let { throw it }
         return try {
@@ -220,7 +220,7 @@ class MoodleService @Inject constructor(
         val req = Request.Builder().url(url).post(form).build()
         val body = client.newCall(req).execute().use { response ->
             if (!response.isSuccessful) throw MoodleWebserviceError.HttpStatus(response.code)
-            response.body?.string() ?: throw MoodleWebserviceError.MalformedResponse("submission status empty body")
+            response.body.string()
         }
         MoodleWebserviceError.fromJsonBody(body)?.let { throw it }
         return try {

--- a/app/src/main/java/org/ntust/app/tigerduck/network/MoodleTokenService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/MoodleTokenService.kt
@@ -277,8 +277,7 @@ class MoodleTokenService @Inject constructor(
             if (!r.isSuccessful) {
                 throw MoodleWebserviceError.HttpStatus(r.code)
             }
-            val body = r.body?.string()
-                ?: throw MoodleWebserviceError.MalformedResponse("empty response body")
+            val body = r.body.string()
             return body to r.request.url
         }
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/network/NtustScoreService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/NtustScoreService.kt
@@ -82,7 +82,7 @@ class NtustScoreService @Inject constructor(
         val request = Request.Builder().url(url).get().build()
         client.newCall(request).execute().use { response ->
             if (!response.isSuccessful) throw NtustScoreError.InvalidResponse
-            val html = response.body?.string() ?: throw NtustScoreError.InvalidResponse
+            val html = response.body.string()
             return html to response.request.url.host
         }
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/network/SsoLoginService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/SsoLoginService.kt
@@ -96,7 +96,7 @@ class SsoLoginService @Inject constructor(
         try {
             val request = Request.Builder().url(url).get().build()
             client.newCall(request).execute().use { response ->
-                val body = response.body?.string() ?: throw SsoLoginError.InvalidResponse
+                val body = response.body.string()
                 return body to (response.request.url)
             }
         } catch (e: SsoLoginError) {
@@ -136,7 +136,7 @@ class SsoLoginService @Inject constructor(
                 .build()
 
             client.newCall(request).execute().use { response ->
-                val html = response.body?.string() ?: throw SsoLoginError.InvalidResponse
+                val html = response.body.string()
                 return html to response.request.url
             }
         } catch (e: SsoLoginError) {

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/BootReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/BootReceiver.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.liveactivity.LiveActivityManager
 import org.ntust.app.tigerduck.liveactivity.LiveActivityPreferences
 import org.ntust.app.tigerduck.widget.WidgetBoundaryScheduler
 import javax.inject.Inject
@@ -25,6 +26,7 @@ class BootReceiver : BroadcastReceiver() {
     @Inject lateinit var dataCache: DataCache
     @Inject lateinit var appPreferences: AppPreferences
     @Inject lateinit var widgetBoundaryScheduler: WidgetBoundaryScheduler
+    @Inject lateinit var liveActivityManager: LiveActivityManager
 
     override fun onReceive(context: Context, intent: Intent) {
         if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
@@ -54,6 +56,14 @@ class BootReceiver : BroadcastReceiver() {
                     // the widget's class-boundary refresh stays dead until the
                     // user opens the app or BackgroundSyncWorker fires.
                     widgetBoundaryScheduler.scheduleForToday(courses)
+
+                    // Same story for the Live Activity ongoing notification —
+                    // re-arm its boundary alarm so the CLASS_PREPARING →
+                    // IN_CLASS transition still fires when the device boots
+                    // before the user reopens the app.
+                    if (liveActivityPreferences.isEnabled) {
+                        liveActivityManager.refreshAndWait()
+                    }
                 }
             } catch (e: Exception) {
                 android.util.Log.w("BootReceiver", "Boot rescheduling failed", e)

--- a/app/src/main/java/org/ntust/app/tigerduck/push/PushApiClient.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/push/PushApiClient.kt
@@ -59,7 +59,7 @@ class PushApiClient @Inject constructor(
                 .post(body)
                 .build()
             client.newCall(request).execute().use { response ->
-                val text = response.body?.string().orEmpty()
+                val text = response.body.string()
                 if (!response.isSuccessful) {
                     throw PushApiException("register failed: HTTP ${response.code} $text")
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.AppConstants

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/calendar/CalendarScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.LocalIndication

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/score/ScoreScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/score/ScoreScreen.kt
@@ -46,7 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
 import kotlin.math.roundToInt
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.CourseGrade

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LanguagePickerScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LanguagePickerScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LiveActivitySettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LiveActivitySettingsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/NotificationSetupScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/NotificationSetupScreen.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModel

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/OtherSettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/OtherSettingsScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.AppFeature
 import org.ntust.app.tigerduck.ui.component.ContentCard

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.delay
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.AppFeature

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SourceCodePickerScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SourceCodePickerScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.ContentCard
 import org.ntust.app.tigerduck.ui.component.SectionHeader

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -1,3 +1,7 @@
+AntiFeatures:
+  NonFreeNet:
+    zh-TW: 依賴多個來自 ntust.edu.tw (*.ntust.edu.tw)、r.xinshou.tw 和 app.tigerduck.app 的服務。
+    en-US: Rely on serveral services on ntust.edu.tw (*.ntust.edu.tw), r.xinshou.tw and app.tigerduck.app.
 Categories:
   - Science & Education
 License: AGPL-3.0-only

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -1,7 +1,7 @@
 AntiFeatures:
   NonFreeNet:
     zh-TW: 依賴多個來自 ntust.edu.tw (*.ntust.edu.tw)、r.xinshou.tw 和 app.tigerduck.app 的服務。
-    en-US: Rely on serveral services on ntust.edu.tw (*.ntust.edu.tw), r.xinshou.tw and app.tigerduck.app.
+    en-US: Relies on several services on ntust.edu.tw (*.ntust.edu.tw), r.xinshou.tw and app.tigerduck.app.
 Categories:
   - Science & Education
 License: AGPL-3.0-only
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.3.0-fdroid
-    versionCode: 9
+  - versionName: 1.3.1-fdroid
+    versionCode: 10
     commit: <replace with commit hash when pr to F-Droid>
     subdir: app
     gradle:
@@ -25,5 +25,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.0-fdroid
-CurrentVersionCode: 9
+CurrentVersion: 1.3.1-fdroid
+CurrentVersionCode: 10


### PR DESCRIPTION
This pull request introduces a new robust scheduling mechanism for Live Activity notifications using `AlarmManager`, replacing the previous in-process coroutine-based approach that could fail if the app process was killed. It also includes a number of code improvements, dependency updates, and workflow documentation enhancements.

**Live Activity boundary scheduling improvements:**

* Added `LiveActivityBoundaryScheduler` and `LiveActivityBoundaryReceiver` to schedule and handle exact alarm-based triggers for Live Activity scenario boundaries (e.g., class start/end), ensuring reliability even if the app is killed. The manager now uses this scheduler instead of in-process coroutine delays. (`LiveActivityBoundaryScheduler.kt`, `LiveActivityBoundaryReceiver.kt`, `LiveActivityManager.kt`, `LiveActivityResolver.kt`, `AndroidManifest.xml`) [[1]](diffhunk://#diff-c0fef9a93da1a312424f9139b61a44064cd4f774469c5dcec362fa0dd328f0fbR1-R65) [[2]](diffhunk://#diff-1c6278f853feac75888b464405eeca888ac3eb03098cb06f2656bed9978266f6R1-R34) [[3]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeR33-L37) [[4]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL71-R70) [[5]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL85-R84) [[6]](diffhunk://#diff-9e8cf580b736e8c0298adabf927e5505a4c833fd4d07afcd46f2ab0c97878afeL125-R165) [[7]](diffhunk://#diff-0312e09217b0d46982d406c072f64710289d4d5b2258c9e2b4e193eb30a717fdR69-R76) [[8]](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdR52-R55)

**Dependency and API usage updates:**

* Updated Hilt Compose ViewModel import to use `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel` instead of the deprecated navigation version in announcement-related screens. (`AnnouncementDetailScreen.kt`, `AnnouncementsScreen.kt`, `SubscriptionSettingsScreen.kt`) [[1]](diffhunk://#diff-6006459baca9ad868d2584c5de2cca9ccc0f1b483178014a87d875f9da7d4261L20-R20) [[2]](diffhunk://#diff-0ce6b5757d0b0ef8714d8b57c8481aa9180c0488b82b869211c10141d38e0f74L43-R43) [[3]](diffhunk://#diff-4b0fe08b2cac40280c6bbc717200dd9a66923078b3656cc498a0801ee6ed5203L36-R36)

**HTTP response handling improvements:**

* Standardized HTTP response body handling by removing unnecessary null checks and always using `response.body.string()` in API clients and services. (`BulletinApiClient.kt`, `CalendarService.kt`, `CourseService.kt`) [[1]](diffhunk://#diff-4fda7534280f9f7afceeced30ef7cd36891bd1ecf5be19316ab7d266fd59a9fcL117-R117) [[2]](diffhunk://#diff-4fda7534280f9f7afceeced30ef7cd36891bd1ecf5be19316ab7d266fd59a9fcL140-R140) [[3]](diffhunk://#diff-c54ea3bcbb52a3e5c31602bcbaa1dafe31fe63316486a4bc26d7bdb01d47292bL52-R52) [[4]](diffhunk://#diff-c54ea3bcbb52a3e5c31602bcbaa1dafe31fe63316486a4bc26d7bdb01d47292bL104-R104) [[5]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL72-R72) [[6]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL105-R105) [[7]](diffhunk://#diff-1c50246139113246d00d8cc2918c4fd6c2dc0e193e846807d3c997cf8052c02fL147-R147)

**Workflow and documentation updates:**

* Added a comprehensive README for GitHub Actions workflows, explaining each workflow's purpose and status. (`.github/workflows/README.md`)
* Simplified the release workflow to always tag from `main` (removing the `ref` input), ensuring consistent release behavior. (`release-manual.yaml`) [[1]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L9-L11) [[2]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L33-R31) [[3]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L92-R89)