### PR TITLE
Optimize release process and fix widget cached data display

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,7 +44,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
-          submodules: true
+          submodules: false
+
+      - name: Shallow init submodules
+        run: git submodule update --init --depth=1 --recursive
 
       - name: Capture build SHA
         id: sha
@@ -148,14 +151,13 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           PUSH_SHARED_SECRET: ${{ secrets.PUSH_SHARED_SECRET }}
-        run: ./gradlew bundleRelease assembleRelease
+        run: ./gradlew bundlePlayRelease assemblePlayRelease assembleFdroidRelease -x lintVitalRelease -x lint
 
       - name: Rename build outputs
         run: |
           mv app/build/outputs/apk/play/release/app-play-release.apk "app/build/outputs/apk/play/release/TigerDuck.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk "app/build/outputs/apk/fdroid/release/TigerDuck-fdroid.apk"
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
-          mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
       - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
@@ -234,7 +236,6 @@ jobs:
             app/build/outputs/apk/play/release/*.apk
             app/build/outputs/apk/fdroid/release/*.apk
             app/build/outputs/bundle/playRelease/*.aab
-            app/build/outputs/bundle/fdroidRelease/*.aab
 
       - name: Clean up secrets
         if: always()

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -44,10 +44,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: true
           token: ${{ steps.app_token.outputs.token }}
-          submodules: false
-
-      - name: Shallow init submodules
-        run: git submodule update --init --depth=1 --recursive
+          submodules: true
 
       - name: Capture build SHA
         id: sha
@@ -151,13 +148,14 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           PUSH_SHARED_SECRET: ${{ secrets.PUSH_SHARED_SECRET }}
-        run: ./gradlew bundlePlayRelease assemblePlayRelease assembleFdroidRelease -x lintVitalRelease -x lint
+        run: ./gradlew bundleRelease assembleRelease
 
       - name: Rename build outputs
         run: |
           mv app/build/outputs/apk/play/release/app-play-release.apk "app/build/outputs/apk/play/release/TigerDuck.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk "app/build/outputs/apk/fdroid/release/TigerDuck-fdroid.apk"
           mv app/build/outputs/bundle/playRelease/app-play-release.aab "app/build/outputs/bundle/playRelease/TigerDuck.aab"
+          mv app/build/outputs/bundle/fdroidRelease/app-fdroid-release.aab "app/build/outputs/bundle/fdroidRelease/TigerDuck-fdroid.aab"
 
       - name: Create and push signed tag
         if: steps.resolve.outputs.tag_exists == 'false'
@@ -236,6 +234,7 @@ jobs:
             app/build/outputs/apk/play/release/*.apk
             app/build/outputs/apk/fdroid/release/*.apk
             app/build/outputs/bundle/playRelease/*.aab
+            app/build/outputs/bundle/fdroidRelease/*.aab
 
       - name: Clean up secrets
         if: always()

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 16
-        versionName = "1.3.7"
+        versionCode = 17
+        versionName = "1.3.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            ndk {
+                debugSymbolLevel = "FULL"
+            }
             val keystoreFile = file("keystore.jks")
             if (keystoreFile.exists() && System.getenv("KEYSTORE_PASSWORD")?.isNotEmpty() == true) {
                 signingConfig = signingConfigs.getByName("release")

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
@@ -29,7 +29,12 @@ object WidgetDataLoader {
             WidgetEntryPoint::class.java,
         )
         val courses = entry.dataCache().loadCourses()
-        val isLoggedIn = entry.authService().isNtustAuthenticated
+        // "Logged in" here means the user has stored credentials, not that
+        // their SSO cookies are still fresh. Cookie validity gates fetching;
+        // it shouldn't gate displaying the cached classtable. Without this,
+        // an expired 1h cookie or a process restart while offline makes the
+        // widget say "Please sign in" even though we have cached courses.
+        val isLoggedIn = entry.authService().authState.value
 
         val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
         val weekday = cal.toWeekday()

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.3.7-fdroid
-    versionCode: 16
+  - versionName: 1.3.8-fdroid
+    versionCode: 17
     commit: <will be replaced by GitHub Action when creating release>
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.3.7-fdroid
-CurrentVersionCode: 16
+CurrentVersion: 1.3.8-fdroid
+CurrentVersionCode: 17


### PR DESCRIPTION
This pull request updates the app to version 1.3.8 and introduces improvements to how authentication state is handled for the widget, as well as build configuration enhancements. The most important changes are as follows:

Version bump and release metadata updates:
* Updated `versionCode` and `versionName` in `app/build.gradle.kts` and corresponding values in `metadata/org.ntust.app.tigerduck.fdroid.yml` to reflect the new release version 1.3.8. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L49-R50) [[2]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L19-R20) [[3]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L29-R30)

Widget authentication logic improvement:
* Changed the widget's "logged in" check in `WidgetDataLoader.kt` to use the current authentication state instead of just checking for stored credentials. This ensures the widget displays cached course data even if SSO cookies are expired or the device is offline, improving user experience.

Build configuration enhancement:
* Added `ndk.debugSymbolLevel = "FULL"` to the release build type in `app/build.gradle.kts` to include full native debug symbols in release builds, aiding in debugging native crashes.