### PR TITLE
Fix Gson TypeToken generic signatures for R8 compatibility

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,14 +13,14 @@
 -keepattributes Signature
 -keepattributes *Annotation*
 
--keep class * extends com.google.gson.TypeAdapter
--keep class * extends com.google.gson.TypeAdapterFactory
--keep class * extends com.google.gson.JsonSerializer
--keep class * extends com.google.gson.JsonDeserializer
+-keep class * extends com.google.gson.TypeAdapter { *; }
+-keep class * extends com.google.gson.TypeAdapterFactory { *; }
+-keep class * extends com.google.gson.JsonSerializer { *; }
+-keep class * extends com.google.gson.JsonDeserializer { *; }
 
 -keepclassmembers,allowobfuscation class * {
   @com.google.gson.annotations.SerializedName <fields>;
 }
 
--keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
--keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking,allowoptimization class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking,allowoptimization class * extends com.google.gson.reflect.TypeToken

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,19 @@
 # Add project specific ProGuard rules here.
 -keep class org.ntust.app.tigerduck.network.model.** { *; }
 -keep class org.ntust.app.tigerduck.data.model.** { *; }
+# Gson DTOs that live outside the model.** packages. Most fields here lack
+# @SerializedName, so without { *; } R8 renames the JVM fields and Gson
+# silently deserializes nulls — same failure mode as the TypeToken bug.
+-keep class org.ntust.app.tigerduck.announcements.BulletinSummary { *; }
+-keep class org.ntust.app.tigerduck.announcements.BulletinDetail { *; }
+-keep class org.ntust.app.tigerduck.announcements.BulletinListResponse { *; }
+-keep class org.ntust.app.tigerduck.announcements.OrgLabel { *; }
+-keep class org.ntust.app.tigerduck.announcements.TagLabel { *; }
+-keep class org.ntust.app.tigerduck.announcements.TaxonomyResponse { *; }
+-keep class org.ntust.app.tigerduck.announcements.SubscriptionRule { *; }
+-keep class org.ntust.app.tigerduck.announcements.SubscriptionsResponse { *; }
+-keep class org.ntust.app.tigerduck.announcements.SubscriptionsPutRequest { *; }
+-keep class org.ntust.app.tigerduck.data.cache.DataCache$* { *; }
 -dontrepackage
 
 # Gson — TypeToken<List<Course>>() {} anonymous subclasses lose their generic

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -2,3 +2,25 @@
 -keep class org.ntust.app.tigerduck.network.model.** { *; }
 -keep class org.ntust.app.tigerduck.data.model.** { *; }
 -dontrepackage
+
+# Gson — TypeToken<List<Course>>() {} anonymous subclasses lose their generic
+# signature under R8 full mode (default since AGP 8.x), which makes
+# fromJson(json, type) deserialize each element as LinkedTreeMap. The cast
+# back to the expected element type is unchecked at runtime, and the bug
+# only surfaces when downstream code touches a property — e.g. cached
+# courses fail to load on reopen because cached.associateBy { it.courseNo }
+# throws ClassCastException, which the coroutine scope swallows.
+-keepattributes Signature
+-keepattributes *Annotation*
+
+-keep class * extends com.google.gson.TypeAdapter
+-keep class * extends com.google.gson.TypeAdapterFactory
+-keep class * extends com.google.gson.JsonSerializer
+-keep class * extends com.google.gson.JsonDeserializer
+
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+-keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken


### PR DESCRIPTION
This pull request updates the ProGuard configuration to address issues with Gson's handling of generic types under R8 full mode, which can cause runtime errors when deserializing JSON into generic collections. The changes ensure that type information and necessary Gson classes are preserved during code shrinking and obfuscation.

**Gson/R8 compatibility improvements:**

* Added rules to keep generic type signatures and annotation attributes, preventing loss of type information needed by Gson's `TypeToken` during deserialization.
* Added keep rules for classes extending `TypeAdapter`, `TypeAdapterFactory`, `JsonSerializer`, and `JsonDeserializer` to ensure Gson's custom adapters are not removed or obfuscated.
* Ensured that fields annotated with `@SerializedName` are retained in class members, preserving Gson's mapping between JSON and model fields.
* Added keep rules for `TypeToken` and its subclasses to prevent them from being obfuscated or removed, which is critical for generic type deserialization.Without these rules, R8 full mode strips the generic signature from TypeToken anonymous subclasses, so DataCache.loadCourses() deserializes each entry as LinkedTreeMap. The unchecked cast to List<Course> succeeds, then cached.associateBy { it.courseNo } throws CCE inside viewModelScope and leaves the timetable empty after reopen — only recoverable via logout/login. Direct debug builds skip minification and never hit this path, which is why it only showed up in CI APKs and the Play Store AAB.