### PR TITLE
GPG-sign release tag and update actions to Node 24

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -33,12 +33,12 @@ jobs:
 
       - name: Mint Releaser App token
         id: app_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ steps.resolve.outputs.checkout_ref }}
           fetch-depth: 0
@@ -50,13 +50,13 @@ jobs:
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up JDK 17
-        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Decode keystore
         env:
@@ -78,33 +78,40 @@ jobs:
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
           mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
-      - name: Create signed tag via API
+      - name: Import release GPG key
+        if: steps.resolve.outputs.tag_exists == 'false'
+        id: gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_tag_gpgsign: true
+
+      - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
           TAG: ${{ github.event.inputs.tag }}
           SHA: ${{ steps.sha.outputs.sha }}
           REPO: ${{ github.repository }}
+          TAGGER_NAME: ${{ steps.gpg.outputs.name }}
+          TAGGER_EMAIL: ${{ steps.gpg.outputs.email }}
         run: |
           set -euo pipefail
-          # Create an annotated tag object via the API so GitHub signs it
-          # with the web-flow key; the release page then shows "Verified".
-          tag_sha=$(gh api -X POST "repos/${REPO}/git/tags" \
-            -f tag="${TAG}" \
-            -f message="${TAG}" \
-            -f object="${SHA}" \
-            -f type=commit \
-            -f tagger[name]="github-actions[bot]" \
-            -f tagger[email]="41898282+github-actions[bot]@users.noreply.github.com" \
-            -f tagger[date]="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            --jq .sha)
-          gh api -X POST "repos/${REPO}/git/refs" \
-            -f ref="refs/tags/${TAG}" \
-            -f sha="${tag_sha}"
-          state=$(gh api "repos/${REPO}/git/tags/${tag_sha}" --jq .verification.verified)
+          git config user.name "${TAGGER_NAME}"
+          git config user.email "${TAGGER_EMAIL}"
+          git tag -s "${TAG}" "${SHA}" -m "${TAG}"
+          # Tag refs are outside the ruleset's include list, so this push
+          # uses the App token already configured in checkout's credentials.
+          git push origin "refs/tags/${TAG}"
+          # Verify GitHub recognised the signature.
+          state=$(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha' \
+            | xargs -I{} gh api "repos/${REPO}/git/tags/{}" --jq .verification.verified)
           if [ "$state" != "true" ]; then
-            echo "Tag ${TAG} was created but is NOT verified (state=$state)" >&2
-            gh api "repos/${REPO}/git/tags/${tag_sha}" --jq .verification >&2
+            tag_obj=$(gh api "repos/${REPO}/git/refs/tags/${TAG}" --jq '.object.sha')
+            echo "Tag ${TAG} pushed but NOT verified (state=$state)" >&2
+            gh api "repos/${REPO}/git/tags/${tag_obj}" --jq .verification >&2
             exit 1
           fi
           echo "Tag ${TAG} created and verified."
@@ -151,7 +158,7 @@ jobs:
           done
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag }}
           files: |


### PR DESCRIPTION
This pull request updates the `release-manual.yaml` GitHub Actions workflow to modernize dependencies and improve the release tagging process. The most significant changes include upgrading all major GitHub Actions to their latest versions and switching from API-based tag creation to directly creating and pushing GPG-signed tags using a release GPG key. This ensures that release tags are cryptographically signed and verified, improving security and trust in the release process.

**Dependency upgrades:**
* Upgraded all major GitHub Actions to their latest stable versions, including `actions/create-github-app-token`, `actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`, and `softprops/action-gh-release`, to ensure compatibility and receive the latest features and security updates. [[1]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L36-R41) [[2]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L53-R59) [[3]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L154-R161)

**Release tag signing improvements:**
* Replaced the previous GitHub API-based tag creation with a new step that imports a release GPG key and creates a GPG-signed tag directly using `git tag -s`, then pushes the signed tag to the repository. This makes the release tag cryptographically verifiable and leverages the configured GPG key for signing.
* Added logic to verify that the pushed tag is recognized as "verified" by GitHub, and improved error reporting if verification fails.Tags created via the Git Data API aren't signed by the web-flow key (unlike commits via the Contents API), so the previous attempt left the tag unverified. Switch to importing a GPG key in the runner and using `git tag -s`; the resulting tag is signed by a key whose public half is registered to a GitHub user, so it shows Verified.

Bump checkout/setup-java/setup-gradle/create-github-app-token to their Node 24-compatible majors to clear the Node 20 deprecation warnings.