### PR TITLE
Remove AD_ID permissions and bump version to 1.3.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 13
-        versionName = "1.3.4"
+        versionCode = 14
+        versionName = "1.3.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/play/AndroidManifest.xml
+++ b/app/src/play/AndroidManifest.xml
@@ -6,7 +6,21 @@
     notifications (we always supply our own channel id, but Firebase logs a
     warning if this hint is missing).
 -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- firebase-analytics auto-merges advertising-id permissions into the
+         manifest. We only use Analytics for basic event counts (no ads, no
+         audience/conversion features, no Privacy Sandbox AdServices), so
+         strip both so we can declare "No" for advertising ID in Play
+         Console Data safety. -->
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.ACCESS_ADSERVICES_AD_ID"
+        tools:node="remove" />
+
     <application>
         <service
             android:name="org.ntust.app.tigerduck.push.FcmService"

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.3.4-fdroid
-    versionCode: 13
+  - versionName: 1.3.5-fdroid
+    versionCode: 14
     commit: <will be replaced by GitHub Action when creating release>
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.4-fdroid
-CurrentVersionCode: 13
+CurrentVersion: 1.3.5-fdroid
+CurrentVersionCode: 14


### PR DESCRIPTION
This pull request updates the app version to 1.3.5 (version code 14) and makes changes to comply with Play Console data safety requirements by explicitly removing advertising ID permissions from the Play Store build. The most important changes are:

**Version bump and metadata updates:**
* Updated `versionCode` to 14 and `versionName` to 1.3.5 in `app/build.gradle.kts`.
* Updated `versionName` and `versionCode` to 1.3.5-fdroid and 14, respectively, in `metadata/org.ntust.app.tigerduck.fdroid.yml`.
* Set `CurrentVersion` and `CurrentVersionCode` to 1.3.5-fdroid and 14 in `metadata/org.ntust.app.tigerduck.fdroid.yml`.

**Play Store build permission compliance:**
* Modified `app/src/play/AndroidManifest.xml` to explicitly remove advertising ID permissions (`com.google.android.gms.permission.AD_ID` and `android.permission.ACCESS_ADSERVICES_AD_ID`) using the `tools:node="remove"` attribute, ensuring compliance with Play Console data safety declarations.