### PR TITLE
Bundle all languages into base APK for per-app language picker

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -143,6 +143,19 @@ android {
             assets.directories.add(rootProject.file("name-abbr").path)
         }
     }
+
+    // Per-app language picker hands users any locale we ship, but Play's
+    // default per-language AAB splits only deliver the split matching the
+    // device's system locale at install time. Result: picking any other
+    // language falls back to values/ (English) because that locale's
+    // strings.xml isn't on disk. Bundle every language into the base APK
+    // so the picker always has resources to resolve against. The added
+    // install size is small — strings.xml only, no per-language assets.
+    bundle {
+        language {
+            enableSplit = false
+        }
+    }
 }
 
 // Fail fast if the name-abbr submodule wasn't checked out — otherwise the


### PR DESCRIPTION
This pull request updates the `app/build.gradle.kts` build configuration to ensure proper support for the in-app language picker feature. The change addresses an issue where users selecting a language different from their device's system locale would not see the correct translations, due to missing language resources in the installed APK.

Localization and app bundle improvements:

* Updated the `android` build configuration to disable language splits in the app bundle (`enableSplit = false`), ensuring that all language `strings.xml` resources are included in the base APK. This guarantees that the in-app language picker can always access the correct translations, regardless of the device's system locale, with minimal impact on APK size.Per-app language picker offers any of the 60+ locales the app ships, but Play's default per-language AAB splits only deliver the split matching the device's system locale at install time. Picking any other language fell back to values/ (English) because that locale's strings.xml wasn't on disk. Disable language splits so every values-* dir lives in the base APK and the picker always resolves.