### PR TITLE
Optimize manual release process by skipping lint and F-Droid AAB

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,7 +44,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
-          submodules: true
+          submodules: false
+
+      - name: Shallow init submodules
+        run: git submodule update --init --depth=1 --recursive
 
       - name: Capture build SHA
         id: sha
@@ -148,14 +151,13 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           PUSH_SHARED_SECRET: ${{ secrets.PUSH_SHARED_SECRET }}
-        run: ./gradlew bundleRelease assembleRelease
+        run: ./gradlew bundlePlayRelease assemblePlayRelease assembleFdroidRelease -x lintVitalRelease -x lint
 
       - name: Rename build outputs
         run: |
           mv app/build/outputs/apk/play/release/app-play-release.apk "app/build/outputs/apk/play/release/TigerDuck.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk "app/build/outputs/apk/fdroid/release/TigerDuck-fdroid.apk"
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
-          mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
       - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
@@ -234,7 +236,6 @@ jobs:
             app/build/outputs/apk/play/release/*.apk
             app/build/outputs/apk/fdroid/release/*.apk
             app/build/outputs/bundle/playRelease/*.aab
-            app/build/outputs/bundle/fdroidRelease/*.aab
 
       - name: Clean up secrets
         if: always()


### PR DESCRIPTION
This pull request updates the manual release workflow in `.github/workflows/release-manual.yaml` to improve submodule handling and adjust the build and artifact steps for Android releases. The main focus is on optimizing how submodules are initialized and refining which build variants and artifacts are produced and handled.

**Submodule handling improvements:**
- Changed the `actions/checkout` step to set `submodules: false` and added a new step to initialize submodules shallowly, which can speed up the workflow and reduce unnecessary data fetching.

**Build process adjustments:**
- Updated the Gradle build command to explicitly build the Play Store and F-Droid variants (`bundlePlayRelease`, `assemblePlayRelease`, `assembleFdroidRelease`), while skipping certain lint tasks to streamline the process.

**Artifact management changes:**
- Removed the renaming and handling of the F-Droid AAB bundle, so only Play Store artifacts are renamed and processed in subsequent steps.
- Stopped uploading the F-Droid AAB bundle as part of the release artifacts, focusing artifact upload on Play Store outputs.…id AAB, shallow submodules

Skip lintVitalRelease and lint, build only the artifacts we ship (Play AAB+APK, F-Droid APK), and shallow-clone submodules.