### PR TITLE
Sign tags and commits using Releaser App for F-Droid updates

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -31,11 +31,19 @@ jobs:
             echo "Tag $TAG not found; will tag 'main' and create the release."
           fi
 
+      - name: Mint Releaser App token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 0
           persist-credentials: true
+          token: ${{ steps.app_token.outputs.token }}
 
       - name: Capture build SHA
         id: sha
@@ -70,47 +78,76 @@ jobs:
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
           mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
-      - name: Create and push tag
+      - name: Create signed tag via API
         if: steps.resolve.outputs.tag_exists == 'false'
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           TAG: ${{ github.event.inputs.tag }}
           SHA: ${{ steps.sha.outputs.sha }}
+          REPO: ${{ github.repository }}
         run: |
-          set -e
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" "$SHA" -m "$TAG"
-          git push origin "refs/tags/$TAG"
+          set -euo pipefail
+          # Create an annotated tag object via the API so GitHub signs it
+          # with the web-flow key; the release page then shows "Verified".
+          tag_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
+            -f tag="${TAG}" \
+            -f message="${TAG}" \
+            -f object="${SHA}" \
+            -f type=commit \
+            -f tagger[name]="github-actions[bot]" \
+            -f tagger[email]="41898282+github-actions[bot]@users.noreply.github.com" \
+            -f tagger[date]="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --jq .sha)
+          gh api -X POST "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${tag_sha}"
+          state=$(gh api "repos/${REPO}/git/tags/${tag_sha}" --jq .verification.verified)
+          if [ "$state" != "true" ]; then
+            echo "Tag ${TAG} was created but is NOT verified (state=$state)" >&2
+            gh api "repos/${REPO}/git/tags/${tag_sha}" --jq .verification >&2
+            exit 1
+          fi
+          echo "Tag ${TAG} created and verified."
 
       - name: Update F-Droid metadata commit hash
         if: steps.resolve.outputs.tag_exists == 'false'
         env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
           SHA: ${{ steps.sha.outputs.sha }}
+          REPO: ${{ github.repository }}
           BRANCH: main
+          TAG: ${{ github.event.inputs.tag }}
+          FILE_PATH: metadata/org.ntust.app.tigerduck.fdroid.yml
         run: |
-          set -e
-          file="metadata/org.ntust.app.tigerduck.fdroid.yml"
-          sed -i -E "s|^([[:space:]]*commit:).*|\1 ${SHA}|" "$file"
-          if git diff --quiet -- "$file"; then
-            echo "No change to $file; skipping commit."
-            exit 0
-          fi
-          git add "$file"
-          git commit -m "chore(fdroid): pin metadata commit to ${SHA} for ${{ github.event.inputs.tag }}"
-          # Build can take minutes; another commit may have landed on ${BRANCH}
-          # in the meantime. Rebase our single metadata commit on top before
-          # pushing so a non-fast-forward doesn't leave the release half-done
-          # (tag + artifacts published but fdroid.yml stale).
+          set -euo pipefail
+          # Use the Contents API so GitHub signs the resulting commit with
+          # the web-flow key (verified) and the App token's bypass entry on
+          # the ruleset lets the push through. Retries on SHA conflict in
+          # case another commit landed on ${BRANCH} during the build.
           for attempt in 1 2 3; do
-            git pull --rebase origin "${BRANCH}"
-            if git push origin "HEAD:${BRANCH}"; then
-              break
+            current=$(gh api "repos/${REPO}/contents/${FILE_PATH}?ref=${BRANCH}")
+            file_sha=$(printf '%s' "$current" | jq -r .sha)
+            content=$(printf '%s' "$current" | jq -r .content | base64 -d)
+            new_content=$(printf '%s' "$content" | sed -E "s|^([[:space:]]*commit:).*|\1 ${SHA}|")
+            if [ "$content" = "$new_content" ]; then
+              echo "No change to ${FILE_PATH}; skipping."
+              exit 0
+            fi
+            new_b64=$(printf '%s' "$new_content" | base64 | tr -d '\n')
+            if gh api -X PUT "repos/${REPO}/contents/${FILE_PATH}" \
+              -f message="chore(fdroid): pin metadata commit to ${SHA} for ${TAG}" \
+              -f content="${new_b64}" \
+              -f sha="${file_sha}" \
+              -f branch="${BRANCH}"; then
+              echo "F-Droid metadata commit pushed."
+              exit 0
             fi
             if [ "$attempt" = "3" ]; then
-              echo "Failed to push fdroid metadata after 3 attempts" >&2
+              echo "Failed to update ${FILE_PATH} after 3 attempts" >&2
               exit 1
             fi
-            echo "Push rejected; retrying after rebase (attempt $attempt)"
+            echo "Update rejected (likely SHA conflict); retrying (attempt $attempt)"
+            sleep 2
           done
 
       - name: Create or update GitHub Release


### PR DESCRIPTION
This pull request updates the `release-manual.yaml` GitHub Actions workflow to improve security and reliability for tagging releases and updating F-Droid metadata. The workflow now uses a GitHub App token for authentication and leverages the GitHub API to create verified, signed tags and commits, ensuring actions are securely attributed and marked as "Verified" on GitHub. Additionally, the update process for F-Droid metadata is now more robust, handling race conditions with retries.

Key improvements:

**Authentication and Security Enhancements**
* Added a step to mint a GitHub App token using `actions/create-github-app-token@v1` and updated the `actions/checkout` step to use this token for all subsequent operations, enhancing security and ensuring proper permissions.

**Release Tagging Process**
* Replaced direct `git tag` and `git push` commands with GitHub API calls via `gh api` to create annotated tags. This ensures tags are signed with GitHub's web-flow key and marked as "Verified" in the UI, with verification checks and error handling.

**F-Droid Metadata Update Process**
* Switched from using `git` commands to the GitHub Contents API for updating the F-Droid metadata file. The update is now performed via `gh api`, resulting in a verified commit, and includes retry logic to handle SHA conflicts if concurrent updates occur.Mint a GitHub App installation token (Releaser) and use it for the checkout, tag creation, and F-Droid metadata update. The ruleset's bypass list grants this App write access to refs/heads/main, which GITHUB_TOKEN's github-actions[bot] identity does not have. Tag and commit are now produced via the GitHub API, so both are signed by the web-flow key and show as Verified.