### PR TITLE
Fix widget to display cached ClassTable on SSO cookie expiry

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
@@ -29,7 +29,12 @@ object WidgetDataLoader {
             WidgetEntryPoint::class.java,
         )
         val courses = entry.dataCache().loadCourses()
-        val isLoggedIn = entry.authService().isNtustAuthenticated
+        // "Logged in" here means the user has stored credentials, not that
+        // their SSO cookies are still fresh. Cookie validity gates fetching;
+        // it shouldn't gate displaying the cached classtable. Without this,
+        // an expired 1h cookie or a process restart while offline makes the
+        // widget say "Please sign in" even though we have cached courses.
+        val isLoggedIn = entry.authService().authState.value
 
         val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
         val weekday = cal.toWeekday()


### PR DESCRIPTION
This pull request updates the logic for determining the logged-in state in the widget data loader. Instead of checking for fresh SSO cookies, it now checks whether the user has stored credentials, allowing cached course data to be displayed even if the session has expired or the device is offline.

Authentication state handling:

* Changed the `isLoggedIn` check in `WidgetDataLoader` to use `authState.value` instead of `isNtustAuthenticated`, so the widget displays cached courses as long as credentials are present, regardless of SSO cookie freshness.The widget gated rendering on `authService.isNtustAuthenticated`, which also requires fresh NTUST SSO cookies (1h TTL, plus an in-memory store that empties on every process restart). When the cookies lapsed — common after a process kill or while the phone is offline — the widget threw away the cached courses we'd just loaded and showed "Please sign in to TigerDuck first," even though the user was still signed in and the Moodle-derived data was perfectly displayable.

Switch to `authService.authState.value`, the same signal the in-app ClassTableScreen uses. It's true iff the user has stored credentials, so it only flips on explicit logout (or first launch). Cookie freshness remains the right gate for *fetching*, but it has no business gating the display of cached data.