### PR TITLE
Configure CI to include Firebase config for release builds

### DIFF
--- a/.github/workflows/release-manual-playstore-internal.yaml
+++ b/.github/workflows/release-manual-playstore-internal.yaml
@@ -46,7 +46,12 @@ jobs:
       - name: Decode google-services.json
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
-        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+            echo "::error::GOOGLE_SERVICES_JSON_BASE64 secret is empty or missing." >&2
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
 
       - name: Build release AAB and APK
         env:

--- a/.github/workflows/release-manual-playstore-internal.yaml
+++ b/.github/workflows/release-manual-playstore-internal.yaml
@@ -43,6 +43,11 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+
       - name: Build release AAB and APK
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -80,6 +85,8 @@ jobs:
           track: internal
           status: completed
 
-      - name: Clean up keystore
+      - name: Clean up secrets
         if: always()
-        run: rm -f app/keystore.jks
+        run: |
+          rm -f app/keystore.jks
+          rm -f app/src/play/google-services.json

--- a/.github/workflows/release-manual-playstore.yaml
+++ b/.github/workflows/release-manual-playstore.yaml
@@ -46,7 +46,12 @@ jobs:
       - name: Decode google-services.json
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
-        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+            echo "::error::GOOGLE_SERVICES_JSON_BASE64 secret is empty or missing." >&2
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
 
       - name: Build release AAB and APK
         env:

--- a/.github/workflows/release-manual-playstore.yaml
+++ b/.github/workflows/release-manual-playstore.yaml
@@ -43,6 +43,11 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+
       - name: Build release AAB and APK
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -81,6 +86,8 @@ jobs:
           status: inProgress
           userFraction: 0.1
 
-      - name: Clean up keystore
+      - name: Clean up secrets
         if: always()
-        run: rm -f app/keystore.jks
+        run: |
+          rm -f app/keystore.jks
+          rm -f app/src/play/google-services.json

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -78,7 +78,7 @@ jobs:
           fi
 
           # 3. Required artefact secrets present (don't print values; just check non-empty length).
-          for s in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD; do
+          for s in KEYSTORE_BASE64 KEYSTORE_PASSWORD KEY_ALIAS KEY_PASSWORD GOOGLE_SERVICES_JSON_BASE64; do
             v="${!s:-}"
             if [ -z "$v" ]; then
               echo "::error::Secret $s is empty or missing." >&2
@@ -121,6 +121,7 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -135,6 +136,11 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
+
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
 
       - name: Build release AAB and APK
         env:
@@ -230,6 +236,8 @@ jobs:
             app/build/outputs/bundle/playRelease/*.aab
             app/build/outputs/bundle/fdroidRelease/*.aab
 
-      - name: Clean up keystore
+      - name: Clean up secrets
         if: always()
-        run: rm -f app/keystore.jks
+        run: |
+          rm -f app/keystore.jks
+          rm -f app/src/play/google-services.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,12 @@ jobs:
       - name: Decode google-services.json
         env:
           GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
-        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+        run: |
+          if [ -z "$GOOGLE_SERVICES_JSON_BASE64" ]; then
+            echo "::error::GOOGLE_SERVICES_JSON_BASE64 secret is empty or missing." >&2
+            exit 1
+          fi
+          echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
 
       - name: Build release AAB and APK
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,11 @@ jobs:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
         run: echo "$KEYSTORE_BASE64" | base64 --decode > app/keystore.jks
 
+      - name: Decode google-services.json
+        env:
+          GOOGLE_SERVICES_JSON_BASE64: ${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}
+        run: echo "$GOOGLE_SERVICES_JSON_BASE64" | base64 --decode > app/src/play/google-services.json
+
       - name: Build release AAB and APK
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -67,6 +72,8 @@ jobs:
           status: inProgress
           userFraction: 0.1
 
-      - name: Clean up keystore
+      - name: Clean up secrets
         if: always()
-        run: rm -f app/keystore.jks
+        run: |
+          rm -f app/keystore.jks
+          rm -f app/src/play/google-services.json

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,6 @@
+# Greptile Review Rules
+
+## F-Droid metadata
+
+- In `metadata/org.ntust.app.tigerduck.fdroid.yml`, ignore the `commit:` field when its value is the placeholder `<will be replaced by GitHub Action when creating release>`. Do not flag it as missing, invalid, or insecure.
+  - **Why:** F-Droid requires the `commit:` field to be a full commit hash (plain-text tags like `v1.3.5` are not allowed). Because the release commit doesn't exist yet at PR time, the real hash is injected by a GitHub Action on the `main` branch when the release is cut. The placeholder is intentional.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 14
-        versionName = "1.3.5"
+        versionCode = 15
+        versionName = "1.3.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.3.5-fdroid
-    versionCode: 14
+  - versionName: 1.3.6-fdroid
+    versionCode: 15
     commit: <will be replaced by GitHub Action when creating release>
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.5-fdroid
-CurrentVersionCode: 14
+CurrentVersion: 1.3.6-fdroid
+CurrentVersionCode: 15


### PR DESCRIPTION
This pull request updates the Android app to version 1.3.6 and improves the Play Store release workflows by adding secure handling for the `google-services.json` file. It also introduces a documentation rule for F-Droid metadata validation. The most important changes are:

**Release Workflow Improvements:**

* All Play Store release workflows (`release.yaml`, `release-manual.yaml`, `release-manual-playstore.yaml`, `release-manual-playstore-internal.yaml`) now securely decode the `google-services.json` file from a base64-encoded secret and ensure it is cleaned up after the build, alongside the keystore. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR33-R37) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL70-R79) [[3]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3R140-R144) [[4]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L233-R243) [[5]](diffhunk://#diff-ee9bc701ef81d19ff38b83829b37d7ee070634389180f356fc6938a4ac49cf3bR46-R50) [[6]](diffhunk://#diff-ee9bc701ef81d19ff38b83829b37d7ee070634389180f356fc6938a4ac49cf3bL84-R93) [[7]](diffhunk://#diff-86b41b1c5e5d912e17972861dbd8f46ae4e44af7c33d11fe37e9f965ae7684cdR46-R50) [[8]](diffhunk://#diff-86b41b1c5e5d912e17972861dbd8f46ae4e44af7c33d11fe37e9f965ae7684cdL83-R92)

* The `release-manual.yaml` workflow now checks that the `GOOGLE_SERVICES_JSON_BASE64` secret is present before proceeding. [[1]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3L81-R81) [[2]](diffhunk://#diff-5e2879b75b796a76210b8136d016f392d4c50a21a27e583ae999dfe5e557d2c3R124)

**Version Updates:**

* Bumped the app's `versionCode` and `versionName` in `app/build.gradle.kts` to 15 and 1.3.6, respectively.
* Updated F-Droid metadata to reflect the new version and version code. [[1]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L19-R20) [[2]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L29-R30)

**Documentation and Validation:**

* Added a new rule in `.greptile/rules.md` clarifying that the placeholder `commit:` field in F-Droid metadata should not be flagged as invalid, as it is replaced during the release process.