### PR TITLE
Add password visibility toggle and improve accessibility

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/PasswordTrailingIcons.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/PasswordTrailingIcons.kt
@@ -1,0 +1,62 @@
+package org.ntust.app.tigerduck.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.res.stringResource
+import org.ntust.app.tigerduck.R
+
+/**
+ * Trailing icons cluster for a password `OutlinedTextField`: a clear button
+ * (only when the field has content) plus a visibility toggle that swaps the
+ * field's `visualTransformation` between `PasswordVisualTransformation` and
+ * `VisualTransformation.None`.
+ *
+ * The eye `IconButton` carries a state-aware `contentDescription` ("Show
+ * password" / "Hide password") so TalkBack announces what the toggle will do
+ * on the next tap.
+ */
+@Composable
+fun PasswordTrailingIcons(
+    password: String,
+    passwordVisible: Boolean,
+    onClear: () -> Unit,
+    onToggleVisibility: () -> Unit,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.End,
+    ) {
+        if (password.isNotEmpty()) {
+            IconButton(onClick = onClear) {
+                Icon(
+                    imageVector = Icons.Filled.Cancel,
+                    contentDescription = stringResource(R.string.action_clear_text),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+        IconButton(
+            onClick = onToggleVisibility,
+            enabled = password.isNotEmpty(),
+        ) {
+            Icon(
+                imageVector = if (passwordVisible) Icons.Filled.Visibility
+                else Icons.Filled.VisibilityOff,
+                contentDescription = stringResource(
+                    if (passwordVisible) R.string.password_hide
+                    else R.string.password_show
+                ),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
@@ -373,7 +373,7 @@ private fun LoginPromptCard(
                         PasswordTrailingIcons(
                             password = password,
                             passwordVisible = passwordVisible,
-                            onClear = { onPasswordChange("") },
+                            onClear = { onPasswordChange(""); passwordVisible = false },
                             onToggleVisibility = { passwordVisible = !passwordVisible },
                         )
                     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -43,6 +41,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -51,6 +50,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
 import org.ntust.app.tigerduck.ui.component.PageHeader
+import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 
 @Composable
@@ -329,6 +329,7 @@ private fun LoginPromptCard(
 ) {
     val focusManager = LocalFocusManager.current
     val passwordFocusRequester = remember { FocusRequester() }
+    var passwordVisible by remember { mutableStateOf(false) }
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -365,16 +366,16 @@ private fun LoginPromptCard(
                 onValueChange = onPasswordChange,
                 label = { Text(stringResource(R.string.library_login_password)) },
                 singleLine = true,
-                visualTransformation = PasswordVisualTransformation(),
-                trailingIcon = if (!isLoggingIn && password.isNotEmpty()) {
+                visualTransformation = if (passwordVisible) VisualTransformation.None
+                else PasswordVisualTransformation(),
+                trailingIcon = if (!isLoggingIn) {
                     {
-                        IconButton(onClick = { onPasswordChange("") }) {
-                            Icon(
-                                imageVector = Icons.Filled.Cancel,
-                                contentDescription = stringResource(R.string.action_clear_text),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
+                        PasswordTrailingIcons(
+                            password = password,
+                            passwordVisible = passwordVisible,
+                            onClear = { onPasswordChange("") },
+                            onToggleVisibility = { passwordVisible = !passwordVisible },
+                        )
                     }
                 } else null,
                 enabled = !isLoggingIn,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
-import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.Info
@@ -37,6 +36,8 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Watch
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -58,6 +59,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
@@ -66,6 +68,7 @@ import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
+import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
 import org.ntust.app.tigerduck.ui.screen.settings.NotificationSetupContent
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 
@@ -91,6 +94,7 @@ fun OnboardingScreen(
 
     var studentId by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
+    var passwordVisible by remember { mutableStateOf(false) }
     var privacyPolicyAccepted by remember { mutableStateOf(false) }
     var deleteAccountAccepted by remember { mutableStateOf(false) }
 
@@ -265,16 +269,16 @@ fun OnboardingScreen(
                             onValueChange = { password = it },
                             label = { Text(stringResource(R.string.login_password)) },
                             singleLine = true,
-                            visualTransformation = PasswordVisualTransformation(),
-                            trailingIcon = if (!isLoggingIn && password.isNotEmpty()) {
+                            visualTransformation = if (passwordVisible) VisualTransformation.None
+                            else PasswordVisualTransformation(),
+                            trailingIcon = if (!isLoggingIn) {
                                 {
-                                    IconButton(onClick = { password = "" }) {
-                                        Icon(
-                                            imageVector = Icons.Filled.Cancel,
-                                            contentDescription = stringResource(R.string.action_clear_text),
-                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                        )
-                                    }
+                                    PasswordTrailingIcons(
+                                        password = password,
+                                        passwordVisible = passwordVisible,
+                                        onClear = { password = "" },
+                                        onToggleVisibility = { passwordVisible = !passwordVisible },
+                                    )
                                 }
                             } else null,
                             enabled = !isLoggingIn,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -36,8 +36,6 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.PrivacyTip
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material.icons.filled.School
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material.icons.filled.Watch
 import androidx.compose.material3.*
 import androidx.compose.runtime.*

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -274,7 +274,7 @@ fun OnboardingScreen(
                                     PasswordTrailingIcons(
                                         password = password,
                                         passwordVisible = passwordVisible,
-                                        onClear = { password = "" },
+                                        onClear = { password = ""; passwordVisible = false },
                                         onToggleVisibility = { passwordVisible = !passwordVisible },
                                     )
                                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
@@ -164,7 +164,7 @@ fun LoginSheet(
                                 PasswordTrailingIcons(
                                     password = password,
                                     passwordVisible = passwordVisible,
-                                    onClear = { password = "" },
+                                    onClear = { password = ""; passwordVisible = false },
                                     onToggleVisibility = { passwordVisible = !passwordVisible },
                                 )
                             }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Keyboard
@@ -24,7 +23,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
@@ -54,11 +52,13 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
+import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
 
 /**
  * Login prompt rendered as a custom Dialog wrapping a Material 3 Surface so the
@@ -82,6 +82,10 @@ fun LoginSheet(
 ) {
     var username by rememberSaveable(initialUsername) { mutableStateOf(initialUsername) }
     var password by rememberSaveable { mutableStateOf("") }
+    // Visibility toggle is intentionally NOT persisted across config changes —
+    // a rotation should snap the password back to hidden so a shoulder-surf
+    // window doesn't survive a screen flip.
+    var passwordVisible by remember { mutableStateOf(false) }
     // Hoisted out of `OutlinedAccountIdField` so the toggle UI can sit
     // inline in the action row instead of as a floating popup chip — the
     // popup approach got fiddly inside Compose `Dialog` (IME insets,
@@ -153,16 +157,16 @@ fun LoginSheet(
                         onValueChange = { password = it },
                         label = { Text(passwordPlaceholder) },
                         singleLine = true,
-                        visualTransformation = PasswordVisualTransformation(),
-                        trailingIcon = if (!isLoggingIn && password.isNotEmpty()) {
+                        visualTransformation = if (passwordVisible) VisualTransformation.None
+                        else PasswordVisualTransformation(),
+                        trailingIcon = if (!isLoggingIn) {
                             {
-                                IconButton(onClick = { password = "" }) {
-                                    Icon(
-                                        imageVector = Icons.Filled.Cancel,
-                                        contentDescription = stringResource(R.string.action_clear_text),
-                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    )
-                                }
+                                PasswordTrailingIcons(
+                                    password = password,
+                                    passwordVisible = passwordVisible,
+                                    onClear = { password = "" },
+                                    onToggleVisibility = { passwordVisible = !passwordVisible },
+                                )
                             }
                         } else null,
                         modifier = Modifier

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">مساعدك في حرم NTUST</string>
     <string name="onboarding_welcome_title">مرحبًا بك في TigerDuck</string>
     <string name="onboarding_welcome_website_label">الموقع الرسمي لـ TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">في إعدادات البطارية / الخلفية بالنظام، اضبط TigerDuck على غير مقيد (أو لا تقيد النشاط في الخلفية) لتقليل تأخر التذكيرات.</string>
     <string name="permission_battery_optimization_name">تقييد النشاط في الخلفية</string>
     <string name="permission_exact_alarm_description">اسمح للتطبيق بإرسال تذكيرات الواجبات والمحاضرات في أوقات دقيقة. عند تعطيله قد تتأخر التذكيرات عدة دقائق.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Вашият асистент за кампуса на NTUST</string>
     <string name="onboarding_welcome_title">Добре дошли в TigerDuck</string>
     <string name="onboarding_welcome_website_label">Официален сайт на TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">В системните настройки за батерия/фонова активност задайте TigerDuck като неограничен (или не ограничавайте фоновата активност), за да намалите закъснението на напомнянията.</string>
     <string name="permission_battery_optimization_name">Ограничение на фонова активност</string>
     <string name="permission_exact_alarm_description">Разрешете на приложението да изпраща напомняния за задания и часове в точно определено време. Ако е деактивирано, напомнянията може да закъснеят с няколко минути.</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">আপনার NTUST ক্যাম্পাস সহকারী</string>
     <string name="onboarding_welcome_title">TigerDuck-এ স্বাগতম</string>
     <string name="onboarding_welcome_website_label">TigerDuck অফিসিয়াল ওয়েবসাইট</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">সিস্টেমের ব্যাটারি/ব্যাকগ্রাউন্ড সেটিংসে TigerDuck-কে অসীমাবদ্ধ রাখুন (বা ব্যাকগ্রাউন্ড কার্যকলাপ সীমাবদ্ধ করবেন না) যাতে স্মরণিকার বিলম্ব কমে।</string>
     <string name="permission_battery_optimization_name">ব্যাকগ্রাউন্ড কার্যকলাপ সীমাবদ্ধতা</string>
     <string name="permission_exact_alarm_description">অ্যাপকে নির্দিষ্ট সময়ে অ্যাসাইনমেন্ট ও ক্লাসের স্মরণিকা পাঠানোর অনুমতি দিন। বন্ধ করলে স্মরণিকা কয়েক মিনিট বিলম্বিত হতে পারে।</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">El vostre assistent del campus de NTUST</string>
     <string name="onboarding_welcome_title">Benvingut a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Lloc web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">A la configuració de bateria/segon pla del sistema, configureu TigerDuck com a sense restriccions (o no restringiu l\'activitat en segon pla) per reduir els retards dels recordatoris.</string>
     <string name="permission_battery_optimization_name">Restricció d\'activitat en segon pla</string>
     <string name="permission_exact_alarm_description">Permet que l\'aplicació enviï recordatoris de tasques i classes en moments exactes. Si està desactivat, els recordatoris poden arribar amb minuts de retard.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Váš pomocník pro kampus NTUST</string>
     <string name="onboarding_welcome_title">Vítejte v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficiální web TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V systémovém nastavení baterie / aktivity na pozadí nastavte TigerDuck na neomezený režim (nebo neomezujte aktivitu na pozadí), abyste snížili zpoždění upozornění.</string>
     <string name="permission_battery_optimization_name">Omezení aktivity na pozadí</string>
     <string name="permission_exact_alarm_description">Povolte aplikaci odesílat upozornění na úkoly a hodiny v přesný čas. Pokud je vypnuto, mohou být upozornění zpožděna o několik minut.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-campusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks officielle hjemmeside</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/baggrundsindstillinger skal du indstille TigerDuck til ubegrænset (eller undlade at begrænse baggrundsaktivitet) for at reducere forsinkelse af påmindelser.</string>
     <string name="permission_battery_optimization_name">Begrænsning af baggrundsaktivitet</string>
     <string name="permission_exact_alarm_description">Tillad appen at sende påmindelser om opgaver og undervisning på præcise tidspunkter. Hvis deaktiveret, kan påmindelser blive forsinket med flere minutter.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ihr Campus-Assistent für die NTUST</string>
     <string name="onboarding_welcome_title">Willkommen bei TigerDuck</string>
     <string name="onboarding_welcome_website_label">Offizielle Website von TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Setzen Sie TigerDuck in den Akku-/Hintergrundeinstellungen des Systems auf uneingeschränkt (oder beschränken Sie die Hintergrundaktivität nicht), um Verzögerungen bei Erinnerungen zu reduzieren.</string>
     <string name="permission_battery_optimization_name">Einschränkung der Hintergrundaktivität</string>
     <string name="permission_exact_alarm_description">Erlauben Sie der App, Aufgaben- und Unterrichtserinnerungen zur exakten Zeit zu senden. Wenn deaktiviert, können sich Erinnerungen um mehrere Minuten verzögern.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ο βοηθός σας στην πανεπιστημιούπολη NTUST</string>
     <string name="onboarding_welcome_title">Καλώς ήρθατε στο TigerDuck</string>
     <string name="onboarding_welcome_website_label">Επίσημος ιστότοπος TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Στις ρυθμίσεις μπαταρίας/παρασκηνίου του συστήματος, ορίστε το TigerDuck ως χωρίς περιορισμούς (ή μην περιορίζετε τη δραστηριότητα παρασκηνίου) για να μειώσετε καθυστερήσεις υπενθυμίσεων.</string>
     <string name="permission_battery_optimization_name">Περιορισμός παρασκηνιακής δραστηριότητας</string>
     <string name="permission_exact_alarm_description">Επιτρέψτε στην εφαρμογή να αποστέλλει υπενθυμίσεις εργασιών και μαθημάτων σε ακριβείς χρόνους. Εάν απενεργοποιηθεί, οι υπενθυμίσεις μπορεί να καθυστερήσουν αρκετά λεπτά.</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Tu asistente del campus de NTUST</string>
     <string name="onboarding_welcome_title">Bienvenido a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sitio web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">En la configuración de batería/segundo plano del sistema, configura TigerDuck como sin restricciones (o no restrinjas la actividad en segundo plano) para reducir los retrasos de los recordatorios.</string>
     <string name="permission_battery_optimization_name">Restricción de actividad en segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que la app envíe recordatorios de tareas y de clases en horarios exactos. Si está deshabilitado, los recordatorios pueden retrasarse varios minutos.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Tu asistente del campus de NTUST</string>
     <string name="onboarding_welcome_title">Bienvenido a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sitio web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">En la configuración de batería/segundo plano del sistema, configura TigerDuck como sin restricciones (o no restrinjas la actividad en segundo plano) para reducir los retrasos de los recordatorios.</string>
     <string name="permission_battery_optimization_name">Restricción de actividad en segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que la app envíe recordatorios de tareas y de clases en horarios exactos. Si está deshabilitado, los recordatorios pueden retrasarse varios minutos.</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Teie NTUST-i ülikoolilinnaku assistent</string>
     <string name="onboarding_welcome_title">Tere tulemast TigerDucki</string>
     <string name="onboarding_welcome_website_label">TigerDucki ametlik veebisait</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Seadke TigerDuck süsteemi aku/taustatöö seadetes piiramatuks (või ärge piirake taustatöid), et vähendada meeldetuletuste hilinemist.</string>
     <string name="permission_battery_optimization_name">Taustatöö piirang</string>
     <string name="permission_exact_alarm_description">Lubage rakendusel saata ülesande ja tunni meeldetuletusi täpselt õigel ajal. Kui see on keelatud, võivad meeldetuletused hilineda mõne minuti võrra.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">دستیار پردیس NTUST شما</string>
     <string name="onboarding_welcome_title">به TigerDuck خوش آمدید</string>
     <string name="onboarding_welcome_website_label">وب‌سایت رسمی TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">در تنظیمات باتری/پس‌زمینه سیستم، TigerDuck را روی «بدون محدودیت» قرار دهید (یا فعالیت پس‌زمینه را محدود نکنید) تا تأخیر یادآورها کمتر شود.</string>
     <string name="permission_battery_optimization_name">محدودیت فعالیت پس‌زمینه</string>
     <string name="permission_exact_alarm_description">به برنامه اجازه بدهید یادآورها را دقیقاً در زمان مقرر ارسال کند. اگر غیرفعال باشد، یادآورها ممکن است چند دقیقه دیرتر برسند.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">NTUST-kampusavustajasi</string>
     <string name="onboarding_welcome_title">Tervetuloa TigerDuck-sovellukseen</string>
     <string name="onboarding_welcome_website_label">TigerDuckin virallinen sivusto</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Aseta TigerDuck järjestelmän akku-/taustarajoitusasetuksissa rajoittamattomaksi (tai älä rajoita taustatoimintaa) muistutusviiveiden vähentämiseksi.</string>
     <string name="permission_battery_optimization_name">Taustatoiminnan rajoitus</string>
     <string name="permission_exact_alarm_description">Salli sovelluksen lähettää tehtävä- ja tuntimuistutukset tarkasti. Jos poistettu käytöstä, muistutukset voivat viivästyä useita minuutteja.</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ang iyong NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Maligayang pagdating sa TigerDuck</string>
     <string name="onboarding_welcome_website_label">Opisyal na website ng TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sa mga setting ng baterya/background ng sistema, itakda ang TigerDuck bilang walang paghihigpit (o huwag limitahan ang background activity) para mabawasan ang pagkaantala ng mga paalala.</string>
     <string name="permission_battery_optimization_name">Paghihigpit sa background activity</string>
     <string name="permission_exact_alarm_description">Payagan ang app na magpadala ng mga paalala sa takdang-aralin at klase sa tumpak na oras. Kung hindi pinagana, maaaring maantala ng ilang minuto ang mga paalala.</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Votre assistant de campus à NTUST</string>
     <string name="onboarding_welcome_title">Bienvenue sur TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site officiel de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dans les paramètres de batterie/arrière-plan du système, définissez TigerDuck sur sans restriction (ou ne limitez pas l\'activité en arrière-plan) pour réduire les retards de rappel.</string>
     <string name="permission_battery_optimization_name">Restriction d\'activité en arrière-plan</string>
     <string name="permission_exact_alarm_description">Autoriser l\'application à envoyer les rappels de devoirs et de cours à l\'heure exacte. Si désactivée, les rappels peuvent être retardés de plusieurs minutes.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Votre assistant de campus à NTUST</string>
     <string name="onboarding_welcome_title">Bienvenue sur TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site officiel de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dans les paramètres de batterie/arrière-plan du système, définissez TigerDuck sur sans restriction (ou ne limitez pas l\'activité en arrière-plan) pour réduire les retards de rappel.</string>
     <string name="permission_battery_optimization_name">Restriction d\'activité en arrière-plan</string>
     <string name="permission_exact_alarm_description">Autoriser l\'application à envoyer les rappels de devoirs et de cours à l\'heure exacte. Si désactivée, les rappels peuvent être retardés de plusieurs minutes.</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">તમારો NTUST કૅમ્પસ સહાયક</string>
     <string name="onboarding_welcome_title">TigerDuck માં સ્વાગત છે</string>
     <string name="onboarding_welcome_website_label">TigerDuck ઓફિશિયલ વેબસાઇટ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">સિસ્ટમ બૅટરી/બૅકગ્રાઉન્ડ સેટિંગ્સમાં TigerDuck ને અપ્રતિબંધિત (અથવા બૅકગ્રાઉન્ડ પ્રવૃત્તિ ન રોકો) પર સેટ કરો, જેથી રિમાઇન્ડર વિલંબ ઘટે.</string>
     <string name="permission_battery_optimization_name">બૅકગ્રાઉન્ડ એક્ટિવિટી પ્રતિબંધ</string>
     <string name="permission_exact_alarm_description">App ને ચોક્કસ સમયે અસાઇનમેન્ટ અને ક્લાસ રિમાઇન્ડર મોકલવાની મંજૂરી આપો. બંધ કરવામાં આવે, તો રિમાઇન્ડર કેટલીક મિનિટ મોડા આવી શકે.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">आपका NTUST कैंपस सहायक</string>
     <string name="onboarding_welcome_title">TigerDuck में आपका स्वागत है</string>
     <string name="onboarding_welcome_website_label">TigerDuck आधिकारिक वेबसाइट</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">सिस्टम बैटरी/बैकग्राउंड सेटिंग में TigerDuck को अप्रतिबंधित (या बैकग्राउंड गतिविधि को प्रतिबंधित न करें) पर सेट करें ताकि अनुस्मारक में देरी कम हो।</string>
     <string name="permission_battery_optimization_name">बैकग्राउंड गतिविधि प्रतिबंध</string>
     <string name="permission_exact_alarm_description">ऐप को सटीक समय पर असाइनमेंट और कक्षा अनुस्मारक भेजने की अनुमति दें। अक्षम करने पर अनुस्मारक कई मिनट देरी से आ सकते हैं।</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Vaš NTUST campus asistent</string>
     <string name="onboarding_welcome_title">Dobrodošli u TigerDuck</string>
     <string name="onboarding_welcome_website_label">Službena web-stranica TigerDucka</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">U postavkama baterije/pozadinske aktivnosti, postavite TigerDuck na neograničeno (ili ne ograničavajte pozadinsku aktivnost) kako biste smanjili kašnjenje podsjetnika.</string>
     <string name="permission_battery_optimization_name">Ograničenje pozadinske aktivnosti</string>
     <string name="permission_exact_alarm_description">Dopustite aplikaciji slanje podsjetnika za zadatke i predavanja u točno određeno vrijeme. Ako je onemogućeno, podsjetnici mogu kasniti nekoliko minuta.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Az Ön NTUST kampusz asszisztense</string>
     <string name="onboarding_welcome_title">Üdvözöljük a TigerDuck alkalmazásban</string>
     <string name="onboarding_welcome_website_label">TigerDuck hivatalos weboldal</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">A rendszer akkumulátor/háttér beállításaiban állítsa a TigerDuck alkalmazást korlátozás nélkülire (vagy ne korlátozza a háttértevékenységet) az emlékeztetők késésének csökkentése érdekében.</string>
     <string name="permission_battery_optimization_name">Háttértevékenység korlátozása</string>
     <string name="permission_exact_alarm_description">Engedélyezze az alkalmazásnak, hogy pontosan időzített házi feladat és óra emlékeztetőket küldjön. Ha letiltja, az emlékeztetők néhány percet késhetnek.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Asisten kampus NTUST kamu</string>
     <string name="onboarding_welcome_title">Selamat datang di TigerDuck</string>
     <string name="onboarding_welcome_website_label">Situs resmi TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Pada pengaturan baterai/latar belakang sistem, atur TigerDuck menjadi tidak dibatasi (atau jangan batasi aktivitas latar belakang) untuk mengurangi keterlambatan pengingat.</string>
     <string name="permission_battery_optimization_name">Pembatasan aktivitas latar belakang</string>
     <string name="permission_exact_alarm_description">Izinkan aplikasi mengirim pengingat tugas dan kelas pada waktu yang tepat. Jika dinonaktifkan, pengingat dapat tertunda beberapa menit.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Háskólaassistentinn þinn hjá NTUST</string>
     <string name="onboarding_welcome_title">Velkomin í TigerDuck</string>
     <string name="onboarding_welcome_website_label">Opinber vefsíða TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Í rafhlöðu-/bakgrunnsstillingum kerfisins skaltu stilla TigerDuck á ótakmarkað (eða ekki takmarka bakgrunnsstarfsemi) til að draga úr seinkun á áminningum.</string>
     <string name="permission_battery_optimization_name">Takmörkun bakgrunnsstarfsemi</string>
     <string name="permission_exact_alarm_description">Leyfðu forritinu að senda verkefna- og tímaáminningar á nákvæmum tíma. Ef slökkt er á þessu gætu áminningar seinkað um nokkrar mínútur.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Il tuo assistente per il campus NTUST</string>
     <string name="onboarding_welcome_title">Benvenuto su TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sito ufficiale di TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nelle impostazioni di sistema della batteria/background, imposta TigerDuck come senza limitazioni (oppure non limitare l\'attività in background) per ridurre i ritardi dei promemoria.</string>
     <string name="permission_battery_optimization_name">Limitazione attività in background</string>
     <string name="permission_exact_alarm_description">Consenti all\'app di inviare promemoria di compiti e lezioni con orari precisi. Se disattivata, i promemoria potrebbero essere ritardati di alcuni minuti.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">העוזר שלך לקמפוס NTUST</string>
     <string name="onboarding_welcome_title">ברוך הבא ל-TigerDuck</string>
     <string name="onboarding_welcome_website_label">האתר הרשמי של TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">בהגדרות הסוללה/רקע של המערכת, הגדר את TigerDuck כלא מוגבל (או אל תגביל פעילות ברקע) כדי להפחית עיכובים בתזכורות.</string>
     <string name="permission_battery_optimization_name">הגבלת פעילות ברקע</string>
     <string name="permission_exact_alarm_description">אפשר לאפליקציה לשלוח תזכורות למטלות ושיעורים בזמנים מדויקים. אם מושבת, התזכורות עלולות להתעכב בכמה דקות.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">あなたの NTUST キャンパスアシスタント</string>
     <string name="onboarding_welcome_title">TigerDuck へようこそ</string>
     <string name="onboarding_welcome_website_label">TigerDuck 公式サイト</string>
+    <string name="password_hide">パスワードを非表示</string>
+    <string name="password_show">パスワードを表示</string>
     <string name="permission_battery_optimization_description">システムのバッテリー/バックグラウンド設定で、TigerDuck を制限なし（またはバックグラウンド動作を制限しない）に設定すると、リマインダーの遅延を減らせます。</string>
     <string name="permission_battery_optimization_name">バックグラウンド動作の制限</string>
     <string name="permission_exact_alarm_description">アプリが課題や授業のリマインダーを正確な時刻に送信できるようにします。無効にするとリマインダーが数分から十数分遅れる場合があります。</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Сіздің NTUST кампус көмекшіңіз</string>
     <string name="onboarding_welcome_title">TigerDuck-қа қош келдіңіз</string>
     <string name="onboarding_welcome_website_label">TigerDuck-тің ресми сайты</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Жүйенің батарея/фон параметрлерінде TigerDuck-ты шектеусіз етіп орнатыңыз (немесе фондық белсенділікті шектемеңіз), осылай еске салулар кешікпейді.</string>
     <string name="permission_battery_optimization_name">Фондық белсенділікті шектеу</string>
     <string name="permission_exact_alarm_description">Қолданбаға тапсырма мен сабақ еске салуларын дәл уақытында жіберуге рұқсат беріңіз. Өшірілген жағдайда еске салулар бірнеше минутқа кешігуі мүмкін.</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ನಿಮ್ಮ NTUST ಕ್ಯಾಂಪಸ್ ಸಹಾಯಕ</string>
     <string name="onboarding_welcome_title">TigerDuck ಗೆ ಸ್ವಾಗತ</string>
     <string name="onboarding_welcome_website_label">TigerDuck ಅಧಿಕೃತ ವೆಬ್‌ಸೈಟ್</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ಜ್ಞಾಪನೆ ವಿಳಂಬ ತಗ್ಗಿಸಲು, ಸಿಸ್ಟಂ ಬ್ಯಾಟರಿ/ಹಿನ್ನೆಲೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ TigerDuck ಅನ್ನು ಅನಿರ್ಬಂಧಿತ ಎಂದು ಹೊಂದಿಸಿ (ಅಥವಾ ಹಿನ್ನೆಲೆ ಚಟುವಟಿಕೆ ನಿರ್ಬಂಧಿಸಬೇಡಿ).</string>
     <string name="permission_battery_optimization_name">ಹಿನ್ನೆಲೆ ಚಟುವಟಿಕೆ ನಿರ್ಬಂಧ</string>
     <string name="permission_exact_alarm_description">ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ನಿಖರ ಸಮಯದಲ್ಲಿ ಕಾರ್ಯ ಮತ್ತು ತರಗತಿ ಜ್ಞಾಪನೆಗಳನ್ನು ಕಳುಹಿಸಲು ಅನುಮತಿ ನೀಡಿ. ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದರೆ, ಜ್ಞಾಪನೆಗಳು ಹಲವು ನಿಮಿಷ ತಡವಾಗಬಹುದು.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">당신의 NTUST 캠퍼스 도우미</string>
     <string name="onboarding_welcome_title">TigerDuck에 오신 것을 환영합니다</string>
     <string name="onboarding_welcome_website_label">TigerDuck 공식 웹사이트</string>
+    <string name="password_hide">비밀번호 숨기기</string>
+    <string name="password_show">비밀번호 표시</string>
     <string name="permission_battery_optimization_description">시스템 배터리/백그라운드 설정에서 TigerDuck을 제한 없음(또는 백그라운드 활동을 제한하지 않음)으로 설정하면 알림 지연을 줄일 수 있습니다.</string>
     <string name="permission_battery_optimization_name">백그라운드 활동 제한</string>
     <string name="permission_exact_alarm_description">앱이 정확한 시간에 과제 및 수업 알림을 보낼 수 있도록 허용해 주세요. 비활성화하면 알림이 몇 분 지연될 수 있습니다.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jūsų NTUST universiteto asistentas</string>
     <string name="onboarding_welcome_title">Sveiki atvykę į TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficialus TigerDuck tinklalapis</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistemos akumuliatoriaus / fono nustatymuose nustatykite TigerDuck kaip neapribotą (arba neribokite fono veiklos), kad sumažintumėte priminimų vėlavimą.</string>
     <string name="permission_battery_optimization_name">Fono veiklos apribojimas</string>
     <string name="permission_exact_alarm_description">Leiskite programai tiksliai laiku siųsti užduočių ir paskaitų priminimus. Jei išjungta, priminimai gali vėluoti kelias minutes.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jūsu NTUST universitātes palīgs</string>
     <string name="onboarding_welcome_title">Laipni lūdzam TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck oficiālā vietne</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistēmas akumulatora/fona iestatījumos iestatiet TigerDuck kā neierobežotu (vai neatļaujiet fona darbības ierobežošanu), lai samazinātu atgādinājumu kavēšanos.</string>
     <string name="permission_battery_optimization_name">Fona darbības ierobežojums</string>
     <string name="permission_exact_alarm_description">Atļaujiet lietotnei sūtīt uzdevumu un nodarbību atgādinājumus precīzos laikos. Ja atspējots, atgādinājumi var aizkavēties par dažām minūtēm.</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">നിങ്ങളുടെ NTUST ക്യാമ്പസ് സഹായി</string>
     <string name="onboarding_welcome_title">TigerDuck-ലേക്ക് സ്വാഗതം</string>
     <string name="onboarding_welcome_website_label">TigerDuck ഔദ്യോഗിക വെബ്സൈറ്റ്</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ഓർമ്മപ്പെടുത്തൽ കാലതാമസം കുറയ്ക്കാൻ, സിസ്റ്റം ബാറ്ററി/പശ്ചാത്തല ക്രമീകരണങ്ങളിൽ TigerDuck-നെ അൺറെസ്ട്രിക്റ്റഡ് ആക്കുക (അല്ലെങ്കിൽ പശ്ചാത്തല പ്രവർത്തനം നിയന്ത്രിക്കരുത്).</string>
     <string name="permission_battery_optimization_name">പശ്ചാത്തല പ്രവർത്തന നിയന്ത്രണം</string>
     <string name="permission_exact_alarm_description">കൃത്യ സമയത്ത് അസൈൻമെന്റ്, ക്ലാസ് ഓർമ്മപ്പെടുത്തലുകൾ അയയ്ക്കാൻ ആപ്പിന് അനുവദിക്കുക. അക്ഷമം ചെയ്താൽ, ഓർമ്മപ്പെടുത്തലുകൾ കുറച്ച് മിനിറ്റ് വൈകിയേക്കാം.</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">तुमचा NTUST कॅम्पस सहाय्यक</string>
     <string name="onboarding_welcome_title">TigerDuck मध्ये आपले स्वागत आहे</string>
     <string name="onboarding_welcome_website_label">TigerDuck अधिकृत वेबसाइट</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">सिस्टम बॅटरी/पार्श्वभूमी सेटिंग्जमध्ये TigerDuck ला अप्रतिबंधित (किंवा पार्श्वभूमी क्रियाकलाप प्रतिबंधित नाही) असे सेट करा, जेणेकरून स्मरणपत्रे वेळेवर येतील.</string>
     <string name="permission_battery_optimization_name">पार्श्वभूमी क्रियाकलाप निर्बंध</string>
     <string name="permission_exact_alarm_description">ॲपला असाइनमेंट आणि वर्गाची स्मरणपत्रे अचूक वेळी पाठवण्याची परवानगी द्या. बंद केल्यास, स्मरणपत्रे काही मिनिटे उशिरा येऊ शकतात.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Pembantu kampus NTUST anda</string>
     <string name="onboarding_welcome_title">Selamat datang ke TigerDuck</string>
     <string name="onboarding_welcome_website_label">Laman web rasmi TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dalam tetapan bateri/latar belakang sistem, tetapkan TigerDuck kepada tidak terhad (atau jangan hadkan aktiviti latar belakang) untuk mengurangkan kelewatan peringatan.</string>
     <string name="permission_battery_optimization_name">Sekatan aktiviti latar belakang</string>
     <string name="permission_exact_alarm_description">Benarkan aplikasi menghantar peringatan tugasan dan kelas pada masa yang tepat. Jika dilumpuhkan, peringatan mungkin tertunda beberapa minit.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks offisielle nettsted</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/bakgrunnsinnstillinger setter du TigerDuck til ubegrenset (eller ikke begrens bakgrunnsaktivitet) for å redusere forsinkelser i påminnelser.</string>
     <string name="permission_battery_optimization_name">Bakgrunnsaktivitetsbegrensning</string>
     <string name="permission_exact_alarm_description">La appen sende oppgave- og timepåminnelser til nøyaktig tid. Hvis deaktivert, kan påminnelser bli forsinket med flere minutter.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jouw NTUST campusassistent</string>
     <string name="onboarding_welcome_title">Welkom bij TigerDuck</string>
     <string name="onboarding_welcome_website_label">Officiële TigerDuck-website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Stel TigerDuck in de batterij-/achtergrondinstellingen van het systeem in op onbeperkt (of beperk de achtergrondactiviteit niet) om vertragingen bij herinneringen te verminderen.</string>
     <string name="permission_battery_optimization_name">Beperking achtergrondactiviteit</string>
     <string name="permission_exact_alarm_description">Sta de app toe om opdracht- en lesherinneringen op exacte tijden te sturen. Als dit is uitgeschakeld, kunnen herinneringen enkele minuten vertraging hebben.</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks offisielle nettsted</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/bakgrunnsinnstillinger setter du TigerDuck til ubegrenset (eller ikke begrens bakgrunnsaktivitet) for å redusere forsinkelser i påminnelser.</string>
     <string name="permission_battery_optimization_name">Bakgrunnsaktivitetsbegrensning</string>
     <string name="permission_exact_alarm_description">La appen sende oppgave- og timepåminnelser til nøyaktig tid. Hvis deaktivert, kan påminnelser bli forsinket med flere minutter.</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ਤੁਹਾਡਾ NTUST ਕੈਂਪਸ ਸਹਾਇਕ</string>
     <string name="onboarding_welcome_title">TigerDuck ਵਿੱਚ ਸੁਆਗਤ ਹੈ</string>
     <string name="onboarding_welcome_website_label">TigerDuck ਅਧਿਕਾਰਤ ਵੈੱਬਸਾਈਟ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ਸਿਸਟਮ ਬੈਟਰੀ/ਬੈਕਗ੍ਰਾਊਂਡ ਸੈਟਿੰਗਾਂ ਵਿੱਚ TigerDuck ਨੂੰ ਅਣਸੀਮਿਤ ਕਰੋ (ਜਾਂ ਬੈਕਗ੍ਰਾਊਂਡ ਗਤੀਵਿਧੀ ਨਾ ਰੋਕੋ) ਤਾਂ ਜੋ ਰੀਮਾਈਂਡਰ ਵਿੱਚ ਦੇਰੀ ਘੱਟ ਹੋਵੇ।</string>
     <string name="permission_battery_optimization_name">ਬੈਕਗ੍ਰਾਊਂਡ ਗਤੀਵਿਧੀ ਪਾਬੰਦੀ</string>
     <string name="permission_exact_alarm_description">ਐਪ ਨੂੰ ਸਹੀ ਸਮੇਂ \'ਤੇ ਅਸਾਈਨਮੈਂਟ ਅਤੇ ਕਲਾਸ ਰੀਮਾਈਂਡਰ ਭੇਜਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ। ਅਯੋਗ ਹੋਣ \'ਤੇ ਰੀਮਾਈਂਡਰ ਕੁਝ ਮਿੰਟ ਦੇਰ ਨਾਲ ਆ ਸਕਦੇ ਹਨ।</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Państwa asystent kampusu NTUST</string>
     <string name="onboarding_welcome_title">Witamy w TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficjalna strona TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">W systemowych ustawieniach baterii/aktywności w tle ustawić TigerDuck jako bez ograniczeń (lub nie ograniczać aktywności w tle), aby zmniejszyć opóźnienia przypomnień.</string>
     <string name="permission_battery_optimization_name">Ograniczenie aktywności w tle</string>
     <string name="permission_exact_alarm_description">Pozwolić aplikacji wysyłać przypomnienia o zadaniach i zajęciach o dokładnych porach. Po wyłączeniu przypomnienia mogą być opóźnione o kilka minut.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Seu assistente do campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas configurações de bateria/segundo plano do sistema, defina o TigerDuck como sem restrições (ou não restrinja a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permita que o app envie lembretes de atividades e aulas em horários exatos. Se desativado, os lembretes podem atrasar alguns minutos.</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">O teu assistente de campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas definições do sistema de bateria/segundo plano, define o TigerDuck como sem restrições (ou não restrinjas a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que a aplicação envie lembretes de trabalhos e aulas a horas exatas. Se estiver desativado, os lembretes podem atrasar-se vários minutos.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">O teu assistente de campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas definições do sistema de bateria/segundo plano, define o TigerDuck como sem restrições (ou não restrinjas a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que a aplicação envie lembretes de trabalhos e aulas a horas exatas. Se estiver desativado, os lembretes podem atrasar-se vários minutos.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Asistentul tău de campus NTUST</string>
     <string name="onboarding_welcome_title">Bun venit la TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site-ul oficial TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">În setările bateriei/fundalului sistemului, setează TigerDuck ca nerestricționat (sau nu restricționa activitatea în fundal) pentru a reduce întârzierile reminderelor.</string>
     <string name="permission_battery_optimization_name">Restricție activitate în fundal</string>
     <string name="permission_exact_alarm_description">Permite aplicației să trimită remindere pentru teme și cursuri la ore exacte. Dacă este dezactivat, reminderele pot întârzia câteva minute.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш кампусный помощник NTUST</string>
     <string name="onboarding_welcome_title">Добро пожаловать в TigerDuck</string>
     <string name="onboarding_welcome_website_label">Официальный сайт TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">В системных настройках батареи/фоновой активности установите для TigerDuck режим без ограничений (или не ограничивайте фоновую активность), чтобы уменьшить задержки напоминаний.</string>
     <string name="permission_battery_optimization_name">Ограничение фоновой активности</string>
     <string name="permission_exact_alarm_description">Разрешите приложению отправлять напоминания о заданиях и занятиях точно в назначенное время. Если отключено, напоминания могут запаздывать на несколько минут.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Váš asistent kampusu NTUST</string>
     <string name="onboarding_welcome_title">Vitajte v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficiálna stránka TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V systémových nastaveniach batérie/aktivít na pozadí nastavte TigerDuck ako neobmedzený (alebo neobmedzujte aktivity na pozadí), aby sa znížilo meškanie pripomienok.</string>
     <string name="permission_battery_optimization_name">Obmedzenie aktivít na pozadí</string>
     <string name="permission_exact_alarm_description">Povolte aplikácii posielať pripomienky úloh a hodín v presnom čase. Ak je vypnuté, pripomienky môžu meškať niekoľko minút.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Vaš pomočnik na kampusu NTUST</string>
     <string name="onboarding_welcome_title">Dobrodošli v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Uradno spletno mesto TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V sistemskih nastavitvah baterije/ozadja nastavite TigerDuck na neomejeno (ali ne omejujte dejavnosti v ozadju), da zmanjšate zamude pri opomnikih.</string>
     <string name="permission_battery_optimization_name">Omejitev dejavnosti v ozadju</string>
     <string name="permission_exact_alarm_description">Dovolite aplikaciji pošiljanje opomnikov za naloge in ure ob natančnem času. Če je onemogočeno, so opomniki lahko zamaknjeni za nekaj minut.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш NTUST кампус асистент</string>
     <string name="onboarding_welcome_title">Добродошли у TigerDuck</string>
     <string name="onboarding_welcome_website_label">Званична страница TigerDuck-а</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">У системским поставкама батерије/позадинских активности поставите TigerDuck на неограничено (или не ограничавајте позадинску активност) да бисте смањили кашњење подсетника.</string>
     <string name="permission_battery_optimization_name">Ограничење позадинске активности</string>
     <string name="permission_exact_alarm_description">Дозволите апликацији да шаље подсетнике за задатке и часове у тачно одређено вријеме. Ако је онемогућено, подсетници могу каснити неколико минута.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Välkommen till TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks officiella webbplats</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Ange TigerDuck som obegränsad (eller begränsa inte bakgrundsaktivitet) i systemets batteri-/bakgrundsinställningar för att minska förseningar av påminnelser.</string>
     <string name="permission_battery_optimization_name">Begränsning av bakgrundsaktivitet</string>
     <string name="permission_exact_alarm_description">Tillåt appen att skicka påminnelser om uppgifter och lektioner vid exakta tider. Om inaktiverat kan påminnelser försenas med flera minuter.</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">உங்கள் NTUST வளாக உதவியாளர்</string>
     <string name="onboarding_welcome_title">TigerDuck-க்கு வரவேற்கிறோம்</string>
     <string name="onboarding_welcome_website_label">TigerDuck அதிகாரப்பூர்வ வலைத்தளம்</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">நினைவூட்டல் தாமதங்களை குறைக்க, கணினி பேட்டரி/பின்னணி அமைப்புகளில் TigerDuck-ஐ கட்டுப்பாடற்றதாக (அல்லது பின்னணி செயல்பாட்டை கட்டுப்படுத்தாதே) அமைக்கவும்.</string>
     <string name="permission_battery_optimization_name">பின்னணி செயல்பாடு கட்டுப்பாடு</string>
     <string name="permission_exact_alarm_description">ஒப்படைப்பு மற்றும் வகுப்பு நினைவூட்டல்களை சரியான நேரத்தில் அனுப்ப App-ஐ அனுமதிக்கவும். முடக்கப்பட்டால், நினைவூட்டல்கள் சில நிமிடங்கள் தாமதமாகலாம்.</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">మీ NTUST క్యాంపస్ అసిస్టెంట్</string>
     <string name="onboarding_welcome_title">TigerDuck కి స్వాగతం</string>
     <string name="onboarding_welcome_website_label">TigerDuck అధికారిక వెబ్‌సైట్</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">సిస్టమ్ బ్యాటరీ/బ్యాక్‌గ్రౌండ్ సెట్టింగ్స్‌లో TigerDuck ని అపరిమిత (లేదా బ్యాక్‌గ్రౌండ్ యాక్టివిటీని పరిమితం చేయవద్దు) గా సెట్ చేయండి, రిమైండర్ ఆలస్యాలు తగ్గించడానికి.</string>
     <string name="permission_battery_optimization_name">బ్యాక్‌గ్రౌండ్ యాక్టివిటీ పరిమితి</string>
     <string name="permission_exact_alarm_description">అసైన్‌మెంట్ మరియు తరగతి రిమైండర్లను ఖచ్చితమైన సమయానికి పంపించడానికి యాప్‌ను అనుమతించండి. నిష్క్రియం చేస్తే, రిమైండర్లు కొన్ని నిమిషాలు ఆలస్యం అవుతాయి.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ผู้ช่วยในรั้วมหาวิทยาลัย NTUST ของคุณ</string>
     <string name="onboarding_welcome_title">ยินดีต้อนรับสู่ TigerDuck</string>
     <string name="onboarding_welcome_website_label">เว็บไซต์ทางการของ TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ในการตั้งค่าแบตเตอรี่/การทำงานเบื้องหลังของระบบ ให้ตั้งค่า TigerDuck เป็นไม่จำกัด (หรือไม่จำกัดการทำงานเบื้องหลัง) เพื่อลดความล่าช้าของการแจ้งเตือน</string>
     <string name="permission_battery_optimization_name">การจำกัดการทำงานเบื้องหลัง</string>
     <string name="permission_exact_alarm_description">อนุญาตให้แอปส่งการแจ้งเตือนการบ้านและการเข้าเรียนตรงเวลาที่กำหนด หากปิดใช้งาน การแจ้งเตือนอาจล่าช้าหลายนาที</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">NTUST kampüs asistanınız</string>
     <string name="onboarding_welcome_title">TigerDuck\'a hoş geldiniz</string>
     <string name="onboarding_welcome_website_label">TigerDuck resmi web sitesi</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistem pil/arka plan ayarlarında, hatırlatıcı gecikmelerini azaltmak için TigerDuck\'ı kısıtlanmamış olarak ayarlayın (veya arka plan etkinliğini kısıtlamayın).</string>
     <string name="permission_battery_optimization_name">Arka plan etkinliği kısıtlaması</string>
     <string name="permission_exact_alarm_description">Uygulamanın ödev ve ders hatırlatıcılarını tam zamanında göndermesine izin verin. Devre dışı bırakılırsa hatırlatıcılar birkaç dakika gecikebilir.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш помічник у кампусі NTUST</string>
     <string name="onboarding_welcome_title">Ласкаво просимо до TigerDuck</string>
     <string name="onboarding_welcome_website_label">Офіційний сайт TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">У системних налаштуваннях акумулятора/фонової активності встановіть для TigerDuck режим без обмежень (або не обмежуйте фонову активність), щоб зменшити затримки нагадувань.</string>
     <string name="permission_battery_optimization_name">Обмеження фонової активності</string>
     <string name="permission_exact_alarm_description">Дозвольте застосунку надсилати нагадування про завдання та заняття точно вчасно. Якщо вимкнено, нагадування можуть запізнюватися на кілька хвилин.</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">آپ کا NTUST کیمپس اسسٹنٹ</string>
     <string name="onboarding_welcome_title">TigerDuck میں خوش آمدید</string>
     <string name="onboarding_welcome_website_label">TigerDuck کی سرکاری ویب سائٹ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">سسٹم کی بیٹری/پس منظر کی ترتیبات میں TigerDuck کو غیر محدود (یا پس منظر کی سرگرمی پر پابندی نہ لگائیں) پر سیٹ کریں تاکہ یاددہانی میں تاخیر کم ہو۔</string>
     <string name="permission_battery_optimization_name">پس منظر کی سرگرمی پر پابندی</string>
     <string name="permission_exact_alarm_description">ایپ کو اسائنمنٹ اور کلاس کی یاددہانی بالکل صحیح وقت پر بھیجنے کی اجازت دیں۔ اگر بند ہو تو یاددہانی کئی منٹ تاخیر سے آ سکتی ہے۔</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Trợ lý sinh viên NTUST của bạn</string>
     <string name="onboarding_welcome_title">Chào mừng đến với TigerDuck</string>
     <string name="onboarding_welcome_website_label">Trang web chính thức của TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Trong cài đặt pin/hoạt động nền của hệ thống, hãy đặt TigerDuck ở chế độ không bị giới hạn (hoặc không hạn chế hoạt động nền) để giảm độ trễ thông báo.</string>
     <string name="permission_battery_optimization_name">Hạn chế hoạt động nền</string>
     <string name="permission_exact_alarm_description">Cho phép ứng dụng gửi nhắc bài tập và lớp học vào đúng thời điểm. Nếu tắt, nhắc nhở có thể bị trễ vài phút.</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的台科大校园助手</string>
     <string name="onboarding_welcome_title">欢迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 应用程序官网</string>
+    <string name="password_hide">隐藏密码</string>
+    <string name="password_show">显示密码</string>
     <string name="permission_battery_optimization_description">建议在系统的电池/背景活动设置中，将 TigerDuck 设为不受限制（或不要限制背景活动），以降低提醒延迟。</string>
     <string name="permission_battery_optimization_name">背景活动限制</string>
     <string name="permission_exact_alarm_description">允许 App 在精确的时间送出作业与上课提醒；关闭后提醒可能延后数分钟至十几分钟。</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的台科大校园助手</string>
     <string name="onboarding_welcome_title">欢迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 应用程序官网</string>
+    <string name="password_hide">隐藏密码</string>
+    <string name="password_show">显示密码</string>
     <string name="permission_battery_optimization_description">建议在系统的电池/背景活动设置中，将 TigerDuck 设为不受限制（或不要限制背景活动），以降低提醒延迟。</string>
     <string name="permission_battery_optimization_name">背景活动限制</string>
     <string name="permission_exact_alarm_description">允许 App 在精确的时间送出作业与上课提醒；关闭后提醒可能延后数分钟至十几分钟。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議在系統的電池/背景活動設定中，將 TigerDuck 設為不受限制（或不要限制背景活動），以降低提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 在精確的時間送出作業與上課提醒；關閉後提醒可能延後數分鐘至十幾分鐘。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/wear/src/main/res/values-ar/strings.xml
+++ b/wear/src/main/res/values-ar/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">مساعدك في حرم NTUST</string>
     <string name="onboarding_welcome_title">مرحبًا بك في TigerDuck</string>
     <string name="onboarding_welcome_website_label">الموقع الرسمي لـ TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">في إعدادات البطارية / الخلفية بالنظام، اضبط TigerDuck على غير مقيد (أو لا تقيد النشاط في الخلفية) لتقليل تأخر التذكيرات.</string>
     <string name="permission_battery_optimization_name">تقييد النشاط في الخلفية</string>
     <string name="permission_exact_alarm_description">اسمح للتطبيق بإرسال تذكيرات الواجبات والمحاضرات في أوقات دقيقة. عند تعطيله قد تتأخر التذكيرات عدة دقائق.</string>

--- a/wear/src/main/res/values-bg/strings.xml
+++ b/wear/src/main/res/values-bg/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Вашият асистент за кампуса на NTUST</string>
     <string name="onboarding_welcome_title">Добре дошли в TigerDuck</string>
     <string name="onboarding_welcome_website_label">Официален сайт на TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">В системните настройки за батерия/фонова активност задайте TigerDuck като неограничен (или не ограничавайте фоновата активност), за да намалите закъснението на напомнянията.</string>
     <string name="permission_battery_optimization_name">Ограничение на фонова активност</string>
     <string name="permission_exact_alarm_description">Разрешете на приложението да изпраща напомняния за задания и часове в точно определено време. Ако е деактивирано, напомнянията може да закъснеят с няколко минути.</string>

--- a/wear/src/main/res/values-bn/strings.xml
+++ b/wear/src/main/res/values-bn/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">আপনার NTUST ক্যাম্পাস সহকারী</string>
     <string name="onboarding_welcome_title">TigerDuck-এ স্বাগতম</string>
     <string name="onboarding_welcome_website_label">TigerDuck অফিসিয়াল ওয়েবসাইট</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">সিস্টেমের ব্যাটারি/ব্যাকগ্রাউন্ড সেটিংসে TigerDuck-কে অসীমাবদ্ধ রাখুন (বা ব্যাকগ্রাউন্ড কার্যকলাপ সীমাবদ্ধ করবেন না) যাতে স্মরণিকার বিলম্ব কমে।</string>
     <string name="permission_battery_optimization_name">ব্যাকগ্রাউন্ড কার্যকলাপ সীমাবদ্ধতা</string>
     <string name="permission_exact_alarm_description">অ্যাপকে নির্দিষ্ট সময়ে অ্যাসাইনমেন্ট ও ক্লাসের স্মরণিকা পাঠানোর অনুমতি দিন। বন্ধ করলে স্মরণিকা কয়েক মিনিট বিলম্বিত হতে পারে।</string>

--- a/wear/src/main/res/values-ca/strings.xml
+++ b/wear/src/main/res/values-ca/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">El vostre assistent del campus de NTUST</string>
     <string name="onboarding_welcome_title">Benvingut a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Lloc web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">A la configuració de bateria/segon pla del sistema, configureu TigerDuck com a sense restriccions (o no restringiu l\'activitat en segon pla) per reduir els retards dels recordatoris.</string>
     <string name="permission_battery_optimization_name">Restricció d\'activitat en segon pla</string>
     <string name="permission_exact_alarm_description">Permet que l\'aplicació enviï recordatoris de tasques i classes en moments exactes. Si està desactivat, els recordatoris poden arribar amb minuts de retard.</string>

--- a/wear/src/main/res/values-cs/strings.xml
+++ b/wear/src/main/res/values-cs/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Váš pomocník pro kampus NTUST</string>
     <string name="onboarding_welcome_title">Vítejte v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficiální web TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V systémovém nastavení baterie / aktivity na pozadí nastavte TigerDuck na neomezený režim (nebo neomezujte aktivitu na pozadí), abyste snížili zpoždění upozornění.</string>
     <string name="permission_battery_optimization_name">Omezení aktivity na pozadí</string>
     <string name="permission_exact_alarm_description">Povolte aplikaci odesílat upozornění na úkoly a hodiny v přesný čas. Pokud je vypnuto, mohou být upozornění zpožděna o několik minut.</string>

--- a/wear/src/main/res/values-da/strings.xml
+++ b/wear/src/main/res/values-da/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-campusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks officielle hjemmeside</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/baggrundsindstillinger skal du indstille TigerDuck til ubegrænset (eller undlade at begrænse baggrundsaktivitet) for at reducere forsinkelse af påmindelser.</string>
     <string name="permission_battery_optimization_name">Begrænsning af baggrundsaktivitet</string>
     <string name="permission_exact_alarm_description">Tillad appen at sende påmindelser om opgaver og undervisning på præcise tidspunkter. Hvis deaktiveret, kan påmindelser blive forsinket med flere minutter.</string>

--- a/wear/src/main/res/values-de/strings.xml
+++ b/wear/src/main/res/values-de/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ihr Campus-Assistent für die NTUST</string>
     <string name="onboarding_welcome_title">Willkommen bei TigerDuck</string>
     <string name="onboarding_welcome_website_label">Offizielle Website von TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Setzen Sie TigerDuck in den Akku-/Hintergrundeinstellungen des Systems auf uneingeschränkt (oder beschränken Sie die Hintergrundaktivität nicht), um Verzögerungen bei Erinnerungen zu reduzieren.</string>
     <string name="permission_battery_optimization_name">Einschränkung der Hintergrundaktivität</string>
     <string name="permission_exact_alarm_description">Erlauben Sie der App, Aufgaben- und Unterrichtserinnerungen zur exakten Zeit zu senden. Wenn deaktiviert, können sich Erinnerungen um mehrere Minuten verzögern.</string>

--- a/wear/src/main/res/values-el/strings.xml
+++ b/wear/src/main/res/values-el/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ο βοηθός σας στην πανεπιστημιούπολη NTUST</string>
     <string name="onboarding_welcome_title">Καλώς ήρθατε στο TigerDuck</string>
     <string name="onboarding_welcome_website_label">Επίσημος ιστότοπος TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Στις ρυθμίσεις μπαταρίας/παρασκηνίου του συστήματος, ορίστε το TigerDuck ως χωρίς περιορισμούς (ή μην περιορίζετε τη δραστηριότητα παρασκηνίου) για να μειώσετε καθυστερήσεις υπενθυμίσεων.</string>
     <string name="permission_battery_optimization_name">Περιορισμός παρασκηνιακής δραστηριότητας</string>
     <string name="permission_exact_alarm_description">Επιτρέψτε στην εφαρμογή να αποστέλλει υπενθυμίσεις εργασιών και μαθημάτων σε ακριβείς χρόνους. Εάν απενεργοποιηθεί, οι υπενθυμίσεις μπορεί να καθυστερήσουν αρκετά λεπτά.</string>

--- a/wear/src/main/res/values-en-rAU/strings.xml
+++ b/wear/src/main/res/values-en-rAU/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/wear/src/main/res/values-en-rCA/strings.xml
+++ b/wear/src/main/res/values-en-rCA/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/wear/src/main/res/values-en-rGB/strings.xml
+++ b/wear/src/main/res/values-en-rGB/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/wear/src/main/res/values-en-rIN/strings.xml
+++ b/wear/src/main/res/values-en-rIN/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>

--- a/wear/src/main/res/values-es-rMX/strings.xml
+++ b/wear/src/main/res/values-es-rMX/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Tu asistente del campus de NTUST</string>
     <string name="onboarding_welcome_title">Bienvenido a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sitio web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">En la configuración de batería/segundo plano del sistema, configura TigerDuck como sin restricciones (o no restrinjas la actividad en segundo plano) para reducir los retrasos de los recordatorios.</string>
     <string name="permission_battery_optimization_name">Restricción de actividad en segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que la app envíe recordatorios de tareas y de clases en horarios exactos. Si está deshabilitado, los recordatorios pueden retrasarse varios minutos.</string>

--- a/wear/src/main/res/values-es/strings.xml
+++ b/wear/src/main/res/values-es/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Tu asistente del campus de NTUST</string>
     <string name="onboarding_welcome_title">Bienvenido a TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sitio web oficial de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">En la configuración de batería/segundo plano del sistema, configura TigerDuck como sin restricciones (o no restrinjas la actividad en segundo plano) para reducir los retrasos de los recordatorios.</string>
     <string name="permission_battery_optimization_name">Restricción de actividad en segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que la app envíe recordatorios de tareas y de clases en horarios exactos. Si está deshabilitado, los recordatorios pueden retrasarse varios minutos.</string>

--- a/wear/src/main/res/values-et/strings.xml
+++ b/wear/src/main/res/values-et/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Teie NTUST-i ülikoolilinnaku assistent</string>
     <string name="onboarding_welcome_title">Tere tulemast TigerDucki</string>
     <string name="onboarding_welcome_website_label">TigerDucki ametlik veebisait</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Seadke TigerDuck süsteemi aku/taustatöö seadetes piiramatuks (või ärge piirake taustatöid), et vähendada meeldetuletuste hilinemist.</string>
     <string name="permission_battery_optimization_name">Taustatöö piirang</string>
     <string name="permission_exact_alarm_description">Lubage rakendusel saata ülesande ja tunni meeldetuletusi täpselt õigel ajal. Kui see on keelatud, võivad meeldetuletused hilineda mõne minuti võrra.</string>

--- a/wear/src/main/res/values-fa/strings.xml
+++ b/wear/src/main/res/values-fa/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">دستیار پردیس NTUST شما</string>
     <string name="onboarding_welcome_title">به TigerDuck خوش آمدید</string>
     <string name="onboarding_welcome_website_label">وب‌سایت رسمی TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">در تنظیمات باتری/پس‌زمینه سیستم، TigerDuck را روی «بدون محدودیت» قرار دهید (یا فعالیت پس‌زمینه را محدود نکنید) تا تأخیر یادآورها کمتر شود.</string>
     <string name="permission_battery_optimization_name">محدودیت فعالیت پس‌زمینه</string>
     <string name="permission_exact_alarm_description">به برنامه اجازه بدهید یادآورها را دقیقاً در زمان مقرر ارسال کند. اگر غیرفعال باشد، یادآورها ممکن است چند دقیقه دیرتر برسند.</string>

--- a/wear/src/main/res/values-fi/strings.xml
+++ b/wear/src/main/res/values-fi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">NTUST-kampusavustajasi</string>
     <string name="onboarding_welcome_title">Tervetuloa TigerDuck-sovellukseen</string>
     <string name="onboarding_welcome_website_label">TigerDuckin virallinen sivusto</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Aseta TigerDuck järjestelmän akku-/taustarajoitusasetuksissa rajoittamattomaksi (tai älä rajoita taustatoimintaa) muistutusviiveiden vähentämiseksi.</string>
     <string name="permission_battery_optimization_name">Taustatoiminnan rajoitus</string>
     <string name="permission_exact_alarm_description">Salli sovelluksen lähettää tehtävä- ja tuntimuistutukset tarkasti. Jos poistettu käytöstä, muistutukset voivat viivästyä useita minuutteja.</string>

--- a/wear/src/main/res/values-fil/strings.xml
+++ b/wear/src/main/res/values-fil/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ang iyong NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Maligayang pagdating sa TigerDuck</string>
     <string name="onboarding_welcome_website_label">Opisyal na website ng TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sa mga setting ng baterya/background ng sistema, itakda ang TigerDuck bilang walang paghihigpit (o huwag limitahan ang background activity) para mabawasan ang pagkaantala ng mga paalala.</string>
     <string name="permission_battery_optimization_name">Paghihigpit sa background activity</string>
     <string name="permission_exact_alarm_description">Payagan ang app na magpadala ng mga paalala sa takdang-aralin at klase sa tumpak na oras. Kung hindi pinagana, maaaring maantala ng ilang minuto ang mga paalala.</string>

--- a/wear/src/main/res/values-fr-rCA/strings.xml
+++ b/wear/src/main/res/values-fr-rCA/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Votre assistant de campus à NTUST</string>
     <string name="onboarding_welcome_title">Bienvenue sur TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site officiel de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dans les paramètres de batterie/arrière-plan du système, définissez TigerDuck sur sans restriction (ou ne limitez pas l\'activité en arrière-plan) pour réduire les retards de rappel.</string>
     <string name="permission_battery_optimization_name">Restriction d\'activité en arrière-plan</string>
     <string name="permission_exact_alarm_description">Autoriser l\'application à envoyer les rappels de devoirs et de cours à l\'heure exacte. Si désactivée, les rappels peuvent être retardés de plusieurs minutes.</string>

--- a/wear/src/main/res/values-fr/strings.xml
+++ b/wear/src/main/res/values-fr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Votre assistant de campus à NTUST</string>
     <string name="onboarding_welcome_title">Bienvenue sur TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site officiel de TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dans les paramètres de batterie/arrière-plan du système, définissez TigerDuck sur sans restriction (ou ne limitez pas l\'activité en arrière-plan) pour réduire les retards de rappel.</string>
     <string name="permission_battery_optimization_name">Restriction d\'activité en arrière-plan</string>
     <string name="permission_exact_alarm_description">Autoriser l\'application à envoyer les rappels de devoirs et de cours à l\'heure exacte. Si désactivée, les rappels peuvent être retardés de plusieurs minutes.</string>

--- a/wear/src/main/res/values-gu/strings.xml
+++ b/wear/src/main/res/values-gu/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">તમારો NTUST કૅમ્પસ સહાયક</string>
     <string name="onboarding_welcome_title">TigerDuck માં સ્વાગત છે</string>
     <string name="onboarding_welcome_website_label">TigerDuck ઓફિશિયલ વેબસાઇટ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">સિસ્ટમ બૅટરી/બૅકગ્રાઉન્ડ સેટિંગ્સમાં TigerDuck ને અપ્રતિબંધિત (અથવા બૅકગ્રાઉન્ડ પ્રવૃત્તિ ન રોકો) પર સેટ કરો, જેથી રિમાઇન્ડર વિલંબ ઘટે.</string>
     <string name="permission_battery_optimization_name">બૅકગ્રાઉન્ડ એક્ટિવિટી પ્રતિબંધ</string>
     <string name="permission_exact_alarm_description">App ને ચોક્કસ સમયે અસાઇનમેન્ટ અને ક્લાસ રિમાઇન્ડર મોકલવાની મંજૂરી આપો. બંધ કરવામાં આવે, તો રિમાઇન્ડર કેટલીક મિનિટ મોડા આવી શકે.</string>

--- a/wear/src/main/res/values-hi/strings.xml
+++ b/wear/src/main/res/values-hi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">आपका NTUST कैंपस सहायक</string>
     <string name="onboarding_welcome_title">TigerDuck में आपका स्वागत है</string>
     <string name="onboarding_welcome_website_label">TigerDuck आधिकारिक वेबसाइट</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">सिस्टम बैटरी/बैकग्राउंड सेटिंग में TigerDuck को अप्रतिबंधित (या बैकग्राउंड गतिविधि को प्रतिबंधित न करें) पर सेट करें ताकि अनुस्मारक में देरी कम हो।</string>
     <string name="permission_battery_optimization_name">बैकग्राउंड गतिविधि प्रतिबंध</string>
     <string name="permission_exact_alarm_description">ऐप को सटीक समय पर असाइनमेंट और कक्षा अनुस्मारक भेजने की अनुमति दें। अक्षम करने पर अनुस्मारक कई मिनट देरी से आ सकते हैं।</string>

--- a/wear/src/main/res/values-hr/strings.xml
+++ b/wear/src/main/res/values-hr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Vaš NTUST campus asistent</string>
     <string name="onboarding_welcome_title">Dobrodošli u TigerDuck</string>
     <string name="onboarding_welcome_website_label">Službena web-stranica TigerDucka</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">U postavkama baterije/pozadinske aktivnosti, postavite TigerDuck na neograničeno (ili ne ograničavajte pozadinsku aktivnost) kako biste smanjili kašnjenje podsjetnika.</string>
     <string name="permission_battery_optimization_name">Ograničenje pozadinske aktivnosti</string>
     <string name="permission_exact_alarm_description">Dopustite aplikaciji slanje podsjetnika za zadatke i predavanja u točno određeno vrijeme. Ako je onemogućeno, podsjetnici mogu kasniti nekoliko minuta.</string>

--- a/wear/src/main/res/values-hu/strings.xml
+++ b/wear/src/main/res/values-hu/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Az Ön NTUST kampusz asszisztense</string>
     <string name="onboarding_welcome_title">Üdvözöljük a TigerDuck alkalmazásban</string>
     <string name="onboarding_welcome_website_label">TigerDuck hivatalos weboldal</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">A rendszer akkumulátor/háttér beállításaiban állítsa a TigerDuck alkalmazást korlátozás nélkülire (vagy ne korlátozza a háttértevékenységet) az emlékeztetők késésének csökkentése érdekében.</string>
     <string name="permission_battery_optimization_name">Háttértevékenység korlátozása</string>
     <string name="permission_exact_alarm_description">Engedélyezze az alkalmazásnak, hogy pontosan időzített házi feladat és óra emlékeztetőket küldjön. Ha letiltja, az emlékeztetők néhány percet késhetnek.</string>

--- a/wear/src/main/res/values-in/strings.xml
+++ b/wear/src/main/res/values-in/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Asisten kampus NTUST kamu</string>
     <string name="onboarding_welcome_title">Selamat datang di TigerDuck</string>
     <string name="onboarding_welcome_website_label">Situs resmi TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Pada pengaturan baterai/latar belakang sistem, atur TigerDuck menjadi tidak dibatasi (atau jangan batasi aktivitas latar belakang) untuk mengurangi keterlambatan pengingat.</string>
     <string name="permission_battery_optimization_name">Pembatasan aktivitas latar belakang</string>
     <string name="permission_exact_alarm_description">Izinkan aplikasi mengirim pengingat tugas dan kelas pada waktu yang tepat. Jika dinonaktifkan, pengingat dapat tertunda beberapa menit.</string>

--- a/wear/src/main/res/values-is/strings.xml
+++ b/wear/src/main/res/values-is/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Háskólaassistentinn þinn hjá NTUST</string>
     <string name="onboarding_welcome_title">Velkomin í TigerDuck</string>
     <string name="onboarding_welcome_website_label">Opinber vefsíða TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Í rafhlöðu-/bakgrunnsstillingum kerfisins skaltu stilla TigerDuck á ótakmarkað (eða ekki takmarka bakgrunnsstarfsemi) til að draga úr seinkun á áminningum.</string>
     <string name="permission_battery_optimization_name">Takmörkun bakgrunnsstarfsemi</string>
     <string name="permission_exact_alarm_description">Leyfðu forritinu að senda verkefna- og tímaáminningar á nákvæmum tíma. Ef slökkt er á þessu gætu áminningar seinkað um nokkrar mínútur.</string>

--- a/wear/src/main/res/values-it/strings.xml
+++ b/wear/src/main/res/values-it/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Il tuo assistente per il campus NTUST</string>
     <string name="onboarding_welcome_title">Benvenuto su TigerDuck</string>
     <string name="onboarding_welcome_website_label">Sito ufficiale di TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nelle impostazioni di sistema della batteria/background, imposta TigerDuck come senza limitazioni (oppure non limitare l\'attività in background) per ridurre i ritardi dei promemoria.</string>
     <string name="permission_battery_optimization_name">Limitazione attività in background</string>
     <string name="permission_exact_alarm_description">Consenti all\'app di inviare promemoria di compiti e lezioni con orari precisi. Se disattivata, i promemoria potrebbero essere ritardati di alcuni minuti.</string>

--- a/wear/src/main/res/values-iw/strings.xml
+++ b/wear/src/main/res/values-iw/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">העוזר שלך לקמפוס NTUST</string>
     <string name="onboarding_welcome_title">ברוך הבא ל-TigerDuck</string>
     <string name="onboarding_welcome_website_label">האתר הרשמי של TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">בהגדרות הסוללה/רקע של המערכת, הגדר את TigerDuck כלא מוגבל (או אל תגביל פעילות ברקע) כדי להפחית עיכובים בתזכורות.</string>
     <string name="permission_battery_optimization_name">הגבלת פעילות ברקע</string>
     <string name="permission_exact_alarm_description">אפשר לאפליקציה לשלוח תזכורות למטלות ושיעורים בזמנים מדויקים. אם מושבת, התזכורות עלולות להתעכב בכמה דקות.</string>

--- a/wear/src/main/res/values-ja/strings.xml
+++ b/wear/src/main/res/values-ja/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">あなたの NTUST キャンパスアシスタント</string>
     <string name="onboarding_welcome_title">TigerDuck へようこそ</string>
     <string name="onboarding_welcome_website_label">TigerDuck 公式サイト</string>
+    <string name="password_hide">パスワードを非表示</string>
+    <string name="password_show">パスワードを表示</string>
     <string name="permission_battery_optimization_description">システムのバッテリー/バックグラウンド設定で、TigerDuck を制限なし（またはバックグラウンド動作を制限しない）に設定すると、リマインダーの遅延を減らせます。</string>
     <string name="permission_battery_optimization_name">バックグラウンド動作の制限</string>
     <string name="permission_exact_alarm_description">アプリが課題や授業のリマインダーを正確な時刻に送信できるようにします。無効にするとリマインダーが数分から十数分遅れる場合があります。</string>

--- a/wear/src/main/res/values-kk/strings.xml
+++ b/wear/src/main/res/values-kk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Сіздің NTUST кампус көмекшіңіз</string>
     <string name="onboarding_welcome_title">TigerDuck-қа қош келдіңіз</string>
     <string name="onboarding_welcome_website_label">TigerDuck-тің ресми сайты</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Жүйенің батарея/фон параметрлерінде TigerDuck-ты шектеусіз етіп орнатыңыз (немесе фондық белсенділікті шектемеңіз), осылай еске салулар кешікпейді.</string>
     <string name="permission_battery_optimization_name">Фондық белсенділікті шектеу</string>
     <string name="permission_exact_alarm_description">Қолданбаға тапсырма мен сабақ еске салуларын дәл уақытында жіберуге рұқсат беріңіз. Өшірілген жағдайда еске салулар бірнеше минутқа кешігуі мүмкін.</string>

--- a/wear/src/main/res/values-kn/strings.xml
+++ b/wear/src/main/res/values-kn/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ನಿಮ್ಮ NTUST ಕ್ಯಾಂಪಸ್ ಸಹಾಯಕ</string>
     <string name="onboarding_welcome_title">TigerDuck ಗೆ ಸ್ವಾಗತ</string>
     <string name="onboarding_welcome_website_label">TigerDuck ಅಧಿಕೃತ ವೆಬ್‌ಸೈಟ್</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ಜ್ಞಾಪನೆ ವಿಳಂಬ ತಗ್ಗಿಸಲು, ಸಿಸ್ಟಂ ಬ್ಯಾಟರಿ/ಹಿನ್ನೆಲೆ ಸೆಟ್ಟಿಂಗ್‌ಗಳಲ್ಲಿ TigerDuck ಅನ್ನು ಅನಿರ್ಬಂಧಿತ ಎಂದು ಹೊಂದಿಸಿ (ಅಥವಾ ಹಿನ್ನೆಲೆ ಚಟುವಟಿಕೆ ನಿರ್ಬಂಧಿಸಬೇಡಿ).</string>
     <string name="permission_battery_optimization_name">ಹಿನ್ನೆಲೆ ಚಟುವಟಿಕೆ ನಿರ್ಬಂಧ</string>
     <string name="permission_exact_alarm_description">ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ನಿಖರ ಸಮಯದಲ್ಲಿ ಕಾರ್ಯ ಮತ್ತು ತರಗತಿ ಜ್ಞಾಪನೆಗಳನ್ನು ಕಳುಹಿಸಲು ಅನುಮತಿ ನೀಡಿ. ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಿದರೆ, ಜ್ಞಾಪನೆಗಳು ಹಲವು ನಿಮಿಷ ತಡವಾಗಬಹುದು.</string>

--- a/wear/src/main/res/values-ko/strings.xml
+++ b/wear/src/main/res/values-ko/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">당신의 NTUST 캠퍼스 도우미</string>
     <string name="onboarding_welcome_title">TigerDuck에 오신 것을 환영합니다</string>
     <string name="onboarding_welcome_website_label">TigerDuck 공식 웹사이트</string>
+    <string name="password_hide">비밀번호 숨기기</string>
+    <string name="password_show">비밀번호 표시</string>
     <string name="permission_battery_optimization_description">시스템 배터리/백그라운드 설정에서 TigerDuck을 제한 없음(또는 백그라운드 활동을 제한하지 않음)으로 설정하면 알림 지연을 줄일 수 있습니다.</string>
     <string name="permission_battery_optimization_name">백그라운드 활동 제한</string>
     <string name="permission_exact_alarm_description">앱이 정확한 시간에 과제 및 수업 알림을 보낼 수 있도록 허용해 주세요. 비활성화하면 알림이 몇 분 지연될 수 있습니다.</string>

--- a/wear/src/main/res/values-lt/strings.xml
+++ b/wear/src/main/res/values-lt/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jūsų NTUST universiteto asistentas</string>
     <string name="onboarding_welcome_title">Sveiki atvykę į TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficialus TigerDuck tinklalapis</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistemos akumuliatoriaus / fono nustatymuose nustatykite TigerDuck kaip neapribotą (arba neribokite fono veiklos), kad sumažintumėte priminimų vėlavimą.</string>
     <string name="permission_battery_optimization_name">Fono veiklos apribojimas</string>
     <string name="permission_exact_alarm_description">Leiskite programai tiksliai laiku siųsti užduočių ir paskaitų priminimus. Jei išjungta, priminimai gali vėluoti kelias minutes.</string>

--- a/wear/src/main/res/values-lv/strings.xml
+++ b/wear/src/main/res/values-lv/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jūsu NTUST universitātes palīgs</string>
     <string name="onboarding_welcome_title">Laipni lūdzam TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck oficiālā vietne</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistēmas akumulatora/fona iestatījumos iestatiet TigerDuck kā neierobežotu (vai neatļaujiet fona darbības ierobežošanu), lai samazinātu atgādinājumu kavēšanos.</string>
     <string name="permission_battery_optimization_name">Fona darbības ierobežojums</string>
     <string name="permission_exact_alarm_description">Atļaujiet lietotnei sūtīt uzdevumu un nodarbību atgādinājumus precīzos laikos. Ja atspējots, atgādinājumi var aizkavēties par dažām minūtēm.</string>

--- a/wear/src/main/res/values-ml/strings.xml
+++ b/wear/src/main/res/values-ml/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">നിങ്ങളുടെ NTUST ക്യാമ്പസ് സഹായി</string>
     <string name="onboarding_welcome_title">TigerDuck-ലേക്ക് സ്വാഗതം</string>
     <string name="onboarding_welcome_website_label">TigerDuck ഔദ്യോഗിക വെബ്സൈറ്റ്</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ഓർമ്മപ്പെടുത്തൽ കാലതാമസം കുറയ്ക്കാൻ, സിസ്റ്റം ബാറ്ററി/പശ്ചാത്തല ക്രമീകരണങ്ങളിൽ TigerDuck-നെ അൺറെസ്ട്രിക്റ്റഡ് ആക്കുക (അല്ലെങ്കിൽ പശ്ചാത്തല പ്രവർത്തനം നിയന്ത്രിക്കരുത്).</string>
     <string name="permission_battery_optimization_name">പശ്ചാത്തല പ്രവർത്തന നിയന്ത്രണം</string>
     <string name="permission_exact_alarm_description">കൃത്യ സമയത്ത് അസൈൻമെന്റ്, ക്ലാസ് ഓർമ്മപ്പെടുത്തലുകൾ അയയ്ക്കാൻ ആപ്പിന് അനുവദിക്കുക. അക്ഷമം ചെയ്താൽ, ഓർമ്മപ്പെടുത്തലുകൾ കുറച്ച് മിനിറ്റ് വൈകിയേക്കാം.</string>

--- a/wear/src/main/res/values-mr/strings.xml
+++ b/wear/src/main/res/values-mr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">तुमचा NTUST कॅम्पस सहाय्यक</string>
     <string name="onboarding_welcome_title">TigerDuck मध्ये आपले स्वागत आहे</string>
     <string name="onboarding_welcome_website_label">TigerDuck अधिकृत वेबसाइट</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">सिस्टम बॅटरी/पार्श्वभूमी सेटिंग्जमध्ये TigerDuck ला अप्रतिबंधित (किंवा पार्श्वभूमी क्रियाकलाप प्रतिबंधित नाही) असे सेट करा, जेणेकरून स्मरणपत्रे वेळेवर येतील.</string>
     <string name="permission_battery_optimization_name">पार्श्वभूमी क्रियाकलाप निर्बंध</string>
     <string name="permission_exact_alarm_description">ॲपला असाइनमेंट आणि वर्गाची स्मरणपत्रे अचूक वेळी पाठवण्याची परवानगी द्या. बंद केल्यास, स्मरणपत्रे काही मिनिटे उशिरा येऊ शकतात.</string>

--- a/wear/src/main/res/values-ms/strings.xml
+++ b/wear/src/main/res/values-ms/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Pembantu kampus NTUST anda</string>
     <string name="onboarding_welcome_title">Selamat datang ke TigerDuck</string>
     <string name="onboarding_welcome_website_label">Laman web rasmi TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Dalam tetapan bateri/latar belakang sistem, tetapkan TigerDuck kepada tidak terhad (atau jangan hadkan aktiviti latar belakang) untuk mengurangkan kelewatan peringatan.</string>
     <string name="permission_battery_optimization_name">Sekatan aktiviti latar belakang</string>
     <string name="permission_exact_alarm_description">Benarkan aplikasi menghantar peringatan tugasan dan kelas pada masa yang tepat. Jika dilumpuhkan, peringatan mungkin tertunda beberapa minit.</string>

--- a/wear/src/main/res/values-nb/strings.xml
+++ b/wear/src/main/res/values-nb/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks offisielle nettsted</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/bakgrunnsinnstillinger setter du TigerDuck til ubegrenset (eller ikke begrens bakgrunnsaktivitet) for å redusere forsinkelser i påminnelser.</string>
     <string name="permission_battery_optimization_name">Bakgrunnsaktivitetsbegrensning</string>
     <string name="permission_exact_alarm_description">La appen sende oppgave- og timepåminnelser til nøyaktig tid. Hvis deaktivert, kan påminnelser bli forsinket med flere minutter.</string>

--- a/wear/src/main/res/values-nl/strings.xml
+++ b/wear/src/main/res/values-nl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Jouw NTUST campusassistent</string>
     <string name="onboarding_welcome_title">Welkom bij TigerDuck</string>
     <string name="onboarding_welcome_website_label">Officiële TigerDuck-website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Stel TigerDuck in de batterij-/achtergrondinstellingen van het systeem in op onbeperkt (of beperk de achtergrondactiviteit niet) om vertragingen bij herinneringen te verminderen.</string>
     <string name="permission_battery_optimization_name">Beperking achtergrondactiviteit</string>
     <string name="permission_exact_alarm_description">Sta de app toe om opdracht- en lesherinneringen op exacte tijden te sturen. Als dit is uitgeschakeld, kunnen herinneringen enkele minuten vertraging hebben.</string>

--- a/wear/src/main/res/values-no/strings.xml
+++ b/wear/src/main/res/values-no/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Velkommen til TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks offisielle nettsted</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">I systemets batteri-/bakgrunnsinnstillinger setter du TigerDuck til ubegrenset (eller ikke begrens bakgrunnsaktivitet) for å redusere forsinkelser i påminnelser.</string>
     <string name="permission_battery_optimization_name">Bakgrunnsaktivitetsbegrensning</string>
     <string name="permission_exact_alarm_description">La appen sende oppgave- og timepåminnelser til nøyaktig tid. Hvis deaktivert, kan påminnelser bli forsinket med flere minutter.</string>

--- a/wear/src/main/res/values-pa/strings.xml
+++ b/wear/src/main/res/values-pa/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ਤੁਹਾਡਾ NTUST ਕੈਂਪਸ ਸਹਾਇਕ</string>
     <string name="onboarding_welcome_title">TigerDuck ਵਿੱਚ ਸੁਆਗਤ ਹੈ</string>
     <string name="onboarding_welcome_website_label">TigerDuck ਅਧਿਕਾਰਤ ਵੈੱਬਸਾਈਟ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ਸਿਸਟਮ ਬੈਟਰੀ/ਬੈਕਗ੍ਰਾਊਂਡ ਸੈਟਿੰਗਾਂ ਵਿੱਚ TigerDuck ਨੂੰ ਅਣਸੀਮਿਤ ਕਰੋ (ਜਾਂ ਬੈਕਗ੍ਰਾਊਂਡ ਗਤੀਵਿਧੀ ਨਾ ਰੋਕੋ) ਤਾਂ ਜੋ ਰੀਮਾਈਂਡਰ ਵਿੱਚ ਦੇਰੀ ਘੱਟ ਹੋਵੇ।</string>
     <string name="permission_battery_optimization_name">ਬੈਕਗ੍ਰਾਊਂਡ ਗਤੀਵਿਧੀ ਪਾਬੰਦੀ</string>
     <string name="permission_exact_alarm_description">ਐਪ ਨੂੰ ਸਹੀ ਸਮੇਂ \'ਤੇ ਅਸਾਈਨਮੈਂਟ ਅਤੇ ਕਲਾਸ ਰੀਮਾਈਂਡਰ ਭੇਜਣ ਦੀ ਇਜਾਜ਼ਤ ਦਿਓ। ਅਯੋਗ ਹੋਣ \'ਤੇ ਰੀਮਾਈਂਡਰ ਕੁਝ ਮਿੰਟ ਦੇਰ ਨਾਲ ਆ ਸਕਦੇ ਹਨ।</string>

--- a/wear/src/main/res/values-pl/strings.xml
+++ b/wear/src/main/res/values-pl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Państwa asystent kampusu NTUST</string>
     <string name="onboarding_welcome_title">Witamy w TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficjalna strona TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">W systemowych ustawieniach baterii/aktywności w tle ustawić TigerDuck jako bez ograniczeń (lub nie ograniczać aktywności w tle), aby zmniejszyć opóźnienia przypomnień.</string>
     <string name="permission_battery_optimization_name">Ograniczenie aktywności w tle</string>
     <string name="permission_exact_alarm_description">Pozwolić aplikacji wysyłać przypomnienia o zadaniach i zajęciach o dokładnych porach. Po wyłączeniu przypomnienia mogą być opóźnione o kilka minut.</string>

--- a/wear/src/main/res/values-pt-rBR/strings.xml
+++ b/wear/src/main/res/values-pt-rBR/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Seu assistente do campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas configurações de bateria/segundo plano do sistema, defina o TigerDuck como sem restrições (ou não restrinja a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permita que o app envie lembretes de atividades e aulas em horários exatos. Se desativado, os lembretes podem atrasar alguns minutos.</string>

--- a/wear/src/main/res/values-pt-rPT/strings.xml
+++ b/wear/src/main/res/values-pt-rPT/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">O teu assistente de campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas definições do sistema de bateria/segundo plano, define o TigerDuck como sem restrições (ou não restrinjas a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que a aplicação envie lembretes de trabalhos e aulas a horas exatas. Se estiver desativado, os lembretes podem atrasar-se vários minutos.</string>

--- a/wear/src/main/res/values-pt/strings.xml
+++ b/wear/src/main/res/values-pt/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">O teu assistente de campus da NTUST</string>
     <string name="onboarding_welcome_title">Bem-vindo ao TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site oficial do TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Nas definições do sistema de bateria/segundo plano, define o TigerDuck como sem restrições (ou não restrinjas a atividade em segundo plano) para reduzir atrasos nos lembretes.</string>
     <string name="permission_battery_optimization_name">Restrição de atividade em segundo plano</string>
     <string name="permission_exact_alarm_description">Permite que a aplicação envie lembretes de trabalhos e aulas a horas exatas. Se estiver desativado, os lembretes podem atrasar-se vários minutos.</string>

--- a/wear/src/main/res/values-ro/strings.xml
+++ b/wear/src/main/res/values-ro/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Asistentul tău de campus NTUST</string>
     <string name="onboarding_welcome_title">Bun venit la TigerDuck</string>
     <string name="onboarding_welcome_website_label">Site-ul oficial TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">În setările bateriei/fundalului sistemului, setează TigerDuck ca nerestricționat (sau nu restricționa activitatea în fundal) pentru a reduce întârzierile reminderelor.</string>
     <string name="permission_battery_optimization_name">Restricție activitate în fundal</string>
     <string name="permission_exact_alarm_description">Permite aplicației să trimită remindere pentru teme și cursuri la ore exacte. Dacă este dezactivat, reminderele pot întârzia câteva minute.</string>

--- a/wear/src/main/res/values-ru/strings.xml
+++ b/wear/src/main/res/values-ru/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш кампусный помощник NTUST</string>
     <string name="onboarding_welcome_title">Добро пожаловать в TigerDuck</string>
     <string name="onboarding_welcome_website_label">Официальный сайт TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">В системных настройках батареи/фоновой активности установите для TigerDuck режим без ограничений (или не ограничивайте фоновую активность), чтобы уменьшить задержки напоминаний.</string>
     <string name="permission_battery_optimization_name">Ограничение фоновой активности</string>
     <string name="permission_exact_alarm_description">Разрешите приложению отправлять напоминания о заданиях и занятиях точно в назначенное время. Если отключено, напоминания могут запаздывать на несколько минут.</string>

--- a/wear/src/main/res/values-sk/strings.xml
+++ b/wear/src/main/res/values-sk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Váš asistent kampusu NTUST</string>
     <string name="onboarding_welcome_title">Vitajte v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Oficiálna stránka TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V systémových nastaveniach batérie/aktivít na pozadí nastavte TigerDuck ako neobmedzený (alebo neobmedzujte aktivity na pozadí), aby sa znížilo meškanie pripomienok.</string>
     <string name="permission_battery_optimization_name">Obmedzenie aktivít na pozadí</string>
     <string name="permission_exact_alarm_description">Povolte aplikácii posielať pripomienky úloh a hodín v presnom čase. Ak je vypnuté, pripomienky môžu meškať niekoľko minút.</string>

--- a/wear/src/main/res/values-sl/strings.xml
+++ b/wear/src/main/res/values-sl/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Vaš pomočnik na kampusu NTUST</string>
     <string name="onboarding_welcome_title">Dobrodošli v TigerDuck</string>
     <string name="onboarding_welcome_website_label">Uradno spletno mesto TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">V sistemskih nastavitvah baterije/ozadja nastavite TigerDuck na neomejeno (ali ne omejujte dejavnosti v ozadju), da zmanjšate zamude pri opomnikih.</string>
     <string name="permission_battery_optimization_name">Omejitev dejavnosti v ozadju</string>
     <string name="permission_exact_alarm_description">Dovolite aplikaciji pošiljanje opomnikov za naloge in ure ob natančnem času. Če je onemogočeno, so opomniki lahko zamaknjeni za nekaj minut.</string>

--- a/wear/src/main/res/values-sr/strings.xml
+++ b/wear/src/main/res/values-sr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш NTUST кампус асистент</string>
     <string name="onboarding_welcome_title">Добродошли у TigerDuck</string>
     <string name="onboarding_welcome_website_label">Званична страница TigerDuck-а</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">У системским поставкама батерије/позадинских активности поставите TigerDuck на неограничено (или не ограничавајте позадинску активност) да бисте смањили кашњење подсетника.</string>
     <string name="permission_battery_optimization_name">Ограничење позадинске активности</string>
     <string name="permission_exact_alarm_description">Дозволите апликацији да шаље подсетнике за задатке и часове у тачно одређено вријеме. Ако је онемогућено, подсетници могу каснити неколико минута.</string>

--- a/wear/src/main/res/values-sv/strings.xml
+++ b/wear/src/main/res/values-sv/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Din NTUST-kampusassistent</string>
     <string name="onboarding_welcome_title">Välkommen till TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDucks officiella webbplats</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Ange TigerDuck som obegränsad (eller begränsa inte bakgrundsaktivitet) i systemets batteri-/bakgrundsinställningar för att minska förseningar av påminnelser.</string>
     <string name="permission_battery_optimization_name">Begränsning av bakgrundsaktivitet</string>
     <string name="permission_exact_alarm_description">Tillåt appen att skicka påminnelser om uppgifter och lektioner vid exakta tider. Om inaktiverat kan påminnelser försenas med flera minuter.</string>

--- a/wear/src/main/res/values-ta/strings.xml
+++ b/wear/src/main/res/values-ta/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">உங்கள் NTUST வளாக உதவியாளர்</string>
     <string name="onboarding_welcome_title">TigerDuck-க்கு வரவேற்கிறோம்</string>
     <string name="onboarding_welcome_website_label">TigerDuck அதிகாரப்பூர்வ வலைத்தளம்</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">நினைவூட்டல் தாமதங்களை குறைக்க, கணினி பேட்டரி/பின்னணி அமைப்புகளில் TigerDuck-ஐ கட்டுப்பாடற்றதாக (அல்லது பின்னணி செயல்பாட்டை கட்டுப்படுத்தாதே) அமைக்கவும்.</string>
     <string name="permission_battery_optimization_name">பின்னணி செயல்பாடு கட்டுப்பாடு</string>
     <string name="permission_exact_alarm_description">ஒப்படைப்பு மற்றும் வகுப்பு நினைவூட்டல்களை சரியான நேரத்தில் அனுப்ப App-ஐ அனுமதிக்கவும். முடக்கப்பட்டால், நினைவூட்டல்கள் சில நிமிடங்கள் தாமதமாகலாம்.</string>

--- a/wear/src/main/res/values-te/strings.xml
+++ b/wear/src/main/res/values-te/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">మీ NTUST క్యాంపస్ అసిస్టెంట్</string>
     <string name="onboarding_welcome_title">TigerDuck కి స్వాగతం</string>
     <string name="onboarding_welcome_website_label">TigerDuck అధికారిక వెబ్‌సైట్</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">సిస్టమ్ బ్యాటరీ/బ్యాక్‌గ్రౌండ్ సెట్టింగ్స్‌లో TigerDuck ని అపరిమిత (లేదా బ్యాక్‌గ్రౌండ్ యాక్టివిటీని పరిమితం చేయవద్దు) గా సెట్ చేయండి, రిమైండర్ ఆలస్యాలు తగ్గించడానికి.</string>
     <string name="permission_battery_optimization_name">బ్యాక్‌గ్రౌండ్ యాక్టివిటీ పరిమితి</string>
     <string name="permission_exact_alarm_description">అసైన్‌మెంట్ మరియు తరగతి రిమైండర్లను ఖచ్చితమైన సమయానికి పంపించడానికి యాప్‌ను అనుమతించండి. నిష్క్రియం చేస్తే, రిమైండర్లు కొన్ని నిమిషాలు ఆలస్యం అవుతాయి.</string>

--- a/wear/src/main/res/values-th/strings.xml
+++ b/wear/src/main/res/values-th/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">ผู้ช่วยในรั้วมหาวิทยาลัย NTUST ของคุณ</string>
     <string name="onboarding_welcome_title">ยินดีต้อนรับสู่ TigerDuck</string>
     <string name="onboarding_welcome_website_label">เว็บไซต์ทางการของ TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">ในการตั้งค่าแบตเตอรี่/การทำงานเบื้องหลังของระบบ ให้ตั้งค่า TigerDuck เป็นไม่จำกัด (หรือไม่จำกัดการทำงานเบื้องหลัง) เพื่อลดความล่าช้าของการแจ้งเตือน</string>
     <string name="permission_battery_optimization_name">การจำกัดการทำงานเบื้องหลัง</string>
     <string name="permission_exact_alarm_description">อนุญาตให้แอปส่งการแจ้งเตือนการบ้านและการเข้าเรียนตรงเวลาที่กำหนด หากปิดใช้งาน การแจ้งเตือนอาจล่าช้าหลายนาที</string>

--- a/wear/src/main/res/values-tr/strings.xml
+++ b/wear/src/main/res/values-tr/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">NTUST kampüs asistanınız</string>
     <string name="onboarding_welcome_title">TigerDuck\'a hoş geldiniz</string>
     <string name="onboarding_welcome_website_label">TigerDuck resmi web sitesi</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Sistem pil/arka plan ayarlarında, hatırlatıcı gecikmelerini azaltmak için TigerDuck\'ı kısıtlanmamış olarak ayarlayın (veya arka plan etkinliğini kısıtlamayın).</string>
     <string name="permission_battery_optimization_name">Arka plan etkinliği kısıtlaması</string>
     <string name="permission_exact_alarm_description">Uygulamanın ödev ve ders hatırlatıcılarını tam zamanında göndermesine izin verin. Devre dışı bırakılırsa hatırlatıcılar birkaç dakika gecikebilir.</string>

--- a/wear/src/main/res/values-uk/strings.xml
+++ b/wear/src/main/res/values-uk/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Ваш помічник у кампусі NTUST</string>
     <string name="onboarding_welcome_title">Ласкаво просимо до TigerDuck</string>
     <string name="onboarding_welcome_website_label">Офіційний сайт TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">У системних налаштуваннях акумулятора/фонової активності встановіть для TigerDuck режим без обмежень (або не обмежуйте фонову активність), щоб зменшити затримки нагадувань.</string>
     <string name="permission_battery_optimization_name">Обмеження фонової активності</string>
     <string name="permission_exact_alarm_description">Дозвольте застосунку надсилати нагадування про завдання та заняття точно вчасно. Якщо вимкнено, нагадування можуть запізнюватися на кілька хвилин.</string>

--- a/wear/src/main/res/values-ur/strings.xml
+++ b/wear/src/main/res/values-ur/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">آپ کا NTUST کیمپس اسسٹنٹ</string>
     <string name="onboarding_welcome_title">TigerDuck میں خوش آمدید</string>
     <string name="onboarding_welcome_website_label">TigerDuck کی سرکاری ویب سائٹ</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">سسٹم کی بیٹری/پس منظر کی ترتیبات میں TigerDuck کو غیر محدود (یا پس منظر کی سرگرمی پر پابندی نہ لگائیں) پر سیٹ کریں تاکہ یاددہانی میں تاخیر کم ہو۔</string>
     <string name="permission_battery_optimization_name">پس منظر کی سرگرمی پر پابندی</string>
     <string name="permission_exact_alarm_description">ایپ کو اسائنمنٹ اور کلاس کی یاددہانی بالکل صحیح وقت پر بھیجنے کی اجازت دیں۔ اگر بند ہو تو یاددہانی کئی منٹ تاخیر سے آ سکتی ہے۔</string>

--- a/wear/src/main/res/values-vi/strings.xml
+++ b/wear/src/main/res/values-vi/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Trợ lý sinh viên NTUST của bạn</string>
     <string name="onboarding_welcome_title">Chào mừng đến với TigerDuck</string>
     <string name="onboarding_welcome_website_label">Trang web chính thức của TigerDuck</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">Trong cài đặt pin/hoạt động nền của hệ thống, hãy đặt TigerDuck ở chế độ không bị giới hạn (hoặc không hạn chế hoạt động nền) để giảm độ trễ thông báo.</string>
     <string name="permission_battery_optimization_name">Hạn chế hoạt động nền</string>
     <string name="permission_exact_alarm_description">Cho phép ứng dụng gửi nhắc bài tập và lớp học vào đúng thời điểm. Nếu tắt, nhắc nhở có thể bị trễ vài phút.</string>

--- a/wear/src/main/res/values-yue-rHK/strings.xml
+++ b/wear/src/main/res/values-yue-rHK/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/wear/src/main/res/values-zh-rCN/strings.xml
+++ b/wear/src/main/res/values-zh-rCN/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的台科大校园助手</string>
     <string name="onboarding_welcome_title">欢迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 应用程序官网</string>
+    <string name="password_hide">隐藏密码</string>
+    <string name="password_show">显示密码</string>
     <string name="permission_battery_optimization_description">建议在系统的电池/背景活动设置中，将 TigerDuck 设为不受限制（或不要限制背景活动），以降低提醒延迟。</string>
     <string name="permission_battery_optimization_name">背景活动限制</string>
     <string name="permission_exact_alarm_description">允许 App 在精确的时间送出作业与上课提醒；关闭后提醒可能延后数分钟至十几分钟。</string>

--- a/wear/src/main/res/values-zh-rHK/strings.xml
+++ b/wear/src/main/res/values-zh-rHK/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/wear/src/main/res/values-zh-rMO/strings.xml
+++ b/wear/src/main/res/values-zh-rMO/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議喺系統嘅電池／背景活動設定入面，將 TigerDuck 設為不受限制（或者唔好限制背景活動），減少提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 喺精確時間發出功課同上堂提醒；關閉後提醒可能會延後幾分鐘到十幾分鐘。</string>

--- a/wear/src/main/res/values-zh-rSG/strings.xml
+++ b/wear/src/main/res/values-zh-rSG/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的台科大校园助手</string>
     <string name="onboarding_welcome_title">欢迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 应用程序官网</string>
+    <string name="password_hide">隐藏密码</string>
+    <string name="password_show">显示密码</string>
     <string name="permission_battery_optimization_description">建议在系统的电池/背景活动设置中，将 TigerDuck 设为不受限制（或不要限制背景活动），以降低提醒延迟。</string>
     <string name="permission_battery_optimization_name">背景活动限制</string>
     <string name="permission_exact_alarm_description">允许 App 在精确的时间送出作业与上课提醒；关闭后提醒可能延后数分钟至十几分钟。</string>

--- a/wear/src/main/res/values-zh-rTW/strings.xml
+++ b/wear/src/main/res/values-zh-rTW/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">你的臺科大校園助手</string>
     <string name="onboarding_welcome_title">歡迎使用 TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck 應用程式官網</string>
+    <string name="password_hide">隱藏密碼</string>
+    <string name="password_show">顯示密碼</string>
     <string name="permission_battery_optimization_description">建議在系統的電池/背景活動設定中，將 TigerDuck 設為不受限制（或不要限制背景活動），以降低提醒延遲。</string>
     <string name="permission_battery_optimization_name">背景活動限制</string>
     <string name="permission_exact_alarm_description">允許 App 在精確的時間送出作業與上課提醒；關閉後提醒可能延後數分鐘至十幾分鐘。</string>

--- a/wear/src/main/res/values/strings.xml
+++ b/wear/src/main/res/values/strings.xml
@@ -385,6 +385,8 @@
     <string name="onboarding_welcome_subtitle">Your NTUST campus assistant</string>
     <string name="onboarding_welcome_title">Welcome to TigerDuck</string>
     <string name="onboarding_welcome_website_label">TigerDuck official website</string>
+    <string name="password_hide">Hide password</string>
+    <string name="password_show">Show password</string>
     <string name="permission_battery_optimization_description">In system battery/background settings, set TigerDuck to unrestricted (or don\'t restrict background activity) to reduce reminder delays.</string>
     <string name="permission_battery_optimization_name">Background activity restriction</string>
     <string name="permission_exact_alarm_description">Allow the app to send assignment and class reminders at exact times. If disabled, reminders may be delayed by several minutes.</string>


### PR DESCRIPTION
This pull request introduces a reusable `PasswordTrailingIcons` composable to provide a consistent and accessible password field experience throughout the app. The new component combines a clear (reset) button and a password visibility toggle, and replaces duplicated logic in all login-related screens. Additionally, new string resources for "Show password" and "Hide password" are added in multiple languages for improved accessibility.

**Component extraction and UI consistency:**

* Added a new `PasswordTrailingIcons` composable in `PasswordTrailingIcons.kt` to encapsulate the clear and visibility toggle icons for password fields, ensuring consistent behavior and accessibility descriptions across the app.
* Refactored password fields in `LibraryScreen`, `OnboardingScreen`, and `LoginSheet` to use the new `PasswordTrailingIcons` component, removing duplicated icon logic and improving maintainability. [[1]](diffhunk://#diff-4f94a81a776ff8f9a5eea5f48ae6698b26967dc86211d935071fc3ecce00e3c2L368-L378) [[2]](diffhunk://#diff-993d3fba026f5a742e2432f0afe61d00dd80886d2c3eae31f222ff4d5b665d29L268-L278) [[3]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeL156-L166)

**Accessibility and localization:**

* Added new string resources for "Show password" and "Hide password" in multiple languages to support the new visibility toggle and improve accessibility for screen readers. [[1]](diffhunk://#diff-275e22e5424874865d61be0a790c48168da5998ec6dd530c83fb33005bfa4449R388-R389) [[2]](diffhunk://#diff-f721547734cc211b2b18c4089b562c1d0e22d110a36b0f14bc921dab7423a25eR388-R389) [[3]](diffhunk://#diff-434c17d85f690e65211e494964760d86872ab07645e23395e4c88932761281e0R388-R389) [[4]](diffhunk://#diff-386877786b288f19da18e47b00709101126367ea07cf11a91d40ce2cda12fdf6R388-R389) [[5]](diffhunk://#diff-bf5f30504e5874b66c42578605d994279957d435025c3271620cfc607b19e4d9R388-R389)

**Code cleanup and imports:**

* Removed now-unnecessary icon imports and related code from affected screens, as the logic is centralized in the new component. [[1]](diffhunk://#diff-4f94a81a776ff8f9a5eea5f48ae6698b26967dc86211d935071fc3ecce00e3c2L19-L20) [[2]](diffhunk://#diff-993d3fba026f5a742e2432f0afe61d00dd80886d2c3eae31f222ff4d5b665d29L31) [[3]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeL18) [[4]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeL27)

**Password visibility state management:**

* Introduced a `passwordVisible` state in each screen to control the password field's visual transformation, ensuring that the visibility toggle works as expected and is not persisted across configuration changes where appropriate. [[1]](diffhunk://#diff-4f94a81a776ff8f9a5eea5f48ae6698b26967dc86211d935071fc3ecce00e3c2R332) [[2]](diffhunk://#diff-993d3fba026f5a742e2432f0afe61d00dd80886d2c3eae31f222ff4d5b665d29R97) [[3]](diffhunk://#diff-79f9d597b1226b080709a371e450b308ddd8ef46e720b654e6125e81a27177aeR85-R88)Eye-icon trailing affordance on every password input — onboarding landing, library login, and settings re-login. Default state is hidden (eye-with-slash); tap reveals plaintext and swaps the icon. Extracted as `PasswordTrailingIcons` so all three sites share the same widget.

A11y: the eye `IconButton` carries a state-aware `contentDescription` ("Show password" / "Hide password") so TalkBack announces what the next tap will do, and the button is disabled when the field is empty so screen readers skip past a no-op control.

Bumps the localization submodule for the two new shared keys and refreshes the checked-in app/ + wear/ string XMLs.