### PR TITLE
Fix CI to initialize name-abbr submodule for releases

### DIFF
--- a/.github/workflows/release-manual-playstore-internal.yaml
+++ b/.github/workflows/release-manual-playstore-internal.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           ref: ${{ github.event.inputs.tag }}
+          submodules: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4

--- a/.github/workflows/release-manual-playstore.yaml
+++ b/.github/workflows/release-manual-playstore.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
         with:
           ref: ${{ github.event.inputs.tag }}
+          submodules: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,6 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
+          submodules: true
 
       - name: Capture build SHA
         id: sha

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+        with:
+          submodules: true
 
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,19 +147,26 @@ android {
 // FileNotFoundException and returns an empty map). v1.3.2 hit Play Store
 // in exactly this state because the release workflows were missing
 // `submodules: true` on actions/checkout.
-val nameAbbrFiles = listOf("class-name-abbr.json", "classroom-name-abbr.json")
-gradle.taskGraph.whenReady {
-    if (allTasks.any { it.name.startsWith("merge") && it.name.endsWith("Assets") }) {
-        val dir = rootProject.file("name-abbr")
-        val missing = nameAbbrFiles.filterNot { dir.resolve(it).exists() }
+val verifyNameAbbrSubmodule by tasks.registering {
+    val nameAbbrDir = rootProject.file("name-abbr")
+    // Explicit contract: files the runtime loader requires by name. Update
+    // this list when CourseService starts loading additional JSONs.
+    val requiredFiles = listOf("class-name-abbr.json", "classroom-name-abbr.json")
+    doLast {
+        val hint = "Run `git submodule update --init` (or pass submodules: true to actions/checkout in CI)."
+        val jsonFiles = nameAbbrDir.listFiles { f -> f.isFile && f.extension == "json" }.orEmpty()
+        if (jsonFiles.isEmpty()) {
+            throw GradleException("name-abbr submodule is empty (no JSON files in $nameAbbrDir). $hint")
+        }
+        val missing = requiredFiles.filterNot { nameAbbrDir.resolve(it).exists() }
         if (missing.isNotEmpty()) {
-            throw GradleException(
-                "name-abbr submodule is empty or missing files: $missing. " +
-                    "Run `git submodule update --init` (or pass submodules: true to actions/checkout in CI)."
-            )
+            throw GradleException("name-abbr submodule is missing required files: $missing. $hint")
         }
     }
 }
+
+tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
+    .configureEach { dependsOn(verifyNameAbbrSubmodule) }
 
 dependencies {
     implementation(libs.androidx.core.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,25 @@ android {
     }
 }
 
+// Fail fast if the name-abbr submodule wasn't checked out — otherwise the
+// app silently ships without abbreviation JSONs (the loader catches the
+// FileNotFoundException and returns an empty map). v1.3.2 hit Play Store
+// in exactly this state because the release workflows were missing
+// `submodules: true` on actions/checkout.
+val nameAbbrFiles = listOf("class-name-abbr.json", "classroom-name-abbr.json")
+gradle.taskGraph.whenReady {
+    if (allTasks.any { it.name.startsWith("merge") && it.name.endsWith("Assets") }) {
+        val dir = rootProject.file("name-abbr")
+        val missing = nameAbbrFiles.filterNot { dir.resolve(it).exists() }
+        if (missing.isNotEmpty()) {
+            throw GradleException(
+                "name-abbr submodule is empty or missing files: $missing. " +
+                    "Run `git submodule update --init` (or pass submodules: true to actions/checkout in CI)."
+            )
+        }
+    }
+}
+
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -20,6 +20,7 @@ Builds:
     versionCode: 11
     commit: <replace with commit hash when pr to F-Droid>
     subdir: app
+    submodules: true
     gradle:
       - fdroid
 


### PR DESCRIPTION
This pull request ensures that the `name-abbr` submodule is always checked out during builds, preventing the app from shipping without necessary abbreviation JSON files. It updates all relevant CI workflows and the Gradle build configuration to enforce the presence of submodule files, and also updates F-Droid metadata accordingly.

**CI/CD workflow improvements:**

* Adds `submodules: true` to the `actions/checkout` step in all release-related GitHub Actions workflows (`release.yaml`, `release-manual.yaml`, `release-manual-playstore.yaml`, and `release-manual-playstore-internal.yaml`) to ensure submodules are checked out during CI builds. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR16-R17) [[2]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3R47) [[3]](diffhunk://#diff-ee9bc701ef81d19ff38b83829b37d7ee070634389180f356fc6938a4ac49cf3bR30) [[4]](diffhunk://#diff-86b41b1c5e5d912e17972861dbd8f46ae4e44af7c33d11fe37e9f965ae7684cdR30)

**Build system safety:**

* Adds a Gradle build check in `app/build.gradle.kts` to fail fast if the `name-abbr` submodule or its required JSON files are missing, preventing silent production builds with missing data.

**F-Droid metadata update:**

* Sets `submodules: true` in the F-Droid build metadata to ensure submodules are included in F-Droid builds.actions/checkout doesn't init submodules by default, so every GitHub release workflow built the AAB against an empty name-abbr/ directory. The asset loader silently swallowed the missing-file exception (runCatching { … }.getOrDefault(emptyMap())), so v1.3.2 reached Play Store with the abbreviation toggle wired up but no data behind it. The F-Droid build server hit the same trap because the metadata Builds: block defaults to submodules=false.

Patched all four release workflows and the fdroid Builds entry, and added a Gradle preflight that fails any merge*Assets task when the expected JSONs are missing — so a future regression of this kind breaks CI instead of shipping a silently broken APK.