### PR TITLE
Improve accessibility semantics for TalkBack in UI components

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
@@ -34,6 +34,13 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -99,13 +106,19 @@ fun AnnouncementsScreen(
                     )
                 }
             }
-            IconButton(onClick = { viewModel.setUnreadOnly(!state.unreadOnly) }) {
+            val unreadOnlyLabel = stringResource(R.string.bulletin_show_unread_only_action)
+            IconButton(
+                onClick = { viewModel.setUnreadOnly(!state.unreadOnly) },
+                modifier = Modifier.semantics {
+                    role = Role.Switch
+                    contentDescription = unreadOnlyLabel
+                    toggleableState =
+                        if (state.unreadOnly) ToggleableState.On else ToggleableState.Off
+                },
+            ) {
                 Icon(
                     if (state.unreadOnly) Icons.Filled.FilterAlt else Icons.Filled.FilterAltOff,
-                    contentDescription = stringResource(
-                        if (state.unreadOnly) R.string.bulletin_show_all_action
-                        else R.string.bulletin_show_unread_only_action
-                    ),
+                    contentDescription = null,
                 )
             }
             IconButton(onClick = onOpenSubscriptions) {

--- a/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/announcements/AnnouncementsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -36,11 +37,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.semantics.toggleableState
-import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -107,14 +104,18 @@ fun AnnouncementsScreen(
                 }
             }
             val unreadOnlyLabel = stringResource(R.string.bulletin_show_unread_only_action)
-            IconButton(
-                onClick = { viewModel.setUnreadOnly(!state.unreadOnly) },
-                modifier = Modifier.semantics {
-                    role = Role.Switch
-                    contentDescription = unreadOnlyLabel
-                    toggleableState =
-                        if (state.unreadOnly) ToggleableState.On else ToggleableState.Off
-                },
+            Box(
+                modifier = Modifier
+                    .minimumInteractiveComponentSize()
+                    .toggleable(
+                        value = state.unreadOnly,
+                        role = Role.Switch,
+                        onValueChange = { viewModel.setUnreadOnly(it) },
+                    )
+                    .semantics {
+                        contentDescription = unreadOnlyLabel
+                    },
+                contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     if (state.unreadOnly) Icons.Filled.FilterAlt else Icons.Filled.FilterAltOff,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
@@ -48,7 +48,7 @@ fun SyncIndicator(
         modifier = modifier
             .size(20.dp)
             .then(
-                if (statusLabel.isNotEmpty()) Modifier.semantics {
+                if (statusLabel.isNotEmpty()) Modifier.semantics(mergeDescendants = true) {
                     liveRegion = LiveRegionMode.Polite
                     contentDescription = statusLabel
                 } else Modifier

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
@@ -33,7 +37,21 @@ fun SyncIndicator(
     modifier: Modifier = Modifier,
     dragProgress: Float = 0f,
 ) {
-    Box(modifier = modifier.size(20.dp)) {
+    val loadingLabel = stringResource(R.string.refreshing_message)
+    val successLabel = stringResource(R.string.sync_success_content_description)
+    val statusLabel = when {
+        isLoading -> loadingLabel
+        showCheckmark -> successLabel
+        else -> ""
+    }
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                if (statusLabel.isNotEmpty()) contentDescription = statusLabel
+            },
+    ) {
         AnimatedContent(
             targetState = when {
                 isLoading -> "loading"
@@ -53,7 +71,7 @@ fun SyncIndicator(
 
                 "checkmark" -> Icon(
                     Icons.Filled.CheckCircle,
-                    contentDescription = stringResource(R.string.sync_success_content_description),
+                    contentDescription = null,
                     tint = Color(0xFF34C759),
                     modifier = Modifier.size(20.dp)
                 )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SyncIndicator.kt
@@ -47,10 +47,12 @@ fun SyncIndicator(
     Box(
         modifier = modifier
             .size(20.dp)
-            .semantics {
-                liveRegion = LiveRegionMode.Polite
-                if (statusLabel.isNotEmpty()) contentDescription = statusLabel
-            },
+            .then(
+                if (statusLabel.isNotEmpty()) Modifier.semantics {
+                    liveRegion = LiveRegionMode.Polite
+                    contentDescription = statusLabel
+                } else Modifier
+            ),
     ) {
         AnimatedContent(
             targetState = when {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -592,7 +591,7 @@ private fun TimetableGrid(
 
                             is ClassTableViewModel.CellRole.ConflictStart -> {
                                 ConflictCourseCell(
-                                    role = role,
+                                    cellRole = role,
                                     dayColWidth = dayColWidth,
                                     cellHeight = cellHeight,
                                     x = x,
@@ -629,7 +628,6 @@ private fun SemesterPicker(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val currentLabel = labelFor(current)
-    val dropdownHint = stringResource(R.string.a11y_dropdown_action_hint)
     Box {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -637,8 +635,7 @@ private fun SemesterPicker(
                 .clip(RoundedCornerShape(8.dp))
                 .semantics(mergeDescendants = true) {
                     role = Role.DropdownList
-                    stateDescription = currentLabel
-                    contentDescription = dropdownHint
+                    contentDescription = currentLabel
                 }
                 .clickable { expanded = true }
                 .padding(horizontal = 8.dp, vertical = 4.dp)
@@ -781,7 +778,7 @@ private fun SoloCourseCell(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ConflictCourseCell(
-    role: ClassTableViewModel.CellRole.ConflictStart,
+    cellRole: ClassTableViewModel.CellRole.ConflictStart,
     dayColWidth: androidx.compose.ui.unit.Dp,
     cellHeight: androidx.compose.ui.unit.Dp,
     x: androidx.compose.ui.unit.Dp,
@@ -803,8 +800,8 @@ private fun ConflictCourseCell(
         TigerDuckTheme.courseColorVibrant(course.courseNo).copy(alpha = 0.50f)
     }
 
-    val overlapStart = maxOf(role.offsetA, role.offsetB)
-    val overlapEnd = minOf(role.offsetA + role.spanA, role.offsetB + role.spanB)
+    val overlapStart = maxOf(cellRole.offsetA, cellRole.offsetB)
+    val overlapEnd = minOf(cellRole.offsetA + cellRole.spanA, cellRole.offsetB + cellRole.spanB)
 
     // Solo fractions are relative to each course's OWN span (= its Box height),
     // not the combined span.
@@ -814,10 +811,10 @@ private fun ConflictCourseCell(
     fun soloBelow(offset: Int, span: Int) =
         (offset + span - overlapEnd).coerceAtLeast(0).toFloat() / span
 
-    val soloAboveA = soloAbove(role.offsetA, role.spanA)
-    val soloBelowA = soloBelow(role.offsetA, role.spanA)
-    val soloAboveB = soloAbove(role.offsetB, role.spanB)
-    val soloBelowB = soloBelow(role.offsetB, role.spanB)
+    val soloAboveA = soloAbove(cellRole.offsetA, cellRole.spanA)
+    val soloBelowA = soloBelow(cellRole.offsetA, cellRole.spanA)
+    val soloAboveB = soloAbove(cellRole.offsetB, cellRole.spanB)
+    val soloBelowB = soloBelow(cellRole.offsetB, cellRole.spanB)
 
     // Pure overlap at an edge = neither course has solo at that edge. There
     // both shapes have convex corners pointing the same way, so only sharp
@@ -849,7 +846,7 @@ private fun ConflictCourseCell(
     Box(
         modifier = Modifier
             .width(dayColWidth)
-            .height(cellHeight * role.combinedSpan)
+            .height(cellHeight * cellRole.combinedSpan)
             .absoluteOffset(x = x, y = y)
             .padding(1.dp),
     ) {
@@ -858,11 +855,11 @@ private fun ConflictCourseCell(
         // exceed the padded area by 2dp; Compose's overflow handling then
         // leaves a visible seam between the two shapes.
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-            val rowHeight = maxHeight / role.combinedSpan
-            val aTop = rowHeight * role.offsetA
-            val aHeight = rowHeight * role.spanA
-            val bTop = rowHeight * role.offsetB
-            val bHeight = rowHeight * role.spanB
+            val rowHeight = maxHeight / cellRole.combinedSpan
+            val aTop = rowHeight * cellRole.offsetA
+            val aHeight = rowHeight * cellRole.spanA
+            val bTop = rowHeight * cellRole.offsetB
+            val bHeight = rowHeight * cellRole.spanB
             val aBarFraction = (soloAboveA + 0.5f * (1f - soloAboveA - soloBelowA))
                 .coerceAtLeast(0.1f)
             val bBarFraction = (soloBelowB + 0.5f * (1f - soloAboveB - soloBelowB))
@@ -882,8 +879,8 @@ private fun ConflictCourseCell(
                     append(assignmentLabel)
                 }
             }
-            val labelA = cellLabel(role.courseA, hasAssignmentA)
-            val labelB = cellLabel(role.courseB, hasAssignmentB)
+            val labelA = cellLabel(cellRole.courseA, hasAssignmentA)
+            val labelB = cellLabel(cellRole.courseB, hasAssignmentB)
 
             Box(
                 modifier = Modifier
@@ -891,15 +888,15 @@ private fun ConflictCourseCell(
                     .height(aHeight)
                     .absoluteOffset(x = 0.dp, y = aTop)
                     .clip(shapeA)
-                    .background(bgFor(role.courseA))
+                    .background(bgFor(cellRole.courseA))
                     .semantics(mergeDescendants = true) {
                         contentDescription = labelA
-                        this.role = Role.Button
+                        role = Role.Button
                     }
                     .combinedClickable(
                         interactionSource = interactionSource,
                         indication = indication,
-                        onClick = { onPickConflict(role.courseA, role.courseB, weekday, periodId) },
+                        onClick = { onPickConflict(cellRole.courseA, cellRole.courseB, weekday, periodId) },
                         onLongClick = { onLongPress(); showMenu = true },
                     ),
             ) {
@@ -913,7 +910,7 @@ private fun ConflictCourseCell(
                     contentAlignment = Alignment.Center,
                 ) {
                     ClassTableCourseNameText(
-                        text = role.courseA.courseName,
+                        text = cellRole.courseA.courseName,
                         color = textColor,
                         maxLines = 2,
                     )
@@ -937,15 +934,15 @@ private fun ConflictCourseCell(
                     .height(bHeight)
                     .absoluteOffset(x = 0.dp, y = bTop)
                     .clip(shapeB)
-                    .background(bgFor(role.courseB))
+                    .background(bgFor(cellRole.courseB))
                     .semantics(mergeDescendants = true) {
                         contentDescription = labelB
-                        this.role = Role.Button
+                        role = Role.Button
                     }
                     .combinedClickable(
                         interactionSource = interactionSource,
                         indication = indication,
-                        onClick = { onPickConflict(role.courseA, role.courseB, weekday, periodId) },
+                        onClick = { onPickConflict(cellRole.courseA, cellRole.courseB, weekday, periodId) },
                         onLongClick = { onLongPress(); showMenu = true },
                     ),
             ) {
@@ -959,7 +956,7 @@ private fun ConflictCourseCell(
                     contentAlignment = Alignment.Center,
                 ) {
                     ClassTableCourseNameText(
-                        text = role.courseB.courseName,
+                        text = cellRole.courseB.courseName,
                         color = textColor,
                         maxLines = 2,
                     )
@@ -982,7 +979,7 @@ private fun ConflictCourseCell(
                 onDismissRequest = { showMenu = false },
                 shape = RoundedCornerShape(12.dp),
             ) {
-                listOf(role.courseA, role.courseB).forEachIndexed { idx, course ->
+                listOf(cellRole.courseA, cellRole.courseB).forEachIndexed { idx, course ->
                     if (idx > 0) HorizontalDivider()
                     DropdownMenuItem(
                         text = {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -26,6 +26,11 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -623,16 +628,23 @@ private fun SemesterPicker(
     onPick: (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val currentLabel = labelFor(current)
+    val dropdownHint = stringResource(R.string.a11y_dropdown_action_hint)
     Box {
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
+                .semantics(mergeDescendants = true) {
+                    role = Role.DropdownList
+                    stateDescription = currentLabel
+                    contentDescription = dropdownHint
+                }
                 .clickable { expanded = true }
                 .padding(horizontal = 8.dp, vertical = 4.dp)
         ) {
             Text(
-                text = labelFor(current),
+                text = currentLabel,
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.primary
             )
@@ -689,6 +701,18 @@ private fun SoloCourseCell(
     }
     val cellTextColor = if (TigerDuckTheme.isDarkMode) Color.White else Color(0xFF1C1C1E)
     var showMenu by remember { mutableStateOf(false) }
+    val assignmentLabel = stringResource(R.string.a11y_class_table_cell_assignment_indicator)
+    val cellLabel = buildString {
+        append(course.courseName)
+        if (course.classroom.isNotBlank()) {
+            append(", ")
+            append(course.classroom)
+        }
+        if (hasAssignment) {
+            append(". ")
+            append(assignmentLabel)
+        }
+    }
     Box(
         modifier = Modifier
             .width(dayColWidth)
@@ -697,6 +721,10 @@ private fun SoloCourseCell(
             .padding(1.dp)
             .clip(RoundedCornerShape(6.dp))
             .background(cellBg)
+            .semantics(mergeDescendants = true) {
+                contentDescription = cellLabel
+                role = Role.Button
+            }
             .combinedClickable(
                 onClick = onTap,
                 onLongClick = {
@@ -839,6 +867,24 @@ private fun ConflictCourseCell(
                 .coerceAtLeast(0.1f)
             val bBarFraction = (soloBelowB + 0.5f * (1f - soloAboveB - soloBelowB))
                 .coerceAtLeast(0.1f)
+            val conflictPrefix = stringResource(R.string.a11y_class_table_conflict_prefix)
+            val assignmentLabel = stringResource(R.string.a11y_class_table_cell_assignment_indicator)
+            fun cellLabel(course: Course, hasAssignment: Boolean): String = buildString {
+                append(conflictPrefix)
+                append(": ")
+                append(course.courseName)
+                if (course.classroom.isNotBlank()) {
+                    append(", ")
+                    append(course.classroom)
+                }
+                if (hasAssignment) {
+                    append(". ")
+                    append(assignmentLabel)
+                }
+            }
+            val labelA = cellLabel(role.courseA, hasAssignmentA)
+            val labelB = cellLabel(role.courseB, hasAssignmentB)
+
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -846,6 +892,10 @@ private fun ConflictCourseCell(
                     .absoluteOffset(x = 0.dp, y = aTop)
                     .clip(shapeA)
                     .background(bgFor(role.courseA))
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = labelA
+                        this.role = Role.Button
+                    }
                     .combinedClickable(
                         interactionSource = interactionSource,
                         indication = indication,
@@ -888,6 +938,10 @@ private fun ConflictCourseCell(
                     .absoluteOffset(x = 0.dp, y = bTop)
                     .clip(shapeB)
                     .background(bgFor(role.courseB))
+                    .semantics(mergeDescendants = true) {
+                        contentDescription = labelB
+                        this.role = Role.Button
+                    }
                     .combinedClickable(
                         interactionSource = interactionSource,
                         indication = indication,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -56,9 +56,7 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
@@ -534,7 +532,6 @@ private fun FluidTrack(viewModel: TimeSliderViewModel, invertDirection: Boolean)
             .semantics {
                 contentDescription = "$a11yLabel. $a11ySwipeHint"
                 stateDescription = selectedTimeLabel
-                liveRegion = LiveRegionMode.Polite
             }
             .pointerInput(invertDirection) {
                 detectHorizontalDragGestures(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -56,6 +56,11 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -516,6 +521,9 @@ private fun FluidTrack(viewModel: TimeSliderViewModel, invertDirection: Boolean)
     var widthPx by remember { mutableStateOf(0f) }
 
     val pxPerDp = with(density) { 1.dp.toPx() }
+    val a11yLabel = stringResource(R.string.home_time_slider_title)
+    val a11ySwipeHint = stringResource(R.string.a11y_time_slider_swipe_hint)
+    val selectedTimeLabel = formatTimeLabel(viewModel.selectedTime)
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -523,6 +531,11 @@ private fun FluidTrack(viewModel: TimeSliderViewModel, invertDirection: Boolean)
             .onSizeChanged { widthPx = it.width.toFloat() }
             .clip(RoundedCornerShape(50))
             .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f))
+            .semantics {
+                contentDescription = "$a11yLabel. $a11ySwipeHint"
+                stateDescription = selectedTimeLabel
+                liveRegion = LiveRegionMode.Polite
+            }
             .pointerInput(invertDirection) {
                 detectHorizontalDragGestures(
                     onDragStart = {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
@@ -46,7 +46,9 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -194,7 +196,12 @@ fun LoginSheet(
                     }
 
                     if (loginError != null) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.semantics(mergeDescendants = true) {
+                                liveRegion = LiveRegionMode.Assertive
+                            },
+                        ) {
                             Icon(
                                 Icons.Filled.ErrorOutline,
                                 contentDescription = null,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.Dp
@@ -600,6 +603,7 @@ internal fun SettingsLinkRow(label: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .height(SettingRowHeight)
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .clickable { onClick() }
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -620,6 +624,7 @@ private fun SettingsLinkRowWithValue(label: String, value: String, onClick: () -
         modifier = Modifier
             .fillMaxWidth()
             .height(SettingRowHeight)
+            .semantics(mergeDescendants = true) { role = Role.Button }
             .clickable { onClick() }
             .padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">لوحة مفاتيح قياسية</string>
     <string name="action_add">إضافة</string>
     <string name="action_allow">السماح</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавиатура</string>
     <string name="action_add">Добави</string>
     <string name="action_allow">Разреши</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">স্ট্যান্ডার্ড কীবোর্ড</string>
     <string name="action_add">যোগ করুন</string>
     <string name="action_allow">অনুমতি দিন</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclat estàndard</string>
     <string name="action_add">Afegeix</string>
     <string name="action_allow">Permet</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardní klávesnice</string>
     <string name="action_add">Přidat</string>
     <string name="action_allow">Povolit</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Tilføj</string>
     <string name="action_allow">Tillad</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Hinzufügen</string>
     <string name="action_allow">Erlauben</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Τυπικό πληκτρολόγιο</string>
     <string name="action_add">Προσθήκη</string>
     <string name="action_allow">Επιτρέπεται</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardklaviatuur</string>
     <string name="action_add">Lisa</string>
     <string name="action_allow">Luba</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">صفحه‌کلید استاندارد</string>
     <string name="action_add">افزودن</string>
     <string name="action_allow">اجازه دادن</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Vakionäppäimistö</string>
     <string name="action_add">Lisää</string>
     <string name="action_allow">Salli</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard na keyboard</string>
     <string name="action_add">Idagdag</string>
     <string name="action_allow">Payagan</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">પ્રમાણભૂત કીબોર્ડ</string>
     <string name="action_add">ઉમેરો</string>
     <string name="action_allow">મંજૂરી આપો</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोड़ें</string>
     <string name="action_allow">अनुमति दें</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dopusti</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Normál billentyűzet</string>
     <string name="action_add">Hozzáadás</string>
     <string name="action_allow">Engedélyezés</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Keyboard standar</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Izinkan</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Staðlað lyklaborð</string>
     <string name="action_add">Bæta við</string>
     <string name="action_allow">Leyfa</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Tastiera standard</string>
     <string name="action_add">Aggiungi</string>
     <string name="action_allow">Consenti</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">מקלדת רגילה</string>
     <string name="action_add">הוסף</string>
     <string name="action_allow">אפשר</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">標準キーボード</string>
     <string name="action_add">追加</string>
     <string name="action_allow">許可</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартты пернетақта</string>
     <string name="action_add">Қосу</string>
     <string name="action_allow">Рұқсат беру</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ಪ್ರಮಾಣಿತ ಕೀಬೋರ್ಡ್</string>
     <string name="action_add">ಸೇರಿಸಿ</string>
     <string name="action_allow">ಅನುಮತಿಸಿ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">표준 키보드</string>
     <string name="action_add">추가</string>
     <string name="action_allow">허용</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standartinė klaviatūra</string>
     <string name="action_add">Pridėti</string>
     <string name="action_allow">Leisti</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standarta tastatūra</string>
     <string name="action_add">Pievienot</string>
     <string name="action_allow">Atļaut</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">സ്റ്റാൻഡേർഡ് കീബോർഡ്</string>
     <string name="action_add">ചേർക്കുക</string>
     <string name="action_allow">അനുവദിക്കുക</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोडा</string>
     <string name="action_allow">परवानगी द्या</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Papan kekunci standard</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Benarkan</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standaardtoetsenbord</string>
     <string name="action_add">Toevoegen</string>
     <string name="action_allow">Toestaan</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ਸਟੈਂਡਰਡ ਕੀਬੋਰਡ</string>
     <string name="action_add">ਜੋੜੋ</string>
     <string name="action_allow">ਆਗਿਆ ਦਿਓ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardowa klawiatura</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Zezwól</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Tastatură standard</string>
     <string name="action_add">Adaugă</string>
     <string name="action_allow">Permite</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартная клавиатура</string>
     <string name="action_add">Добавить</string>
     <string name="action_allow">Разрешить</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Štandardná klávesnica</string>
     <string name="action_add">Pridať</string>
     <string name="action_allow">Povoliť</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dovoli</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандардна тастатура</string>
     <string name="action_add">Додај</string>
     <string name="action_allow">Дозволи</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtangentbord</string>
     <string name="action_add">Lägg till</string>
     <string name="action_allow">Tillåt</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">நிலையான விசைப்பலகை</string>
     <string name="action_add">சேர்</string>
     <string name="action_allow">அனுமதி</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ప్రామాణిక కీబోర్డ్</string>
     <string name="action_add">జోడించు</string>
     <string name="action_allow">అనుమతించు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">แป้นพิมพ์มาตรฐาน</string>
     <string name="action_add">เพิ่ม</string>
     <string name="action_allow">อนุญาต</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standart klavye</string>
     <string name="action_add">Ekle</string>
     <string name="action_allow">İzin ver</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавіатура</string>
     <string name="action_add">Додати</string>
     <string name="action_allow">Дозволити</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">معیاری کی بورڈ</string>
     <string name="action_add">شامل کریں</string>
     <string name="action_allow">اجازت دیں</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Bàn phím tiêu chuẩn</string>
     <string name="action_add">Thêm</string>
     <string name="action_allow">Cho phép</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
+    <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
+    <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作業</string>
+    <string name="a11y_class_table_conflict_prefix">衝堂</string>
+    <string name="a11y_dropdown_action_hint">點擊兩下以選擇其他選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑動可調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/wear/src/main/res/values-ar/strings.xml
+++ b/wear/src/main/res/values-ar/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">لوحة مفاتيح قياسية</string>
     <string name="action_add">إضافة</string>
     <string name="action_allow">السماح</string>

--- a/wear/src/main/res/values-bg/strings.xml
+++ b/wear/src/main/res/values-bg/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавиатура</string>
     <string name="action_add">Добави</string>
     <string name="action_allow">Разреши</string>

--- a/wear/src/main/res/values-bn/strings.xml
+++ b/wear/src/main/res/values-bn/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">স্ট্যান্ডার্ড কীবোর্ড</string>
     <string name="action_add">যোগ করুন</string>
     <string name="action_allow">অনুমতি দিন</string>

--- a/wear/src/main/res/values-ca/strings.xml
+++ b/wear/src/main/res/values-ca/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclat estàndard</string>
     <string name="action_add">Afegeix</string>
     <string name="action_allow">Permet</string>

--- a/wear/src/main/res/values-cs/strings.xml
+++ b/wear/src/main/res/values-cs/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardní klávesnice</string>
     <string name="action_add">Přidat</string>
     <string name="action_allow">Povolit</string>

--- a/wear/src/main/res/values-da/strings.xml
+++ b/wear/src/main/res/values-da/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Tilføj</string>
     <string name="action_allow">Tillad</string>

--- a/wear/src/main/res/values-de/strings.xml
+++ b/wear/src/main/res/values-de/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Hinzufügen</string>
     <string name="action_allow">Erlauben</string>

--- a/wear/src/main/res/values-el/strings.xml
+++ b/wear/src/main/res/values-el/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Τυπικό πληκτρολόγιο</string>
     <string name="action_add">Προσθήκη</string>
     <string name="action_allow">Επιτρέπεται</string>

--- a/wear/src/main/res/values-en-rAU/strings.xml
+++ b/wear/src/main/res/values-en-rAU/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/wear/src/main/res/values-en-rCA/strings.xml
+++ b/wear/src/main/res/values-en-rCA/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/wear/src/main/res/values-en-rGB/strings.xml
+++ b/wear/src/main/res/values-en-rGB/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/wear/src/main/res/values-en-rIN/strings.xml
+++ b/wear/src/main/res/values-en-rIN/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>

--- a/wear/src/main/res/values-es-rMX/strings.xml
+++ b/wear/src/main/res/values-es-rMX/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>

--- a/wear/src/main/res/values-es/strings.xml
+++ b/wear/src/main/res/values-es/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>

--- a/wear/src/main/res/values-et/strings.xml
+++ b/wear/src/main/res/values-et/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardklaviatuur</string>
     <string name="action_add">Lisa</string>
     <string name="action_allow">Luba</string>

--- a/wear/src/main/res/values-fa/strings.xml
+++ b/wear/src/main/res/values-fa/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">صفحه‌کلید استاندارد</string>
     <string name="action_add">افزودن</string>
     <string name="action_allow">اجازه دادن</string>

--- a/wear/src/main/res/values-fi/strings.xml
+++ b/wear/src/main/res/values-fi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Vakionäppäimistö</string>
     <string name="action_add">Lisää</string>
     <string name="action_allow">Salli</string>

--- a/wear/src/main/res/values-fil/strings.xml
+++ b/wear/src/main/res/values-fil/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard na keyboard</string>
     <string name="action_add">Idagdag</string>
     <string name="action_allow">Payagan</string>

--- a/wear/src/main/res/values-fr-rCA/strings.xml
+++ b/wear/src/main/res/values-fr-rCA/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>

--- a/wear/src/main/res/values-fr/strings.xml
+++ b/wear/src/main/res/values-fr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>

--- a/wear/src/main/res/values-gu/strings.xml
+++ b/wear/src/main/res/values-gu/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">પ્રમાણભૂત કીબોર્ડ</string>
     <string name="action_add">ઉમેરો</string>
     <string name="action_allow">મંજૂરી આપો</string>

--- a/wear/src/main/res/values-hi/strings.xml
+++ b/wear/src/main/res/values-hi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोड़ें</string>
     <string name="action_allow">अनुमति दें</string>

--- a/wear/src/main/res/values-hr/strings.xml
+++ b/wear/src/main/res/values-hr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dopusti</string>

--- a/wear/src/main/res/values-hu/strings.xml
+++ b/wear/src/main/res/values-hu/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Normál billentyűzet</string>
     <string name="action_add">Hozzáadás</string>
     <string name="action_allow">Engedélyezés</string>

--- a/wear/src/main/res/values-in/strings.xml
+++ b/wear/src/main/res/values-in/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Keyboard standar</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Izinkan</string>

--- a/wear/src/main/res/values-is/strings.xml
+++ b/wear/src/main/res/values-is/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Staðlað lyklaborð</string>
     <string name="action_add">Bæta við</string>
     <string name="action_allow">Leyfa</string>

--- a/wear/src/main/res/values-it/strings.xml
+++ b/wear/src/main/res/values-it/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Tastiera standard</string>
     <string name="action_add">Aggiungi</string>
     <string name="action_allow">Consenti</string>

--- a/wear/src/main/res/values-iw/strings.xml
+++ b/wear/src/main/res/values-iw/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">מקלדת רגילה</string>
     <string name="action_add">הוסף</string>
     <string name="action_allow">אפשר</string>

--- a/wear/src/main/res/values-ja/strings.xml
+++ b/wear/src/main/res/values-ja/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">標準キーボード</string>
     <string name="action_add">追加</string>
     <string name="action_allow">許可</string>

--- a/wear/src/main/res/values-kk/strings.xml
+++ b/wear/src/main/res/values-kk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартты пернетақта</string>
     <string name="action_add">Қосу</string>
     <string name="action_allow">Рұқсат беру</string>

--- a/wear/src/main/res/values-kn/strings.xml
+++ b/wear/src/main/res/values-kn/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ಪ್ರಮಾಣಿತ ಕೀಬೋರ್ಡ್</string>
     <string name="action_add">ಸೇರಿಸಿ</string>
     <string name="action_allow">ಅನುಮತಿಸಿ</string>

--- a/wear/src/main/res/values-ko/strings.xml
+++ b/wear/src/main/res/values-ko/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">표준 키보드</string>
     <string name="action_add">추가</string>
     <string name="action_allow">허용</string>

--- a/wear/src/main/res/values-lt/strings.xml
+++ b/wear/src/main/res/values-lt/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standartinė klaviatūra</string>
     <string name="action_add">Pridėti</string>
     <string name="action_allow">Leisti</string>

--- a/wear/src/main/res/values-lv/strings.xml
+++ b/wear/src/main/res/values-lv/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standarta tastatūra</string>
     <string name="action_add">Pievienot</string>
     <string name="action_allow">Atļaut</string>

--- a/wear/src/main/res/values-ml/strings.xml
+++ b/wear/src/main/res/values-ml/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">സ്റ്റാൻഡേർഡ് കീബോർഡ്</string>
     <string name="action_add">ചേർക്കുക</string>
     <string name="action_allow">അനുവദിക്കുക</string>

--- a/wear/src/main/res/values-mr/strings.xml
+++ b/wear/src/main/res/values-mr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोडा</string>
     <string name="action_allow">परवानगी द्या</string>

--- a/wear/src/main/res/values-ms/strings.xml
+++ b/wear/src/main/res/values-ms/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Papan kekunci standard</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Benarkan</string>

--- a/wear/src/main/res/values-nb/strings.xml
+++ b/wear/src/main/res/values-nb/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>

--- a/wear/src/main/res/values-nl/strings.xml
+++ b/wear/src/main/res/values-nl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standaardtoetsenbord</string>
     <string name="action_add">Toevoegen</string>
     <string name="action_allow">Toestaan</string>

--- a/wear/src/main/res/values-no/strings.xml
+++ b/wear/src/main/res/values-no/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>

--- a/wear/src/main/res/values-pa/strings.xml
+++ b/wear/src/main/res/values-pa/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ਸਟੈਂਡਰਡ ਕੀਬੋਰਡ</string>
     <string name="action_add">ਜੋੜੋ</string>
     <string name="action_allow">ਆਗਿਆ ਦਿਓ</string>

--- a/wear/src/main/res/values-pl/strings.xml
+++ b/wear/src/main/res/values-pl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardowa klawiatura</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Zezwól</string>

--- a/wear/src/main/res/values-pt-rBR/strings.xml
+++ b/wear/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/wear/src/main/res/values-pt-rPT/strings.xml
+++ b/wear/src/main/res/values-pt-rPT/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/wear/src/main/res/values-pt/strings.xml
+++ b/wear/src/main/res/values-pt/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>

--- a/wear/src/main/res/values-ro/strings.xml
+++ b/wear/src/main/res/values-ro/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Tastatură standard</string>
     <string name="action_add">Adaugă</string>
     <string name="action_allow">Permite</string>

--- a/wear/src/main/res/values-ru/strings.xml
+++ b/wear/src/main/res/values-ru/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартная клавиатура</string>
     <string name="action_add">Добавить</string>
     <string name="action_allow">Разрешить</string>

--- a/wear/src/main/res/values-sk/strings.xml
+++ b/wear/src/main/res/values-sk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Štandardná klávesnica</string>
     <string name="action_add">Pridať</string>
     <string name="action_allow">Povoliť</string>

--- a/wear/src/main/res/values-sl/strings.xml
+++ b/wear/src/main/res/values-sl/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dovoli</string>

--- a/wear/src/main/res/values-sr/strings.xml
+++ b/wear/src/main/res/values-sr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандардна тастатура</string>
     <string name="action_add">Додај</string>
     <string name="action_allow">Дозволи</string>

--- a/wear/src/main/res/values-sv/strings.xml
+++ b/wear/src/main/res/values-sv/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standardtangentbord</string>
     <string name="action_add">Lägg till</string>
     <string name="action_allow">Tillåt</string>

--- a/wear/src/main/res/values-ta/strings.xml
+++ b/wear/src/main/res/values-ta/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">நிலையான விசைப்பலகை</string>
     <string name="action_add">சேர்</string>
     <string name="action_allow">அனுமதி</string>

--- a/wear/src/main/res/values-te/strings.xml
+++ b/wear/src/main/res/values-te/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">ప్రామాణిక కీబోర్డ్</string>
     <string name="action_add">జోడించు</string>
     <string name="action_allow">అనుమతించు</string>

--- a/wear/src/main/res/values-th/strings.xml
+++ b/wear/src/main/res/values-th/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">แป้นพิมพ์มาตรฐาน</string>
     <string name="action_add">เพิ่ม</string>
     <string name="action_allow">อนุญาต</string>

--- a/wear/src/main/res/values-tr/strings.xml
+++ b/wear/src/main/res/values-tr/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standart klavye</string>
     <string name="action_add">Ekle</string>
     <string name="action_allow">İzin ver</string>

--- a/wear/src/main/res/values-uk/strings.xml
+++ b/wear/src/main/res/values-uk/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавіатура</string>
     <string name="action_add">Додати</string>
     <string name="action_allow">Дозволити</string>

--- a/wear/src/main/res/values-ur/strings.xml
+++ b/wear/src/main/res/values-ur/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">معیاری کی بورڈ</string>
     <string name="action_add">شامل کریں</string>
     <string name="action_allow">اجازت دیں</string>

--- a/wear/src/main/res/values-vi/strings.xml
+++ b/wear/src/main/res/values-vi/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Bàn phím tiêu chuẩn</string>
     <string name="action_add">Thêm</string>
     <string name="action_allow">Cho phép</string>

--- a/wear/src/main/res/values-yue-rHK/strings.xml
+++ b/wear/src/main/res/values-yue-rHK/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/wear/src/main/res/values-zh-rCN/strings.xml
+++ b/wear/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
+    <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>

--- a/wear/src/main/res/values-zh-rHK/strings.xml
+++ b/wear/src/main/res/values-zh-rHK/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/wear/src/main/res/values-zh-rMO/strings.xml
+++ b/wear/src/main/res/values-zh-rMO/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
+    <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/wear/src/main/res/values-zh-rSG/strings.xml
+++ b/wear/src/main/res/values-zh-rSG/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
+    <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>

--- a/wear/src/main/res/values-zh-rTW/strings.xml
+++ b/wear/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">有作業</string>
+    <string name="a11y_class_table_conflict_prefix">衝堂</string>
+    <string name="a11y_dropdown_action_hint">點擊兩下以選擇其他選項</string>
+    <string name="a11y_time_slider_swipe_hint">左右滑動可調整時間</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
+    <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>


### PR DESCRIPTION
This pull request significantly improves accessibility across the app by adding and enhancing semantic properties and content descriptions for key UI components. These changes make the app more usable with screen readers and assistive technologies. Additionally, new localized accessibility strings are introduced for multiple languages.

**Accessibility improvements in UI components:**

* Added semantic roles, content descriptions, and state descriptions to interactive components such as filter buttons, dropdowns, and list rows in `AnnouncementsScreen.kt`, `ClassTableScreen.kt`, and `SettingsScreen.kt`, making them more accessible to screen readers. [[1]](diffhunk://#diff-0ce6b5757d0b0ef8714d8b57c8481aa9180c0488b82b869211c10141d38e0f74R37-R43) [[2]](diffhunk://#diff-0ce6b5757d0b0ef8714d8b57c8481aa9180c0488b82b869211c10141d38e0f74L102-R121) [[3]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R29-R33) [[4]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R631-R647) [[5]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R704-R715) [[6]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R724-R727) [[7]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R870-R898) [[8]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R941-R944) [[9]](diffhunk://#diff-098309e16cff11443bbd81765670f9129d04875ddf00d6c407be8b1a563ee21bR26-R28) [[10]](diffhunk://#diff-098309e16cff11443bbd81765670f9129d04875ddf00d6c407be8b1a563ee21bR606) [[11]](diffhunk://#diff-098309e16cff11443bbd81765670f9129d04875ddf00d6c407be8b1a563ee21bR627)
* Enhanced live region support and content descriptions for dynamic status indicators and error messages in `SyncIndicator.kt`, `TimeSliderSection.kt`, and `LoginSheet.kt`, ensuring timely announcements to users with assistive tech. [[1]](diffhunk://#diff-13a33e1e8193782a1085bc74224bce0eb49549bb140c2fc5f0cc6d6a914dac71R25-R28) [[2]](diffhunk://#diff-13a33e1e8193782a1085bc74224bce0eb49549bb140c2fc5f0cc6d6a914dac71L36-R54) [[3]](diffhunk://#diff-13a33e1e8193782a1085bc74224bce0eb49549bb140c2fc5f0cc6d6a914dac71L56-R74) [[4]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R59-R63) [[5]](diffhunk://#diff-5b80e14a07ffc336e406de3f2308510453794e667bf16abcb78e5fe316804343R524-R538) [[6]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeR49-R51) [[7]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeL197-R204)

**Localization updates for accessibility:**

* Added new accessibility-related strings (e.g., assignment indicators, conflict prefixes, dropdown hints, time slider hints) in multiple languages, expanding support for non-English users. [[1]](diffhunk://#diff-275e22e5424874865d61be0a790c48168da5998ec6dd530c83fb33005bfa4449R4-R7) [[2]](diffhunk://#diff-f721547734cc211b2b18c4089b562c1d0e22d110a36b0f14bc921dab7423a25eR4-R7) [[3]](diffhunk://#diff-434c17d85f690e65211e494964760d86872ab07645e23395e4c88932761281e0R4-R7) [[4]](diffhunk://#diff-386877786b288f19da18e47b00709101126367ea07cf11a91d40ce2cda12fdf6R4-R7) [[5]](diffhunk://#diff-bf5f30504e5874b66c42578605d994279957d435025c3271620cfc607b19e4d9R4-R7) [[6]](diffhunk://#diff-30975d4444f8f3d84321a5e74634cb322e885d6d495f770b5d40f50dc1cd17b6R4-R7)

These changes collectively ensure that interactive elements are properly labeled and described, and that dynamic content is appropriately announced, resulting in a more inclusive user experience.Addresses issue #37 by adding proper accessibility semantics to the highest-impact UI surfaces. Verified by static review only — manual TalkBack walkthrough still required.

Changes:
- TimeSliderSection: FluidTrack now exposes the track as a polite live region with the current time as stateDescription, plus a swipe-hint contentDescription so VoiceOver/TalkBack users know the gesture.
- ClassTableScreen: SoloCourseCell + ConflictCourseCell now merge their descendants and announce "course, classroom (, has assignment)". Conflict cells prepend a localized "Class conflict" prefix. Semester picker exposes Role.DropdownList with the current semester as state.
- AnnouncementsScreen: unread-only filter IconButton now reports as a Switch with toggleable state so TalkBack reads "switch, on/off".
- SettingsScreen: SettingsLinkRow / SettingsLinkRowWithValue merge descendants and expose Role.Button so the entire row is one focus.
- SyncIndicator: wraps in a polite live region with localized "loading" / "sync successful" status descriptions.
- LoginSheet: error row is now an assertive live region so TalkBack announces login failures immediately.

Localization: 4 new shared keys added to localization/source. The submodule sits on a local feature/android-talkback-a11y branch — push that branch and bump the submodule pin in a follow-up commit before opening a PR to main, otherwise CI's submodules-up-to-date check will fail. The generated strings.xml files for all locales are committed in this repo so the build itself stays green in the meantime.


Additional note: This pr is meant to improve talkback. But since I'm not using it and don't really know how to use (well, just a little). I'm not going to test it like people who need this function do.