### PR TITLE
Add Firebase Analytics with flavor-aware logging abstraction

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,6 +208,7 @@ dependencies {
     // building fdroid* variants.
     "playImplementation"(platform(libs.firebase.bom))
     "playImplementation"(libs.firebase.messaging)
+    "playImplementation"(libs.firebase.analytics)
 
     // In-app browser (Custom Tabs)
     implementation(libs.androidx.browser)

--- a/app/src/fdroid/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/fdroid/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -1,0 +1,18 @@
+package org.ntust.app.tigerduck.analytics
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * F-Droid stub. The fdroid flavor ships without Google Play Services or any
+ * Firebase SDK, so all analytics calls are no-ops — nothing leaves the device.
+ *
+ * Same FQN as the play-flavor implementation so callers in `main/` can inject
+ * and call `log(...)` regardless of which flavor is being built.
+ */
+@Singleton
+class AnalyticsLogger @Inject constructor() {
+    fun log(event: String, params: Map<String, Any?> = emptyMap()) = Unit
+    fun setUserProperty(name: String, value: String?) = Unit
+    fun setEnabled(enabled: Boolean) = Unit
+}

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -28,5 +28,13 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_notification" />
+
+        <!-- Default Firebase Analytics collection off so auto-collected events
+             (session_start, first_open, screen_view) don't leave the device
+             before the user consents. AnalyticsLogger.setEnabled(true) flips
+             it on; Firebase persists that choice across launches. -->
+        <meta-data
+            android:name="firebase_analytics_collection_enabled"
+            android:value="false" />
     </application>
 </manifest>

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -2,16 +2,20 @@ package org.ntust.app.tigerduck.analytics
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import com.google.firebase.FirebaseApp
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.ntust.app.tigerduck.BuildConfig
 
 /**
- * Play-flavor wiring for Firebase Analytics. Auto-collected events (sessions,
- * first_open, screen_view) flow without any caller action; this class only
- * exists so feature code can record custom events from `main/`.
+ * Play-flavor wiring for Firebase Analytics. Collection is gated off in the
+ * play manifest (`firebase_analytics_collection_enabled=false`) so neither
+ * auto-collected events (session_start, first_open, screen_view) nor custom
+ * events leave the device until [setEnabled] is called with `true` after the
+ * user consents. Firebase persists that choice across launches.
  *
  * When `google-services.json` is absent at build time `FirebaseApp.getApps`
  * returns empty and every call becomes a silent no-op, mirroring the
@@ -31,17 +35,28 @@ class AnalyticsLogger @Inject constructor(
 
     fun log(event: String, params: Map<String, Any?> = emptyMap()) {
         val fa = analytics ?: return
+        if (!check("event name '$event' exceeds $MAX_NAME_CHARS chars") { event.length <= MAX_NAME_CHARS }) {
+            return
+        }
+        val entries = if (check("event '$event' has ${params.size} params (max $MAX_PARAMS)") { params.size <= MAX_PARAMS }) {
+            params.entries
+        } else {
+            params.entries.take(MAX_PARAMS)
+        }
         val bundle = Bundle().apply {
-            params.forEach { (key, value) ->
+            entries.forEach { (key, value) ->
+                if (!check("param key '$key' on '$event' exceeds $MAX_NAME_CHARS chars") { key.length <= MAX_NAME_CHARS }) {
+                    return@forEach
+                }
                 when (value) {
                     null -> Unit
-                    is String -> putString(key, value)
+                    is String -> putString(key, truncateValue(event, key, value))
                     is Int -> putLong(key, value.toLong())
                     is Long -> putLong(key, value)
                     is Double -> putDouble(key, value)
                     is Float -> putDouble(key, value.toDouble())
                     is Boolean -> putLong(key, if (value) 1L else 0L)
-                    else -> putString(key, value.toString())
+                    else -> putString(key, truncateValue(event, key, value.toString()))
                 }
             }
         }
@@ -54,5 +69,29 @@ class AnalyticsLogger @Inject constructor(
 
     fun setEnabled(enabled: Boolean) {
         analytics?.setAnalyticsCollectionEnabled(enabled)
+    }
+
+    private fun truncateValue(event: String, key: String, value: String): String {
+        if (value.length <= MAX_VALUE_CHARS) return value
+        check("param '$key' on '$event' value of ${value.length} chars exceeds $MAX_VALUE_CHARS") { false }
+        return value.substring(0, MAX_VALUE_CHARS)
+    }
+
+    /** Throws in debug, logs and returns the predicate result in release. */
+    private inline fun check(message: String, predicate: () -> Boolean): Boolean {
+        val ok = predicate()
+        if (!ok) {
+            if (BuildConfig.DEBUG) error("AnalyticsLogger: $message")
+            Log.w(TAG, message)
+        }
+        return ok
+    }
+
+    private companion object {
+        const val TAG = "AnalyticsLogger"
+        // Firebase Analytics hard limits — silently dropped/truncated upstream.
+        const val MAX_NAME_CHARS = 40
+        const val MAX_VALUE_CHARS = 100
+        const val MAX_PARAMS = 25
     }
 }

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -1,0 +1,58 @@
+package org.ntust.app.tigerduck.analytics
+
+import android.content.Context
+import android.os.Bundle
+import com.google.firebase.FirebaseApp
+import com.google.firebase.analytics.FirebaseAnalytics
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Play-flavor wiring for Firebase Analytics. Auto-collected events (sessions,
+ * first_open, screen_view) flow without any caller action; this class only
+ * exists so feature code can record custom events from `main/`.
+ *
+ * When `google-services.json` is absent at build time `FirebaseApp.getApps`
+ * returns empty and every call becomes a silent no-op, mirroring the
+ * FcmBootstrap pattern so debug builds without Firebase config still work.
+ *
+ * The fdroid variant ships a stub at the same FQN so callers in `main/` need
+ * no conditional code.
+ */
+@Singleton
+class AnalyticsLogger @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    private val analytics: FirebaseAnalytics? by lazy {
+        if (FirebaseApp.getApps(context).isEmpty()) null
+        else FirebaseAnalytics.getInstance(context)
+    }
+
+    fun log(event: String, params: Map<String, Any?> = emptyMap()) {
+        val fa = analytics ?: return
+        val bundle = Bundle().apply {
+            params.forEach { (key, value) ->
+                when (value) {
+                    null -> Unit
+                    is String -> putString(key, value)
+                    is Int -> putLong(key, value.toLong())
+                    is Long -> putLong(key, value)
+                    is Double -> putDouble(key, value)
+                    is Float -> putDouble(key, value.toDouble())
+                    is Boolean -> putLong(key, if (value) 1L else 0L)
+                    else -> putString(key, value.toString())
+                }
+            }
+        }
+        fa.logEvent(event, bundle)
+    }
+
+    fun setUserProperty(name: String, value: String?) {
+        analytics?.setUserProperty(name, value)
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        analytics?.setAnalyticsCollectionEnabled(enabled)
+    }
+}

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -67,7 +67,7 @@ class AnalyticsLogger @Inject constructor(
         val fa = analytics ?: return
         if (!validateName("user property name", name, MAX_USER_PROPERTY_NAME_CHARS)) return
         val truncated = value?.let { safeTruncate(it, MAX_USER_PROPERTY_VALUE_CHARS) }
-        if (value != null && truncated.length < value.length) {
+        if (value != null && value.length > MAX_USER_PROPERTY_VALUE_CHARS) {
             Log.w(TAG, "user property '$name' value of ${value.length} chars exceeds $MAX_USER_PROPERTY_VALUE_CHARS")
         }
         fa.setUserProperty(name, truncated)

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -67,7 +67,7 @@ class AnalyticsLogger @Inject constructor(
         val fa = analytics ?: return
         if (!validateName("user property name", name, MAX_USER_PROPERTY_NAME_CHARS)) return
         val truncated = value?.let { safeTruncate(it, MAX_USER_PROPERTY_VALUE_CHARS) }
-        if (value != null && truncated != null && truncated.length < value.length) {
+        if (value != null && truncated.length < value.length) {
             Log.w(TAG, "user property '$name' value of ${value.length} chars exceeds $MAX_USER_PROPERTY_VALUE_CHARS")
         }
         fa.setUserProperty(name, truncated)

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -8,7 +8,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import org.ntust.app.tigerduck.BuildConfig
 
 /**
  * Play-flavor wiring for Firebase Analytics. Collection is gated off in the
@@ -23,6 +22,11 @@ import org.ntust.app.tigerduck.BuildConfig
  *
  * The fdroid variant ships a stub at the same FQN so callers in `main/` need
  * no conditional code.
+ *
+ * TODO: no caller wires `setEnabled(true)` yet. Until a consent UI flips it on,
+ * the play flavor remains in the off-by-default state from the manifest. Add a
+ * preference + Settings toggle (or onboarding consent step) to actually enable
+ * collection.
  */
 @Singleton
 class AnalyticsLogger @Inject constructor(
@@ -35,19 +39,15 @@ class AnalyticsLogger @Inject constructor(
 
     fun log(event: String, params: Map<String, Any?> = emptyMap()) {
         val fa = analytics ?: return
-        if (!check("event name '$event' exceeds $MAX_NAME_CHARS chars") { event.length <= MAX_NAME_CHARS }) {
-            return
-        }
-        val entries = if (check("event '$event' has ${params.size} params (max $MAX_PARAMS)") { params.size <= MAX_PARAMS }) {
+        if (!validateName("event name", event, MAX_NAME_CHARS)) return
+        val entries = if (validate("event '$event' has ${params.size} params (max $MAX_PARAMS)") { params.size <= MAX_PARAMS }) {
             params.entries
         } else {
             params.entries.take(MAX_PARAMS)
         }
         val bundle = Bundle().apply {
             entries.forEach { (key, value) ->
-                if (!check("param key '$key' on '$event' exceeds $MAX_NAME_CHARS chars") { key.length <= MAX_NAME_CHARS }) {
-                    return@forEach
-                }
+                if (!validateName("param key on '$event'", key, MAX_NAME_CHARS)) return@forEach
                 when (value) {
                     null -> Unit
                     is String -> putString(key, truncateValue(event, key, value))
@@ -64,26 +64,77 @@ class AnalyticsLogger @Inject constructor(
     }
 
     fun setUserProperty(name: String, value: String?) {
-        analytics?.setUserProperty(name, value)
+        val fa = analytics ?: return
+        if (!validateName("user property name", name, MAX_USER_PROPERTY_NAME_CHARS)) return
+        val truncated = value?.let { safeTruncate(it, MAX_USER_PROPERTY_VALUE_CHARS) }
+        if (value != null && truncated!!.length < value.length) {
+            Log.w(TAG, "user property '$name' value of ${value.length} chars exceeds $MAX_USER_PROPERTY_VALUE_CHARS")
+        }
+        fa.setUserProperty(name, truncated)
     }
 
+    /**
+     * Toggles Firebase Analytics collection. When disabling, also resets the
+     * App Instance ID so consent revocation severs the link to previously
+     * transmitted data — required for a clean GDPR opt-out.
+     */
     fun setEnabled(enabled: Boolean) {
-        analytics?.setAnalyticsCollectionEnabled(enabled)
+        val fa = analytics ?: return
+        fa.setAnalyticsCollectionEnabled(enabled)
+        if (!enabled) fa.resetAnalyticsData()
     }
 
     private fun truncateValue(event: String, key: String, value: String): String {
         if (value.length <= MAX_VALUE_CHARS) return value
-        check("param '$key' on '$event' value of ${value.length} chars exceeds $MAX_VALUE_CHARS") { false }
-        return value.substring(0, MAX_VALUE_CHARS)
+        Log.w(TAG, "param '$key' on '$event' value of ${value.length} chars exceeds $MAX_VALUE_CHARS")
+        return safeTruncate(value, MAX_VALUE_CHARS)
     }
 
-    /** Throws in debug, logs and returns the predicate result in release. */
-    private inline fun check(message: String, predicate: () -> Boolean): Boolean {
-        val ok = predicate()
-        if (!ok) {
-            if (BuildConfig.DEBUG) error("AnalyticsLogger: $message")
-            Log.w(TAG, message)
+    /**
+     * Validates a Firebase event / param / user-property name against all four
+     * silent-rejection rules (length, identifier syntax, reserved prefix,
+     * non-empty). Logs a warning and returns false on any violation.
+     */
+    private fun validateName(label: String, name: String, maxChars: Int): Boolean {
+        if (name.isEmpty()) {
+            Log.w(TAG, "$label is empty")
+            return false
         }
+        if (name.length > maxChars) {
+            Log.w(TAG, "$label '$name' exceeds $maxChars chars")
+            return false
+        }
+        if (!isValidIdentifier(name)) {
+            Log.w(TAG, "$label '$name' must start with a letter and contain only [A-Za-z0-9_]")
+            return false
+        }
+        if (isReservedPrefix(name)) {
+            Log.w(TAG, "$label '$name' uses a reserved Firebase prefix (firebase_/google_/ga_)")
+            return false
+        }
+        return true
+    }
+
+    private fun isValidIdentifier(name: String): Boolean =
+        name[0].isLetter() && name.all { it.isLetterOrDigit() || it == '_' }
+
+    private fun isReservedPrefix(name: String): Boolean =
+        RESERVED_PREFIXES.any { name.startsWith(it) }
+
+    /**
+     * Truncates [value] to at most [limit] UTF-16 code units, backing off by
+     * one if the cut would split a surrogate pair (which would leave an
+     * unpaired high surrogate and corrupt non-BMP characters like emoji).
+     */
+    private fun safeTruncate(value: String, limit: Int): String {
+        if (value.length <= limit) return value
+        val end = if (Character.isHighSurrogate(value[limit - 1])) limit - 1 else limit
+        return value.substring(0, end)
+    }
+
+    private inline fun validate(message: String, predicate: () -> Boolean): Boolean {
+        val ok = predicate()
+        if (!ok) Log.w(TAG, message)
         return ok
     }
 
@@ -93,5 +144,9 @@ class AnalyticsLogger @Inject constructor(
         const val MAX_NAME_CHARS = 40
         const val MAX_VALUE_CHARS = 100
         const val MAX_PARAMS = 25
+        // User properties have stricter limits than events.
+        const val MAX_USER_PROPERTY_NAME_CHARS = 24
+        const val MAX_USER_PROPERTY_VALUE_CHARS = 36
+        val RESERVED_PREFIXES = listOf("firebase_", "google_", "ga_")
     }
 }

--- a/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt
@@ -67,7 +67,7 @@ class AnalyticsLogger @Inject constructor(
         val fa = analytics ?: return
         if (!validateName("user property name", name, MAX_USER_PROPERTY_NAME_CHARS)) return
         val truncated = value?.let { safeTruncate(it, MAX_USER_PROPERTY_VALUE_CHARS) }
-        if (value != null && truncated!!.length < value.length) {
+        if (value != null && truncated != null && truncated.length < value.length) {
             Log.w(TAG, "user property '$name' value of ${value.length} chars exceeds $MAX_USER_PROPERTY_VALUE_CHARS")
         }
         fa.setUserProperty(name, truncated)
@@ -116,7 +116,7 @@ class AnalyticsLogger @Inject constructor(
     }
 
     private fun isValidIdentifier(name: String): Boolean =
-        name[0].isLetter() && name.all { it.isLetterOrDigit() || it == '_' }
+        name.matches(IDENTIFIER_REGEX)
 
     private fun isReservedPrefix(name: String): Boolean =
         RESERVED_PREFIXES.any { name.startsWith(it) }
@@ -148,5 +148,6 @@ class AnalyticsLogger @Inject constructor(
         const val MAX_USER_PROPERTY_NAME_CHARS = 24
         const val MAX_USER_PROPERTY_VALUE_CHARS = 36
         val RESERVED_PREFIXES = listOf("firebase_", "google_", "ga_")
+        val IDENTIFIER_REGEX = Regex("[a-zA-Z][a-zA-Z0-9_]*")
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", versi
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
Adds firebase-analytics to the play flavor only and introduces an AnalyticsLogger abstraction with a real impl under src/play/ and a no-op stub under src/fdroid/, so callers in main/ can log events without conditional code and the F-Droid build links zero Firebase.
This pull request introduces analytics logging infrastructure that supports both the Play Store and F-Droid variants of the app. The Play variant integrates Firebase Analytics for event logging, while the F-Droid variant provides a no-op stub to preserve privacy and avoid Google dependencies. The implementation ensures that feature code can log analytics events without worrying about the build flavor.

**Analytics infrastructure:**

* Added a new `AnalyticsLogger` class in `app/src/play/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt` that wraps Firebase Analytics, allowing feature code to log custom events, set user properties, and enable/disable analytics. If Firebase is not configured, all methods become silent no-ops.
* Added a matching `AnalyticsLogger` stub in `app/src/fdroid/java/org/ntust/app/tigerduck/analytics/AnalyticsLogger.kt` for the F-Droid flavor. This stub provides the same interface but all methods are no-ops, ensuring no analytics data leaves the device.

**Dependency updates:**

* Added `firebase-analytics` to the dependencies in `gradle/libs.versions.toml` and included it in the Play Store build flavor in `app/build.gradle.kts`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR64) [[2]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R211)