### PR TITLE
Optimize release process by skipping lint and bundling debug symbols

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,7 +44,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
-          submodules: true
+          submodules: false
+
+      - name: Shallow init submodules
+        run: git submodule update --init --depth=1 --recursive
 
       - name: Capture build SHA
         id: sha
@@ -148,14 +151,13 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           PUSH_SHARED_SECRET: ${{ secrets.PUSH_SHARED_SECRET }}
-        run: ./gradlew bundleRelease assembleRelease
+        run: ./gradlew bundlePlayRelease assemblePlayRelease assembleFdroidRelease -x lintVitalRelease -x lint
 
       - name: Rename build outputs
         run: |
           mv app/build/outputs/apk/play/release/app-play-release.apk "app/build/outputs/apk/play/release/TigerDuck.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk "app/build/outputs/apk/fdroid/release/TigerDuck-fdroid.apk"
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
-          mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
       - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
@@ -234,7 +236,6 @@ jobs:
             app/build/outputs/apk/play/release/*.apk
             app/build/outputs/apk/fdroid/release/*.apk
             app/build/outputs/bundle/playRelease/*.aab
-            app/build/outputs/bundle/fdroidRelease/*.aab
 
       - name: Clean up secrets
         if: always()

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,10 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
-          submodules: false
-
-      - name: Shallow init submodules
-        run: git submodule update --init --depth=1 --recursive
+          submodules: true
 
       - name: Capture build SHA
         id: sha
@@ -151,13 +148,14 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           PUSH_SHARED_SECRET: ${{ secrets.PUSH_SHARED_SECRET }}
-        run: ./gradlew bundlePlayRelease assemblePlayRelease assembleFdroidRelease -x lintVitalRelease -x lint
+        run: ./gradlew bundleRelease assembleRelease
 
       - name: Rename build outputs
         run: |
           mv app/build/outputs/apk/play/release/app-play-release.apk "app/build/outputs/apk/play/release/TigerDuck.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk "app/build/outputs/apk/fdroid/release/TigerDuck-fdroid.apk"
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
+          mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
       - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
@@ -236,6 +234,7 @@ jobs:
             app/build/outputs/apk/play/release/*.apk
             app/build/outputs/apk/fdroid/release/*.apk
             app/build/outputs/bundle/playRelease/*.aab
+            app/build/outputs/bundle/fdroidRelease/*.aab
 
       - name: Clean up secrets
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             val keystoreFile = file("keystore.jks")
             if (keystoreFile.exists() && System.getenv("KEYSTORE_PASSWORD")?.isNotEmpty() == true) {
                 signingConfig = signingConfigs.getByName("release")


### PR DESCRIPTION
This pull request updates the release workflow and build configuration to improve submodule handling, build artifact generation, and native debug symbol inclusion. The most significant changes are grouped below.

**Release workflow improvements:**

* Changed submodule fetching to use a shallow recursive init instead of full clone, which can speed up CI and reduce bandwidth usage. (`.github/workflows/release-manual.yaml`)
* Updated Gradle build command to generate Play Store and F-Droid variants, and skip certain lint tasks to streamline the release process. (`.github/workflows/release-manual.yaml`)
* Removed steps related to renaming and uploading F-Droid bundle artifacts, likely to simplify the release outputs. (`.github/workflows/release-manual.yaml`)

**Build configuration enhancements:**

* Enabled full native debug symbol generation for release builds, which improves post-release debugging and crash analysis. (`app/build.gradle.kts`)