### PR TITLE
Allow user-defined course names with revert to default option

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
@@ -130,7 +130,7 @@ class LiveActivityResolver {
         val progress = (elapsed.toDouble() / total.toDouble()).coerceIn(0.0, 1.0)
         return LiveActivitySnapshot(
             scenario = LiveActivityScenario.IN_CLASS,
-            title = slot.course.courseName,
+            title = slot.course.displayName,
             subtitle = formatTimeRange(slot.start, slot.end),
             locationText = slot.course.classroom.ifBlank { null },
             instructor = slot.course.instructor.ifBlank { null },
@@ -144,7 +144,7 @@ class LiveActivityResolver {
     private fun classPreparingSnapshot(slot: Slot, accentHex: Int): LiveActivitySnapshot =
         LiveActivitySnapshot(
             scenario = LiveActivityScenario.CLASS_PREPARING,
-            title = slot.course.courseName,
+            title = slot.course.displayName,
             subtitle = formatTimeRange(slot.start, slot.end),
             locationText = slot.course.classroom.ifBlank { null },
             instructor = slot.course.instructor.ifBlank { null },

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationScheduler.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationScheduler.kt
@@ -65,7 +65,7 @@ class ClassPreparingNotificationScheduler @Inject constructor(
             val intent = Intent(context, ClassPreparingNotificationReceiver::class.java).apply {
                 putExtra(
                     ClassPreparingNotificationReceiver.EXTRA_COURSE_NAME,
-                    slot.course.courseName
+                    slot.course.displayName
                 )
                 putExtra(ClassPreparingNotificationReceiver.EXTRA_CLASSROOM, slot.course.classroom)
                 putExtra(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ConflictCoursePickerSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ConflictCoursePickerSheet.kt
@@ -71,7 +71,7 @@ private fun ConflictCourseRow(course: Course, onPick: (Course) -> Unit) {
         Spacer(Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                course.courseName,
+                course.displayName,
                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
             )
             val subtitle = buildString {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/CourseCard.kt
@@ -72,7 +72,7 @@ fun CourseCard(
                     .padding(12.dp)
             ) {
                 Text(
-                    text = courseNameForDisplay(course.courseName, maxChars = 28),
+                    text = courseNameForDisplay(course.displayName, maxChars = 28),
                     style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = textAlpha),
                     maxLines = 2,
@@ -164,7 +164,7 @@ fun CurrentClassCard(
                 }
                 Spacer(Modifier.height(6.dp))
                 Text(
-                    text = courseNameForDisplay(course.courseName, maxChars = 28),
+                    text = courseNameForDisplay(course.displayName, maxChars = 28),
                     style = MaterialTheme.typography.bodyMedium
                         .copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.onSurface,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -407,7 +407,7 @@ fun ClassTableScreen(
                         Spacer(Modifier.width(8.dp))
                         TextButton(
                             onClick = {
-                                viewModel.revertCourseName(course.courseNo)
+                                if (hasOverride) viewModel.revertCourseName(course.courseNo)
                                 courseToRename = null
                             },
                             enabled = canRevert,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -407,8 +407,12 @@ fun ClassTableScreen(
                         Spacer(Modifier.width(8.dp))
                         TextButton(
                             onClick = {
-                                if (hasOverride) viewModel.revertCourseName(course.courseNo)
-                                courseToRename = null
+                                if (hasOverride) {
+                                    viewModel.revertCourseName(course.courseNo)
+                                    courseToRename = null
+                                } else {
+                                    renameText = defaultName
+                                }
                             },
                             enabled = canRevert,
                             contentPadding = PaddingValues(horizontal = 8.dp),

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.Book
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -280,7 +281,7 @@ fun ClassTableScreen(
                         weekdays = activeWeekdays,
                         periods = activePeriods,
                         onRename = { course ->
-                            renameText = course.courseName
+                            renameText = course.displayName
                             courseToRename = course
                         },
                         onDelete = { course ->
@@ -305,7 +306,30 @@ fun ClassTableScreen(
     selectedCourse?.let { course ->
         AlertDialog(
             onDismissRequest = { viewModel.clearSelection() },
-            title = { Text(viewModel.selectedCourseFullName ?: course.courseName) },
+            title = {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = viewModel.selectedCourseFullName ?: course.displayName,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.headlineSmall,
+                    )
+                    IconButton(
+                        onClick = {
+                            renameText = course.displayName
+                            courseToRename = course
+                            viewModel.clearSelection()
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Edit,
+                            contentDescription = stringResource(R.string.class_table_rename_title),
+                        )
+                    }
+                }
+            },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(stringResource(R.string.class_table_course_no_value, course.courseNo))
@@ -344,21 +368,62 @@ fun ClassTableScreen(
     }
 
     courseToRename?.let { course ->
+        val defaultName = remember(course) { viewModel.defaultNameFor(course) }
+        val trimmed = renameText.trim()
+        val hasOverride = course.customCourseName != null
+        // Revert is meaningful when a stored override exists OR the user has
+        // typed away from the default; either way it restores the default.
+        val canRevert = hasOverride || (trimmed.isNotEmpty() && trimmed != defaultName)
         AlertDialog(
             onDismissRequest = { courseToRename = null },
             title = { Text(stringResource(R.string.class_table_rename_title)) },
             text = {
-                OutlinedTextField(
-                    value = renameText,
-                    onValueChange = { renameText = it },
-                    label = { Text(stringResource(R.string.class_table_course_name)) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth()
-                )
+                Column {
+                    OutlinedTextField(
+                        value = renameText,
+                        onValueChange = { renameText = it },
+                        label = { Text(stringResource(R.string.class_table_course_name)) },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(
+                            text = stringResource(
+                                R.string.class_table_rename_default_label,
+                                defaultName,
+                            ),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(
+                                alpha = ContentAlpha.SECONDARY,
+                            ),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        TextButton(
+                            onClick = {
+                                viewModel.revertCourseName(course.courseNo)
+                                courseToRename = null
+                            },
+                            enabled = canRevert,
+                            contentPadding = PaddingValues(horizontal = 8.dp),
+                        ) {
+                            Text(
+                                stringResource(R.string.class_table_rename_revert),
+                                maxLines = 1,
+                            )
+                        }
+                    }
+                }
             },
             confirmButton = {
                 TextButton(onClick = {
-                    viewModel.renameCourse(course.courseNo, renameText)
+                    viewModel.setCustomCourseName(course.courseNo, renameText)
                     courseToRename = null
                 }) { Text(stringResource(R.string.action_confirm)) }
             },
@@ -366,7 +431,7 @@ fun ClassTableScreen(
                 TextButton(onClick = { courseToRename = null }) {
                     Text(stringResource(R.string.action_cancel))
                 }
-            }
+            },
         )
     }
 
@@ -382,7 +447,7 @@ fun ClassTableScreen(
                 .toSet()
         }
         ColorPickerSheet(
-            courseName = course.courseName,
+            courseName = course.displayName,
             currentColor = currentColor,
             presetPalette = displayPalette,
             usedByOthers = usedByOthers,
@@ -431,8 +496,8 @@ fun ClassTableScreen(
                         err.newCourseName,
                         dayLabel,
                         err.periodId,
-                        err.existingA.courseName,
-                        err.existingB.courseName,
+                        err.existingA.displayName,
+                        err.existingB.displayName,
                     ),
                 )
             },
@@ -710,7 +775,7 @@ private fun SoloCourseCell(
     var showMenu by remember { mutableStateOf(false) }
     val assignmentLabel = stringResource(R.string.a11y_class_table_cell_assignment_indicator)
     val cellLabel = buildString {
-        append(course.courseName)
+        append(course.displayName)
         if (course.classroom.isNotBlank()) {
             append(", ")
             append(course.classroom)
@@ -741,7 +806,7 @@ private fun SoloCourseCell(
             ),
     ) {
         ClassTableCourseNameText(
-            text = course.courseName,
+            text = course.displayName,
             color = cellTextColor,
             maxLines = if (spanCount >= 2) 3 else 2,
             modifier = Modifier
@@ -879,7 +944,7 @@ private fun ConflictCourseCell(
             fun cellLabel(course: Course, hasAssignment: Boolean): String = buildString {
                 append(conflictPrefix)
                 append(": ")
-                append(course.courseName)
+                append(course.displayName)
                 if (course.classroom.isNotBlank()) {
                     append(", ")
                     append(course.classroom)
@@ -920,7 +985,7 @@ private fun ConflictCourseCell(
                     contentAlignment = Alignment.Center,
                 ) {
                     ClassTableCourseNameText(
-                        text = cellRole.courseA.courseName,
+                        text = cellRole.courseA.displayName,
                         color = textColor,
                         maxLines = 2,
                     )
@@ -966,7 +1031,7 @@ private fun ConflictCourseCell(
                     contentAlignment = Alignment.Center,
                 ) {
                     ClassTableCourseNameText(
-                        text = cellRole.courseB.courseName,
+                        text = cellRole.courseB.displayName,
                         color = textColor,
                         maxLines = 2,
                     )
@@ -996,7 +1061,7 @@ private fun ConflictCourseCell(
                             Text(
                                 stringResource(
                                     R.string.class_table_rename_with_course,
-                                    course.courseName,
+                                    course.displayName,
                                 )
                             )
                         },
@@ -1007,7 +1072,7 @@ private fun ConflictCourseCell(
                             Text(
                                 stringResource(
                                     R.string.class_table_pick_color_with_course,
-                                    course.courseName,
+                                    course.displayName,
                                 )
                             )
                         },
@@ -1018,7 +1083,7 @@ private fun ConflictCourseCell(
                             Text(
                                 stringResource(
                                     R.string.class_table_delete_with_course,
-                                    course.courseName,
+                                    course.displayName,
                                 ),
                                 color = MaterialTheme.colorScheme.error,
                             )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -281,7 +281,7 @@ fun ClassTableScreen(
                         weekdays = activeWeekdays,
                         periods = activePeriods,
                         onRename = { course ->
-                            renameText = course.displayName
+                            renameText = course.customCourseName ?: viewModel.defaultNameFor(course)
                             courseToRename = course
                         },
                         onDelete = { course ->
@@ -318,7 +318,7 @@ fun ClassTableScreen(
                     )
                     IconButton(
                         onClick = {
-                            renameText = course.displayName
+                            renameText = course.customCourseName ?: viewModel.defaultNameFor(course)
                             courseToRename = course
                             viewModel.clearSelection()
                         },

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -260,23 +260,15 @@ class ClassTableViewModel @Inject constructor(
         }
 
     /**
-     * The default (non-overridden) name for the selected course — full name
-     * from cache when available, else the derived [Course.courseName]. Used by
-     * the rename dialog as the "what revert restores" preview.
+     * The default (non-overridden) name for [course] — full name from the
+     * lookup cache when available, else the derived [Course.courseName].
+     * Matches the source the popup title uses, so the rename dialog stays
+     * consistent whether opened from the popup's edit pencil or a cell
+     * long-press.
      */
-    val selectedCourseDefaultName: String?
-        get() {
-            val course = _selectedCourse.value ?: return null
-            return courseService.cachedFullCourseName(_currentSemester.value, course.courseNo)
-                ?: course.courseName
-        }
-
-    /**
-     * The default (non-overridden) name for [course] — derived [Course.courseName]
-     * (which already reflects the abbreviation toggle). Used by the rename dialog
-     * to show what "Revert to default" will restore.
-     */
-    fun defaultNameFor(course: Course): String = course.courseName
+    fun defaultNameFor(course: Course): String =
+        courseService.cachedFullCourseName(_currentSemester.value, course.courseNo)
+            ?: course.courseName
 
     val selectedCourseTimeRange: String?
         get() {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -247,16 +247,36 @@ class ClassTableViewModel @Inject constructor(
         }
 
     /**
-     * Full (un-abbreviated) name of the selected course, looked up from the
-     * course-detail cache. Falls back to null when no lookup entry exists
-     * (manual entries, Moodle-only fallbacks); the popup uses the stored
-     * [Course.courseName] in that case.
+     * Title for the course-detail popup. A user-supplied [Course.customCourseName]
+     * wins; otherwise falls back to the cached full (un-abbreviated) name from
+     * the course-detail lookup, then to the stored [Course.courseName] when no
+     * cache entry exists (manual entries, Moodle-only fallbacks).
      */
     val selectedCourseFullName: String?
         get() {
             val course = _selectedCourse.value ?: return null
+            course.customCourseName?.let { return it }
             return courseService.cachedFullCourseName(_currentSemester.value, course.courseNo)
         }
+
+    /**
+     * The default (non-overridden) name for the selected course — full name
+     * from cache when available, else the derived [Course.courseName]. Used by
+     * the rename dialog as the "what revert restores" preview.
+     */
+    val selectedCourseDefaultName: String?
+        get() {
+            val course = _selectedCourse.value ?: return null
+            return courseService.cachedFullCourseName(_currentSemester.value, course.courseNo)
+                ?: course.courseName
+        }
+
+    /**
+     * The default (non-overridden) name for [course] — derived [Course.courseName]
+     * (which already reflects the abbreviation toggle). Used by the rename dialog
+     * to show what "Revert to default" will restore.
+     */
+    fun defaultNameFor(course: Course): String = course.courseName
 
     val selectedCourseTimeRange: String?
         get() {
@@ -326,9 +346,29 @@ class ClassTableViewModel @Inject constructor(
         TigerDuckTheme.buildCourseColorMap(updated)
     }
 
-    fun renameCourse(courseNo: String, newName: String) {
-        val updated = _courses.value.map {
-            if (it.courseNo == courseNo) it.copy(courseName = newName) else it
+    /**
+     * Sets the user-supplied display override for [courseNo]. A blank input or
+     * one that matches the current default ([Course.courseName]) clears the
+     * override so the course re-follows the abbreviation toggle.
+     */
+    fun setCustomCourseName(courseNo: String, newName: String) {
+        val trimmed = newName.trim()
+        val updated = _courses.value.map { course ->
+            if (course.courseNo != courseNo) return@map course
+            val override = trimmed.takeIf { it.isNotEmpty() && it != course.courseName }
+            course.copy(customCourseName = override)
+        }
+        _courses.value = updated
+        viewModelScope.launch {
+            dataCache.saveCourses(updated, _currentSemester.value)
+            widgetUpdater.requestUpdate()
+        }
+    }
+
+    /** Clears any user override for [courseNo], restoring the default name. */
+    fun revertCourseName(courseNo: String) {
+        val updated = _courses.value.map { course ->
+            if (course.courseNo == courseNo) course.copy(customCourseName = null) else course
         }
         _courses.value = updated
         viewModelScope.launch {
@@ -685,6 +725,7 @@ class ClassTableViewModel @Inject constructor(
                                 c.copy(
                                     customColorHex = prior?.customColorHex,
                                     isManual = prior?.isManual == true,
+                                    customCourseName = prior?.customCourseName,
                                 )
                             }
                             val fetchedNos = fetched.map { it.courseNo }.toSet()

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -340,14 +340,18 @@ class ClassTableViewModel @Inject constructor(
 
     /**
      * Sets the user-supplied display override for [courseNo]. A blank input or
-     * one that matches the current default ([Course.courseName]) clears the
-     * override so the course re-follows the abbreviation toggle.
+     * one that matches the current default — either the abbreviation-aware
+     * [Course.courseName] or the full cached name the rename dialog prefilled
+     * — clears the override so the course re-follows the abbreviation toggle.
      */
     fun setCustomCourseName(courseNo: String, newName: String) {
         val trimmed = newName.trim()
         val updated = _courses.value.map { course ->
             if (course.courseNo != courseNo) return@map course
-            val override = trimmed.takeIf { it.isNotEmpty() && it != course.courseName }
+            val defaultName = defaultNameFor(course)
+            val override = trimmed.takeIf {
+                it.isNotEmpty() && it != course.courseName && it != defaultName
+            }
             course.copy(customCourseName = override)
         }
         _courses.value = updated

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -566,7 +566,7 @@ private fun CourseDetailDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text(course.courseName) },
+        title = { Text(course.displayName) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/TimeSliderSection.kt
@@ -494,7 +494,7 @@ private fun SlotCard(
                 }
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    courseNameForDisplay(slot.course.courseName, maxChars = 30),
+                    courseNameForDisplay(slot.course.displayName, maxChars = 30),
                     style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                     color = if (isSkipped) Color(0xFFFF2D55) else Color.Unspecified,
                     maxLines = 2,

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
@@ -117,6 +117,6 @@ object WidgetDataLoader {
             } ?: return null to null
         val firstPeriodId = course.schedule[tomorrowWeekday]!!
             .minByOrNull { order.indexOf(it) }!!
-        return course.courseName to AppConstants.PeriodTimes.mapping[firstPeriodId]?.first
+        return course.displayName to AppConstants.PeriodTimes.mapping[firstPeriodId]?.first
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
@@ -95,7 +95,7 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                 Spacer(GlanceModifier.width(8.dp))
                 Column(modifier = GlanceModifier.defaultWeight()) {
                     Text(
-                        text = first.courseName,
+                        text = first.displayName,
                         style = TextStyle(
                             color = ColorProvider(colors.onSurface),
                             fontSize = 15.sp,
@@ -105,7 +105,7 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                     )
                     val second = ongoing.getOrNull(1)
                     Text(
-                        text = if (second != null) second.courseName else buildString {
+                        text = if (second != null) second.displayName else buildString {
                             if (endTime.isNotEmpty()) {
                                 append(context.getString(R.string.widget_until_time, endTime))
                             }
@@ -142,7 +142,7 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                 Spacer(GlanceModifier.width(8.dp))
                 Column(modifier = GlanceModifier.defaultWeight()) {
                     Text(
-                        text = course.courseName,
+                        text = course.displayName,
                         style = TextStyle(
                             color = ColorProvider(colors.onSurface),
                             fontSize = 15.sp,
@@ -298,7 +298,7 @@ private fun OngoingCard(course: Course, state: WidgetState, colors: WidgetColors
         }
         Spacer(GlanceModifier.height(6.dp))
         Text(
-            text = course.courseName,
+            text = course.displayName,
             style = TextStyle(
                 color = ColorProvider(colors.onSurface),
                 fontSize = 19.sp,
@@ -370,7 +370,7 @@ private fun OngoingMiniCard(course: Course, state: WidgetState, colors: WidgetCo
         }
         Spacer(GlanceModifier.width(5.dp))
         Text(
-            text = course.courseName,
+            text = course.displayName,
             style = TextStyle(
                 color = ColorProvider(colors.onSurface),
                 fontSize = 13.sp,
@@ -424,7 +424,7 @@ private fun NextCard(course: Course, state: WidgetState, colors: WidgetColors) {
     )
     Spacer(GlanceModifier.height(5.dp))
     Text(
-        text = course.courseName,
+        text = course.displayName,
         style = TextStyle(
             color = ColorProvider(colors.onSurface),
             fontSize = 19.sp,

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
@@ -153,7 +153,7 @@ fun TodayListContent(state: WidgetState, colors: WidgetColors, tapAction: Action
                             modifier = GlanceModifier.defaultWeight().padding(start = 6.dp),
                         ) {
                             Text(
-                                text = course.courseName,
+                                text = course.displayName,
                                 style = TextStyle(
                                     color = ColorProvider(primaryText),
                                     fontSize = 14.sp,

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/WeekGridContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/WeekGridContent.kt
@@ -261,7 +261,7 @@ private fun SoloCell(
             contentAlignment = Alignment.Center,
         ) {
             Text(
-                text = course.courseName,
+                text = course.displayName,
                 style = TextStyle(
                     color = ColorProvider(textColor),
                     fontSize = 10.sp,

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">قم بتسجيل الدخول لعرض جدول صفك</string>
     <string name="class_table_pick_color">اختر لونًا</string>
     <string name="class_table_pick_color_with_course">اختر لونًا — %1$s</string>
+    <string name="class_table_rename_default_label">الافتراضي: %1$s</string>
+    <string name="class_table_rename_revert">العودة إلى الافتراضي</string>
     <string name="class_table_rename_title">إعادة التسمية</string>
     <string name="class_table_rename_with_course">إعادة التسمية — %1$s</string>
     <string name="class_table_semester_picker_label">الفصل الدراسي</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Влезте, за да видите таблицата на вашия клас</string>
     <string name="class_table_pick_color">Избор на цвят</string>
     <string name="class_table_pick_color_with_course">Избор на цвят — %1$s</string>
+    <string name="class_table_rename_default_label">По подразбиране: %1$s</string>
+    <string name="class_table_rename_revert">Връщане към подразбиране</string>
     <string name="class_table_rename_title">Преименуване</string>
     <string name="class_table_rename_with_course">Преименуване — %1$s</string>
     <string name="class_table_semester_picker_label">Семестър</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">আপনার ক্লাস টেবিল দেখতে সাইন ইন করুন</string>
     <string name="class_table_pick_color">রং বেছে নিন</string>
     <string name="class_table_pick_color_with_course">রং বেছে নিন — %1$s</string>
+    <string name="class_table_rename_default_label">ডিফল্ট: %1$s</string>
+    <string name="class_table_rename_revert">ডিফল্টে ফিরে যান</string>
     <string name="class_table_rename_title">নাম পরিবর্তন</string>
     <string name="class_table_rename_with_course">নাম পরিবর্তন — %1$s</string>
     <string name="class_table_semester_picker_label">সেমিস্টার</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Inicieu la sessió per veure la vostra taula de classe</string>
     <string name="class_table_pick_color">Tria un color</string>
     <string name="class_table_pick_color_with_course">Tria un color — %1$s</string>
+    <string name="class_table_rename_default_label">Per defecte: %1$s</string>
+    <string name="class_table_rename_revert">Restablir per defecte</string>
     <string name="class_table_rename_title">Reanomena</string>
     <string name="class_table_rename_with_course">Reanomena — %1$s</string>
     <string name="class_table_semester_picker_label">Semestre</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Chcete-li zobrazit tabulku třídy, přihlaste se</string>
     <string name="class_table_pick_color">Vybrat barvu</string>
     <string name="class_table_pick_color_with_course">Vybrat barvu — %1$s</string>
+    <string name="class_table_rename_default_label">Výchozí: %1$s</string>
+    <string name="class_table_rename_revert">Obnovit výchozí</string>
     <string name="class_table_rename_title">Přejmenovat</string>
     <string name="class_table_rename_with_course">Přejmenovat — %1$s</string>
     <string name="class_table_semester_picker_label">Semestr</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Log ind for at se din klassetabel</string>
     <string name="class_table_pick_color">Vælg farve</string>
     <string name="class_table_pick_color_with_course">Vælg farve — %1$s</string>
+    <string name="class_table_rename_default_label">Standard: %1$s</string>
+    <string name="class_table_rename_revert">Gendan standard</string>
     <string name="class_table_rename_title">Omdøb</string>
     <string name="class_table_rename_with_course">Omdøb — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Farbe wählen</string>
     <string name="class_table_pick_color_with_course">Farbe wählen — %1$s</string>
+    <string name="class_table_rename_default_label">Standard: %1$s</string>
+    <string name="class_table_rename_revert">Auf Standard zurücksetzen</string>
     <string name="class_table_rename_title">Umbenennen</string>
     <string name="class_table_rename_with_course">Umbenennen — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Συνδεθείτε για να δείτε τον πίνακα της τάξης σας</string>
     <string name="class_table_pick_color">Επιλογή χρώματος</string>
     <string name="class_table_pick_color_with_course">Επιλογή χρώματος — %1$s</string>
+    <string name="class_table_rename_default_label">Προεπιλογή: %1$s</string>
+    <string name="class_table_rename_revert">Επαναφορά προεπιλογής</string>
     <string name="class_table_rename_title">Μετονομασία</string>
     <string name="class_table_rename_with_course">Μετονομασία — %1$s</string>
     <string name="class_table_semester_picker_label">Ακαδημαϊκό εξάμηνο</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Sign in to view your class table</string>
     <string name="class_table_pick_color">Pick colour</string>
     <string name="class_table_pick_color_with_course">Pick colour — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Revert to default</string>
     <string name="class_table_rename_title">Rename</string>
     <string name="class_table_rename_with_course">Rename — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Sign in to view your class table</string>
     <string name="class_table_pick_color">Pick color</string>
     <string name="class_table_pick_color_with_course">Pick color — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Revert to default</string>
     <string name="class_table_rename_title">Rename</string>
     <string name="class_table_rename_with_course">Rename — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Sign in to view your class table</string>
     <string name="class_table_pick_color">Pick colour</string>
     <string name="class_table_pick_color_with_course">Pick colour — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Revert to default</string>
     <string name="class_table_rename_title">Rename</string>
     <string name="class_table_rename_with_course">Rename — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Sign in to view your class table</string>
     <string name="class_table_pick_color">Pick color</string>
     <string name="class_table_pick_color_with_course">Pick color — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Revert to default</string>
     <string name="class_table_rename_title">Rename</string>
     <string name="class_table_rename_with_course">Rename — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Inicia sesión para ver tu tabla de clases</string>
     <string name="class_table_pick_color">Elegir color</string>
     <string name="class_table_pick_color_with_course">Elegir color — %1$s</string>
+    <string name="class_table_rename_default_label">Predeterminado: %1$s</string>
+    <string name="class_table_rename_revert">Restablecer predeterminado</string>
     <string name="class_table_rename_title">Renombrar</string>
     <string name="class_table_rename_with_course">Renombrar — %1$s</string>
     <string name="class_table_semester_picker_label">Semestre</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Inicia sesión para ver tu tabla de clases</string>
     <string name="class_table_pick_color">Elegir color</string>
     <string name="class_table_pick_color_with_course">Elegir color — %1$s</string>
+    <string name="class_table_rename_default_label">Predeterminado: %1$s</string>
+    <string name="class_table_rename_revert">Restablecer predeterminado</string>
     <string name="class_table_rename_title">Renombrar</string>
     <string name="class_table_rename_with_course">Renombrar — %1$s</string>
     <string name="class_table_semester_picker_label">Semestre</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Oma klassitabeli vaatamiseks logige sisse</string>
     <string name="class_table_pick_color">Vali värv</string>
     <string name="class_table_pick_color_with_course">Vali värv — %1$s</string>
+    <string name="class_table_rename_default_label">Vaikimisi: %1$s</string>
+    <string name="class_table_rename_revert">Lähtesta vaikimisi</string>
     <string name="class_table_rename_title">Nimeta ümber</string>
     <string name="class_table_rename_with_course">Nimeta ümber — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">برای مشاهده جدول کلاس خود وارد شوید</string>
     <string name="class_table_pick_color">انتخاب رنگ</string>
     <string name="class_table_pick_color_with_course">انتخاب رنگ — %1$s</string>
+    <string name="class_table_rename_default_label">پیش‌فرض: %1$s</string>
+    <string name="class_table_rename_revert">بازگرداندن به پیش‌فرض</string>
     <string name="class_table_rename_title">تغییر نام</string>
     <string name="class_table_rename_with_course">تغییر نام — %1$s</string>
     <string name="class_table_semester_picker_label">ترم</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Kirjaudu sisään nähdäksesi luokkataulukkosi</string>
     <string name="class_table_pick_color">Valitse väri</string>
     <string name="class_table_pick_color_with_course">Valitse väri — %1$s</string>
+    <string name="class_table_rename_default_label">Oletus: %1$s</string>
+    <string name="class_table_rename_revert">Palauta oletus</string>
     <string name="class_table_rename_title">Nimeä uudelleen</string>
     <string name="class_table_rename_with_course">Nimeä uudelleen — %1$s</string>
     <string name="class_table_semester_picker_label">Lukukausi</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Mag-sign in upang tingnan ang iyong talahanayan ng klase</string>
     <string name="class_table_pick_color">Pumili ng kulay</string>
     <string name="class_table_pick_color_with_course">Pumili ng kulay — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Ibalik sa default</string>
     <string name="class_table_rename_title">Palitan ng pangalan</string>
     <string name="class_table_rename_with_course">Palitan ng pangalan — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Connectez-vous pour voir votre tableau de classe</string>
     <string name="class_table_pick_color">Choisir une couleur</string>
     <string name="class_table_pick_color_with_course">Choisir une couleur — %1$s</string>
+    <string name="class_table_rename_default_label">Par défaut : %1$s</string>
+    <string name="class_table_rename_revert">Rétablir par défaut</string>
     <string name="class_table_rename_title">Renommer</string>
     <string name="class_table_rename_with_course">Renommer — %1$s</string>
     <string name="class_table_semester_picker_label">Semestre</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Connectez-vous pour voir votre tableau de classe</string>
     <string name="class_table_pick_color">Choisir une couleur</string>
     <string name="class_table_pick_color_with_course">Choisir une couleur — %1$s</string>
+    <string name="class_table_rename_default_label">Par défaut : %1$s</string>
+    <string name="class_table_rename_revert">Rétablir par défaut</string>
     <string name="class_table_rename_title">Renommer</string>
     <string name="class_table_rename_with_course">Renommer — %1$s</string>
     <string name="class_table_semester_picker_label">Semestre</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">તમારું વર્ગ કોષ્ટક જોવા માટે સાઇન ઇન કરો</string>
     <string name="class_table_pick_color">રંગ પસંદ કરો</string>
     <string name="class_table_pick_color_with_course">રંગ પસંદ કરો — %1$s</string>
+    <string name="class_table_rename_default_label">ડિફૉલ્ટ: %1$s</string>
+    <string name="class_table_rename_revert">ડિફૉલ્ટ પર પાછા ફરો</string>
     <string name="class_table_rename_title">નામ બદલો</string>
     <string name="class_table_rename_with_course">નામ બદલો — %1$s</string>
     <string name="class_table_semester_picker_label">સેમેસ્ટર </string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">अपनी क्लास टेबल देखने के लिए साइन इन करें</string>
     <string name="class_table_pick_color">रंग चुनें</string>
     <string name="class_table_pick_color_with_course">रंग चुनें — %1$s</string>
+    <string name="class_table_rename_default_label">डिफ़ॉल्ट: %1$s</string>
+    <string name="class_table_rename_revert">डिफ़ॉल्ट पर लौटें</string>
     <string name="class_table_rename_title">नाम बदलें</string>
     <string name="class_table_rename_with_course">नाम बदलें — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Odaberi boju</string>
     <string name="class_table_pick_color_with_course">Odaberi boju — %1$s</string>
+    <string name="class_table_rename_default_label">Zadano: %1$s</string>
+    <string name="class_table_rename_revert">Vrati na zadano</string>
     <string name="class_table_rename_title">Preimenovanje</string>
     <string name="class_table_rename_with_course">Preimenovanje — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Szín kiválasztása</string>
     <string name="class_table_pick_color_with_course">Szín kiválasztása — %1$s</string>
+    <string name="class_table_rename_default_label">Alapértelmezett: %1$s</string>
+    <string name="class_table_rename_revert">Alapértelmezett visszaállítása</string>
     <string name="class_table_rename_title">Átnevezés</string>
     <string name="class_table_rename_with_course">Átnevezés — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Masuk untuk melihat jadwal kelas Anda</string>
     <string name="class_table_pick_color">Pilih warna</string>
     <string name="class_table_pick_color_with_course">Pilih warna — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Kembalikan ke default</string>
     <string name="class_table_rename_title">Ganti nama</string>
     <string name="class_table_rename_with_course">Ganti nama — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Velja lit</string>
     <string name="class_table_pick_color_with_course">Velja lit — %1$s</string>
+    <string name="class_table_rename_default_label">Sjálfgefið: %1$s</string>
+    <string name="class_table_rename_revert">Endurstilla á sjálfgefið</string>
     <string name="class_table_rename_title">Endurnefna</string>
     <string name="class_table_rename_with_course">Endurnefna — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Accedi per visualizzare il tuo orario delle lezioni</string>
     <string name="class_table_pick_color">Scegli colore</string>
     <string name="class_table_pick_color_with_course">Scegli colore — %1$s</string>
+    <string name="class_table_rename_default_label">Predefinito: %1$s</string>
+    <string name="class_table_rename_revert">Ripristina predefinito</string>
     <string name="class_table_rename_title">Rinomina</string>
     <string name="class_table_rename_with_course">Rinomina — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">היכנס כדי להציג את טבלת הכיתה שלך</string>
     <string name="class_table_pick_color">בחר צבע</string>
     <string name="class_table_pick_color_with_course">בחר צבע — %1$s</string>
+    <string name="class_table_rename_default_label">ברירת מחדל: %1$s</string>
+    <string name="class_table_rename_revert">חזור לברירת המחדל</string>
     <string name="class_table_rename_title">שנה שם</string>
     <string name="class_table_rename_with_course">שנה שם — %1$s</string>
     <string name="class_table_semester_picker_label">שנת הלימודים</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">時間割を表示するにはサインインしてください</string>
     <string name="class_table_pick_color">色を選択</string>
     <string name="class_table_pick_color_with_course">色を選択 — %1$s</string>
+    <string name="class_table_rename_default_label">デフォルト：%1$s</string>
+    <string name="class_table_rename_revert">デフォルトに戻す</string>
     <string name="class_table_rename_title">名前を変更</string>
     <string name="class_table_rename_with_course">名前を変更 — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Сабақ кестесін қарау үшін жүйеге кіріңіз</string>
     <string name="class_table_pick_color">Түс таңдау</string>
     <string name="class_table_pick_color_with_course">Түс таңдау — %1$s</string>
+    <string name="class_table_rename_default_label">Әдепкі: %1$s</string>
+    <string name="class_table_rename_revert">Әдепкіге қайтару</string>
     <string name="class_table_rename_title">Атауын өзгерту</string>
     <string name="class_table_rename_with_course">Атауын өзгерту — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">ನಿಮ್ಮ ತರಗತಿ ವೇಳಾಪಟ್ಟಿ ನೋಡಲು ಸೈನ್ ಇನ್ ಮಾಡಿ</string>
     <string name="class_table_pick_color">ಬಣ್ಣ ಆರಿಸಿ</string>
     <string name="class_table_pick_color_with_course">ಬಣ್ಣ ಆರಿಸಿ — %1$s</string>
+    <string name="class_table_rename_default_label">ಡೀಫಾಲ್ಟ್: %1$s</string>
+    <string name="class_table_rename_revert">ಡೀಫಾಲ್ಟ್‌ಗೆ ಮರಳಿಸಿ</string>
     <string name="class_table_rename_title">ಮರುಹೆಸರಿಸಿ</string>
     <string name="class_table_rename_with_course">ಮರುಹೆಸರಿಸಿ — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">시간표를 보려면 로그인하세요</string>
     <string name="class_table_pick_color">색상 선택</string>
     <string name="class_table_pick_color_with_course">색상 선택 — %1$s</string>
+    <string name="class_table_rename_default_label">기본값: %1$s</string>
+    <string name="class_table_rename_revert">기본값으로 되돌리기</string>
     <string name="class_table_rename_title">이름 바꾸기</string>
     <string name="class_table_rename_with_course">이름 바꾸기 — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Pasirinkti spalvą</string>
     <string name="class_table_pick_color_with_course">Pasirinkti spalvą — %1$s</string>
+    <string name="class_table_rename_default_label">Numatytasis: %1$s</string>
+    <string name="class_table_rename_revert">Atkurti numatytąjį</string>
     <string name="class_table_rename_title">Pervadinti</string>
     <string name="class_table_rename_with_course">Pervadinti — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Pierakstieties, lai skatītu savu stundu sarakstu</string>
     <string name="class_table_pick_color">Izvēlēties krāsu</string>
     <string name="class_table_pick_color_with_course">Izvēlēties krāsu — %1$s</string>
+    <string name="class_table_rename_default_label">Noklusējums: %1$s</string>
+    <string name="class_table_rename_revert">Atjaunot noklusējumu</string>
     <string name="class_table_rename_title">Pārsaukt</string>
     <string name="class_table_rename_with_course">Pārsaukt — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">നിങ്ങളുടെ ക്ലാസ് ടേബിൾ കാണാൻ സൈൻ ഇൻ ചെയ്യുക</string>
     <string name="class_table_pick_color">നിറം തിരഞ്ഞെടുക്കുക</string>
     <string name="class_table_pick_color_with_course">നിറം തിരഞ്ഞെടുക്കുക — %1$s</string>
+    <string name="class_table_rename_default_label">സ്ഥിരസ്ഥിതി: %1$s</string>
+    <string name="class_table_rename_revert">സ്ഥിരസ്ഥിതിയിലേക്ക് മടങ്ങുക</string>
     <string name="class_table_rename_title">പുനർനാമകരണം ചെയ്യുക</string>
     <string name="class_table_rename_with_course">പുനർനാമകരണം — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">तुमचा वर्ग तक्ता पाहण्यासाठी साइन इन करा</string>
     <string name="class_table_pick_color">रंग निवडा</string>
     <string name="class_table_pick_color_with_course">रंग निवडा — %1$s</string>
+    <string name="class_table_rename_default_label">डीफॉल्ट: %1$s</string>
+    <string name="class_table_rename_revert">डीफॉल्टवर परत जा</string>
     <string name="class_table_rename_title">नाव बदला</string>
     <string name="class_table_rename_with_course">नाव बदला — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Log masuk untuk melihat jadual kelas anda</string>
     <string name="class_table_pick_color">Pilih warna</string>
     <string name="class_table_pick_color_with_course">Pilih warna — %1$s</string>
+    <string name="class_table_rename_default_label">Lalai: %1$s</string>
+    <string name="class_table_rename_revert">Kembalikan ke lalai</string>
     <string name="class_table_rename_title">Namakan semula</string>
     <string name="class_table_rename_with_course">Namakan semula — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Logg inn for å se timeplanen din</string>
     <string name="class_table_pick_color">Velg farge</string>
     <string name="class_table_pick_color_with_course">Velg farge — %1$s</string>
+    <string name="class_table_rename_default_label">Standard: %1$s</string>
+    <string name="class_table_rename_revert">Tilbakestill til standard</string>
     <string name="class_table_rename_title">Gi nytt navn</string>
     <string name="class_table_rename_with_course">Gi nytt navn — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Meld je aan om je rooster te bekijken</string>
     <string name="class_table_pick_color">Kleur kiezen</string>
     <string name="class_table_pick_color_with_course">Kleur kiezen — %1$s</string>
+    <string name="class_table_rename_default_label">Standaard: %1$s</string>
+    <string name="class_table_rename_revert">Standaard herstellen</string>
     <string name="class_table_rename_title">Naam wijzigen</string>
     <string name="class_table_rename_with_course">Naam wijzigen — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Logg inn for å se timeplanen din</string>
     <string name="class_table_pick_color">Velg farge</string>
     <string name="class_table_pick_color_with_course">Velg farge — %1$s</string>
+    <string name="class_table_rename_default_label">Standard: %1$s</string>
+    <string name="class_table_rename_revert">Tilbakestill til standard</string>
     <string name="class_table_rename_title">Gi nytt navn</string>
     <string name="class_table_rename_with_course">Gi nytt navn — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">ਆਪਣੀ ਕਲਾਸ ਟੇਬਲ ਦੇਖਣ ਲਈ ਸਾਈਨ ਇਨ ਕਰੋ</string>
     <string name="class_table_pick_color">ਰੰਗ ਚੁਣੋ</string>
     <string name="class_table_pick_color_with_course">ਰੰਗ ਚੁਣੋ — %1$s</string>
+    <string name="class_table_rename_default_label">ਡਿਫਾਲਟ: %1$s</string>
+    <string name="class_table_rename_revert">ਡਿਫਾਲਟ \'ਤੇ ਵਾਪਸ ਜਾਓ</string>
     <string name="class_table_rename_title">ਨਾਂ ਬਦਲੋ</string>
     <string name="class_table_rename_with_course">ਨਾਂ ਬਦਲੋ — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Wybierz kolor</string>
     <string name="class_table_pick_color_with_course">Wybierz kolor — %1$s</string>
+    <string name="class_table_rename_default_label">Domyślnie: %1$s</string>
+    <string name="class_table_rename_revert">Przywróć domyślne</string>
     <string name="class_table_rename_title">Zmień nazwę</string>
     <string name="class_table_rename_with_course">Zmień nazwę — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Faça login para ver sua grade de aulas</string>
     <string name="class_table_pick_color">Escolher cor</string>
     <string name="class_table_pick_color_with_course">Escolher cor — %1$s</string>
+    <string name="class_table_rename_default_label">Padrão: %1$s</string>
+    <string name="class_table_rename_revert">Restaurar padrão</string>
     <string name="class_table_rename_title">Renomear</string>
     <string name="class_table_rename_with_course">Renomear — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Inicia sessão para ver o teu horário</string>
     <string name="class_table_pick_color">Escolher cor</string>
     <string name="class_table_pick_color_with_course">Escolher cor — %1$s</string>
+    <string name="class_table_rename_default_label">Predefinição: %1$s</string>
+    <string name="class_table_rename_revert">Restaurar predefinição</string>
     <string name="class_table_rename_title">Mudar o nome</string>
     <string name="class_table_rename_with_course">Mudar o nome — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Inicia sessão para ver o teu horário</string>
     <string name="class_table_pick_color">Escolher cor</string>
     <string name="class_table_pick_color_with_course">Escolher cor — %1$s</string>
+    <string name="class_table_rename_default_label">Predefinição: %1$s</string>
+    <string name="class_table_rename_revert">Restaurar predefinição</string>
     <string name="class_table_rename_title">Mudar o nome</string>
     <string name="class_table_rename_with_course">Mudar o nome — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Alege culoare</string>
     <string name="class_table_pick_color_with_course">Alege culoare — %1$s</string>
+    <string name="class_table_rename_default_label">Implicit: %1$s</string>
+    <string name="class_table_rename_revert">Revenire la implicit</string>
     <string name="class_table_rename_title">Redenumire</string>
     <string name="class_table_rename_with_course">Redenumire — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Войдите, чтобы просмотреть расписание занятий</string>
     <string name="class_table_pick_color">Выбрать цвет</string>
     <string name="class_table_pick_color_with_course">Выбрать цвет — %1$s</string>
+    <string name="class_table_rename_default_label">По умолчанию: %1$s</string>
+    <string name="class_table_rename_revert">Вернуть по умолчанию</string>
     <string name="class_table_rename_title">Переименовать</string>
     <string name="class_table_rename_with_course">Переименовать — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Vybrať farbu</string>
     <string name="class_table_pick_color_with_course">Vybrať farbu — %1$s</string>
+    <string name="class_table_rename_default_label">Predvolené: %1$s</string>
+    <string name="class_table_rename_revert">Obnoviť predvolené</string>
     <string name="class_table_rename_title">Premenovať</string>
     <string name="class_table_rename_with_course">Premenovať — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Prijavite se za ogled urnika</string>
     <string name="class_table_pick_color">Izberi barvo</string>
     <string name="class_table_pick_color_with_course">Izberi barvo — %1$s</string>
+    <string name="class_table_rename_default_label">Privzeto: %1$s</string>
+    <string name="class_table_rename_revert">Obnovi privzeto</string>
     <string name="class_table_rename_title">Preimenuj</string>
     <string name="class_table_rename_with_course">Preimenuj — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">Одабери боју</string>
     <string name="class_table_pick_color_with_course">Одабери боју — %1$s</string>
+    <string name="class_table_rename_default_label">Подразумевано: %1$s</string>
+    <string name="class_table_rename_revert">Врати на подразумевано</string>
     <string name="class_table_rename_title">Преименуј</string>
     <string name="class_table_rename_with_course">Преименуј — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Logga in för att visa ditt schema</string>
     <string name="class_table_pick_color">Välj färg</string>
     <string name="class_table_pick_color_with_course">Välj färg — %1$s</string>
+    <string name="class_table_rename_default_label">Standard: %1$s</string>
+    <string name="class_table_rename_revert">Återställ till standard</string>
     <string name="class_table_rename_title">Byt namn</string>
     <string name="class_table_rename_with_course">Byt namn — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">உங்கள் வகுப்பு அட்டவணையை காண உள்நுழையவும்</string>
     <string name="class_table_pick_color">நிறம் தேர்வு</string>
     <string name="class_table_pick_color_with_course">நிறம் தேர்வு — %1$s</string>
+    <string name="class_table_rename_default_label">இயல்புநிலை: %1$s</string>
+    <string name="class_table_rename_revert">இயல்புநிலைக்கு மீட்டமை</string>
     <string name="class_table_rename_title">மறுபெயரிடு</string>
     <string name="class_table_rename_with_course">மறுபெயரிடு — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">మీ క్లాస్ టేబుల్ చూడటానికి సైన్ ఇన్ చేయండి</string>
     <string name="class_table_pick_color">రంగు ఎంచుకోండి</string>
     <string name="class_table_pick_color_with_course">రంగు ఎంచుకోండి — %1$s</string>
+    <string name="class_table_rename_default_label">డిఫాల్ట్: %1$s</string>
+    <string name="class_table_rename_revert">డిఫాల్ట్‌కు తిరిగి వెళ్ళు</string>
     <string name="class_table_rename_title">పేరు మార్చండి</string>
     <string name="class_table_rename_with_course">పేరు మార్చండి — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Melden Sie sich an, um Ihre Klassentabelle anzuzeigen</string>
     <string name="class_table_pick_color">เลือกสี</string>
     <string name="class_table_pick_color_with_course">เลือกสี — %1$s</string>
+    <string name="class_table_rename_default_label">ค่าเริ่มต้น: %1$s</string>
+    <string name="class_table_rename_revert">คืนค่าเริ่มต้น</string>
     <string name="class_table_rename_title">เปลี่ยนชื่อ</string>
     <string name="class_table_rename_with_course">เปลี่ยนชื่อ — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Ders programınızı görmek için oturum açın</string>
     <string name="class_table_pick_color">Renk seç</string>
     <string name="class_table_pick_color_with_course">Renk seç — %1$s</string>
+    <string name="class_table_rename_default_label">Varsayılan: %1$s</string>
+    <string name="class_table_rename_revert">Varsayılana döndür</string>
     <string name="class_table_rename_title">Yeniden adlandır</string>
     <string name="class_table_rename_with_course">Yeniden adlandır — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Увійдіть, щоб переглянути розклад занять</string>
     <string name="class_table_pick_color">Вибрати колір</string>
     <string name="class_table_pick_color_with_course">Вибрати колір — %1$s</string>
+    <string name="class_table_rename_default_label">За замовчуванням: %1$s</string>
+    <string name="class_table_rename_revert">Повернути до типового</string>
     <string name="class_table_rename_title">Перейменувати</string>
     <string name="class_table_rename_with_course">Перейменувати — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">اپنا کلاس ٹیبل دیکھنے کے لیے سائن ان کریں</string>
     <string name="class_table_pick_color">رنگ چنیں</string>
     <string name="class_table_pick_color_with_course">رنگ چنیں — %1$s</string>
+    <string name="class_table_rename_default_label">ڈیفالٹ: %1$s</string>
+    <string name="class_table_rename_revert">ڈیفالٹ پر واپس جائیں</string>
     <string name="class_table_rename_title">نام تبدیل کریں</string>
     <string name="class_table_rename_with_course">نام تبدیل کریں — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Đăng nhập để xem thời khóa biểu</string>
     <string name="class_table_pick_color">Chọn màu</string>
     <string name="class_table_pick_color_with_course">Chọn màu — %1$s</string>
+    <string name="class_table_rename_default_label">Mặc định: %1$s</string>
+    <string name="class_table_rename_revert">Khôi phục mặc định</string>
     <string name="class_table_rename_title">Đổi tên</string>
     <string name="class_table_rename_with_course">Đổi tên — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">尚未登入,無法查看課表</string>
     <string name="class_table_pick_color">選擇顏色</string>
     <string name="class_table_pick_color_with_course">選擇顏色 — %1$s</string>
+    <string name="class_table_rename_default_label">預設：%1$s</string>
+    <string name="class_table_rename_revert">還原預設</string>
     <string name="class_table_rename_title">重新命名</string>
     <string name="class_table_rename_with_course">重新命名 — %1$s</string>
     <string name="class_table_semester_picker_label">學期</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">请登录后查看课程表</string>
     <string name="class_table_pick_color">选择颜色</string>
     <string name="class_table_pick_color_with_course">选择颜色 — %1$s</string>
+    <string name="class_table_rename_default_label">默认：%1$s</string>
+    <string name="class_table_rename_revert">恢复默认</string>
     <string name="class_table_rename_title">重命名</string>
     <string name="class_table_rename_with_course">重命名 — %1$s</string>
     <string name="class_table_semester_picker_label">学期</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">尚未登入,無法查看課表</string>
     <string name="class_table_pick_color">選擇顏色</string>
     <string name="class_table_pick_color_with_course">選擇顏色 — %1$s</string>
+    <string name="class_table_rename_default_label">預設：%1$s</string>
+    <string name="class_table_rename_revert">還原預設</string>
     <string name="class_table_rename_title">重新命名</string>
     <string name="class_table_rename_with_course">重新命名 — %1$s</string>
     <string name="class_table_semester_picker_label">學期</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">尚未登入,無法查看課表</string>
     <string name="class_table_pick_color">選擇顏色</string>
     <string name="class_table_pick_color_with_course">選擇顏色 — %1$s</string>
+    <string name="class_table_rename_default_label">預設：%1$s</string>
+    <string name="class_table_rename_revert">還原預設</string>
     <string name="class_table_rename_title">重新命名</string>
     <string name="class_table_rename_with_course">重新命名 — %1$s</string>
     <string name="class_table_semester_picker_label">學期</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">请登录后查看课程表</string>
     <string name="class_table_pick_color">选择颜色</string>
     <string name="class_table_pick_color_with_course">选择颜色 — %1$s</string>
+    <string name="class_table_rename_default_label">默认：%1$s</string>
+    <string name="class_table_rename_revert">恢复默认</string>
     <string name="class_table_rename_title">重命名</string>
     <string name="class_table_rename_with_course">重命名 — %1$s</string>
     <string name="class_table_semester_picker_label">学期</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">尚未登入,無法查看課表</string>
     <string name="class_table_pick_color">選擇顏色</string>
     <string name="class_table_pick_color_with_course">選擇顏色 — %1$s</string>
+    <string name="class_table_rename_default_label">預設：%1$s</string>
+    <string name="class_table_rename_revert">回復預設</string>
     <string name="class_table_rename_title">重新命名</string>
     <string name="class_table_rename_with_course">重新命名 — %1$s</string>
     <string name="class_table_semester_picker_label">學期</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,8 @@
     <string name="class_table_login_required_message">Sign in to view your class table</string>
     <string name="class_table_pick_color">Pick color</string>
     <string name="class_table_pick_color_with_course">Pick color — %1$s</string>
+    <string name="class_table_rename_default_label">Default: %1$s</string>
+    <string name="class_table_rename_revert">Revert to default</string>
     <string name="class_table_rename_title">Rename</string>
     <string name="class_table_rename_with_course">Rename — %1$s</string>
     <string name="class_table_semester_picker_label">Semester</string>

--- a/shared/src/main/java/org/ntust/app/tigerduck/shared/Course.kt
+++ b/shared/src/main/java/org/ntust/app/tigerduck/shared/Course.kt
@@ -22,7 +22,19 @@ data class Course(
      * Moodle list doesn't include them.
      */
     val isManual: Boolean = false,
+    /**
+     * User-supplied display name override. When non-null, [displayName] returns
+     * this instead of the derived [courseName]. Lets the user customize labels
+     * without losing the underlying default — flipping the abbreviation toggle
+     * still updates [courseName], but anything with a non-null override stays
+     * visually unchanged. Reverting to default sets this back to null.
+     */
+    val customCourseName: String? = null,
 ) {
+    /** Resolved name for display: user override if set, else the derived default. */
+    val displayName: String
+        get() = customCourseName ?: courseName
+
     @Transient
     @Volatile
     private var _cachedSchedule: Map<Int, List<String>>? = null

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/complication/NextClassComplicationService.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/complication/NextClassComplicationService.kt
@@ -63,24 +63,24 @@ class NextClassComplicationService : ComplicationDataSourceService() {
         return when (val r = NextClassResolver.resolve(snapshot.courses, weekday, minuteOfDay)) {
             is NextClassResult.Ongoing -> when (type) {
                 ComplicationType.SHORT_TEXT -> ShortTextComplicationData.Builder(
-                    text = PlainComplicationText.Builder(truncate(r.course.courseName, 7)).build(),
-                    contentDescription = PlainComplicationText.Builder(r.course.courseName).build(),
+                    text = PlainComplicationText.Builder(truncate(r.course.displayName, 7)).build(),
+                    contentDescription = PlainComplicationText.Builder(r.course.displayName).build(),
                 ).setTitle(PlainComplicationText.Builder("NOW").build()).setTapAction(tap).build()
                 ComplicationType.LONG_TEXT -> LongTextComplicationData.Builder(
                     text = PlainComplicationText.Builder(r.course.classroom).build(),
-                    contentDescription = PlainComplicationText.Builder(r.course.courseName).build(),
-                ).setTitle(PlainComplicationText.Builder("NOW · ${truncate(r.course.courseName, 7)}").build())
+                    contentDescription = PlainComplicationText.Builder(r.course.displayName).build(),
+                ).setTitle(PlainComplicationText.Builder("NOW · ${truncate(r.course.displayName, 7)}").build())
                   .setTapAction(tap).build()
                 else -> NoDataComplicationData()
             }
             is NextClassResult.NextToday -> shortOrLong(
-                type, r.course.courseName, r.course.classroom,
+                type, r.course.displayName, r.course.classroom,
                 titleShort = formatHm(r.startMinute),
-                titleLong = "${formatHm(r.startMinute)} · ${truncate(r.course.courseName, 7)}",
+                titleLong = "${formatHm(r.startMinute)} · ${truncate(r.course.displayName, 7)}",
                 tap = tap,
             )
             is NextClassResult.NextFuture -> shortOrLong(
-                type, r.course.courseName, r.course.classroom,
+                type, r.course.displayName, r.course.classroom,
                 titleShort = formatHm(r.startMinute),
                 titleLong = "${formatHm(r.startMinute)} · +${r.daysAhead}d",
                 tap = tap,

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
@@ -51,18 +51,18 @@ class NextClassTileService : TileService() {
             else -> when (val r = NextClassResolver.resolve(snapshot.courses, weekday, minuteOfDay)) {
                 is NextClassResult.Ongoing -> Triple(
                     "NOW · ends ${formatHm(r.endMinute)}",
-                    "${r.course.courseName}\n${r.course.classroom} · ${r.course.instructor}",
-                    r.nextToday?.let { "Next: ${it.course.courseName} · ${formatHm(it.startMinute)}" } ?: "",
+                    "${r.course.displayName}\n${r.course.classroom} · ${r.course.instructor}",
+                    r.nextToday?.let { "Next: ${it.course.displayName} · ${formatHm(it.startMinute)}" } ?: "",
                 )
                 is NextClassResult.NextToday -> Triple(
                     "NEXT · ${formatHm(r.startMinute)}",
-                    "${r.course.courseName}\n${r.course.classroom} · ${r.course.instructor}",
+                    "${r.course.displayName}\n${r.course.classroom} · ${r.course.instructor}",
                     "",
                 )
                 is NextClassResult.NextFuture -> Triple(
                     if (r.daysAhead == 1) "TOMORROW · ${formatHm(r.startMinute)}"
                     else "${formatHm(r.startMinute)} · in ${r.daysAhead} d",
-                    "${r.course.courseName}\n${r.course.classroom} · ${r.course.instructor}",
+                    "${r.course.displayName}\n${r.course.classroom} · ${r.course.instructor}",
                     "",
                 )
                 NextClassResult.Empty -> Triple("No upcoming classes", "", "")

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/CourseDetailScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/CourseDetailScreen.kt
@@ -33,7 +33,7 @@ fun CourseDetailScreen(course: Course) {
             item {
                 ListHeader { Text(stringResource(R.string.watch_course_detail_title)) }
             }
-            item { Text(text = course.courseName) }
+            item { Text(text = course.displayName) }
             item { Spacer(Modifier.height(2.dp)) }
             item {
                 LabelValue(

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/NowNextScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/NowNextScreen.kt
@@ -84,7 +84,7 @@ private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
             color = accent,
         )
         Text(
-            text = result.course.courseName,
+            text = result.course.displayName,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
@@ -107,7 +107,7 @@ private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
     result.nextToday?.let {
         Spacer(Modifier.height(6.dp))
         Text(
-            text = stringResource(R.string.watch_next_label, it.course.courseName, formatHm(it.startMinute)),
+            text = stringResource(R.string.watch_next_label, it.course.displayName, formatHm(it.startMinute)),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
@@ -117,7 +117,7 @@ private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
 @Composable
 private fun NextTodayCard(result: NextClassResult.NextToday, minuteOfDay: Int) {
     val minsUntil = result.startMinute - minuteOfDay
-    Text(text = result.course.courseName, maxLines = 2, overflow = TextOverflow.Ellipsis)
+    Text(text = result.course.displayName, maxLines = 2, overflow = TextOverflow.Ellipsis)
     Text(text = "${result.course.classroom} · ${result.course.instructor}", maxLines = 1, overflow = TextOverflow.Ellipsis)
     Text(
         text = if (minsUntil in 1..59)
@@ -130,7 +130,7 @@ private fun NextTodayCard(result: NextClassResult.NextToday, minuteOfDay: Int) {
 
 @Composable
 private fun NextFutureCard(result: NextClassResult.NextFuture, todayWeekday: Int) {
-    Text(text = result.course.courseName, maxLines = 2, overflow = TextOverflow.Ellipsis)
+    Text(text = result.course.displayName, maxLines = 2, overflow = TextOverflow.Ellipsis)
     Text(text = "${result.course.classroom} · ${result.course.instructor}", maxLines = 1, overflow = TextOverflow.Ellipsis)
     val label = if (result.daysAhead == 1) {
         stringResource(R.string.watch_tomorrow_at, formatHm(result.startMinute))

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/TodayScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/TodayScreen.kt
@@ -100,7 +100,7 @@ private fun TodayRow(entry: TodayClassEntry, onClick: () -> Unit) {
             Spacer(Modifier.width(6.dp))
         }
         Column(modifier = Modifier.fillMaxWidth()) {
-            Text(text = entry.course.courseName, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Text(text = entry.course.displayName, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(
                 text = "${entry.course.classroom} · ${formatHm(entry.startMinute)}–${formatHm(entry.endMinute)}",
                 maxLines = 1,


### PR DESCRIPTION
This pull request refactors how course names are handled throughout the app to support user-customizable display names for courses. Instead of always using the underlying `courseName` property, the UI and notifications now consistently use a new `displayName` property, which reflects any user-supplied override. Additionally, the course rename dialog has been improved with a "Revert to default" option, and the view model has been updated to manage these overrides in a robust manner.

**User-facing improvements:**

* All course name displays in the UI and notifications now use `Course.displayName`, ensuring that user-supplied custom names are shown everywhere instead of the default `courseName`. [[1]](diffhunk://#diff-0312e09217b0d46982d406c072f64710289d4d5b2258c9e2b4e193eb30a717fdL133-R133) [[2]](diffhunk://#diff-0312e09217b0d46982d406c072f64710289d4d5b2258c9e2b4e193eb30a717fdL147-R147) [[3]](diffhunk://#diff-9b26202d8d4966f3e1e7866154af5bd6fc32f462ca59e4de1ccffa6337bc591fL68-R68) [[4]](diffhunk://#diff-77b2b14b2eb2932cd79fd1aa92237b7bd6e978bece1c01c7527a07a8d5eef61fL74-R74) [[5]](diffhunk://#diff-9ce50f931f42c7f04fd15b3e74b593da54e852b67f54b8f8c5267940a7dc2623L75-R75) [[6]](diffhunk://#diff-9ce50f931f42c7f04fd15b3e74b593da54e852b67f54b8f8c5267940a7dc2623L167-R167) [[7]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L283-R284) [[8]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L308-R332) [[9]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L385-R450) [[10]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L434-R500) [[11]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L713-R778) [[12]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L744-R809) [[13]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L882-R947) [[14]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L923-R988) [[15]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L969-R1034) [[16]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L999-R1064) [[17]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L1010-R1075) [[18]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L1021-R1086)

**Course renaming enhancements:**

* The rename dialog now shows the current default name and provides a "Revert to default" button, which restores the default (non-overridden) name. The dialog logic has been updated to handle when the revert option is enabled.
* The course detail popup and other relevant UI components have been updated to use the new logic for displaying either the custom or default course name.

**ViewModel and data model changes:**

* Added `customCourseName` support in the course model and updated the `ClassTableViewModel` with methods to set, revert, and retrieve the effective display name for a course. [[1]](diffhunk://#diff-c8416fc23a597274e2d62d351a16637c2198bf24adc25324d29ce559067b5ebbL329-R371) [[2]](diffhunk://#diff-c8416fc23a597274e2d62d351a16637c2198bf24adc25324d29ce559067b5ebbR728)
* The ViewModel now provides methods to get the default name for a course, and the logic for determining the displayed name prioritizes user overrides, then the full name from cache, then the stored name.

**UI polish:**

* Added an "Edit" icon to the course detail dialog for quick access to renaming. [[1]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82R18) [[2]](diffhunk://#diff-94a2e867d48bc931aeec4a8939f37afa0e7c3db52caa85c2fc4710fd4b671f82L308-R332)

These changes ensure a consistent and user-friendly experience for managing and displaying custom course names throughout the application.Long-press a course card or tap the new pencil icon in the course-info dialog to override its display name. The edit dialog shows a "Default: <name>" hint and a Revert button that restores the abbreviation-aware default — so flipping the abbr toggle keeps the override but updates what "default" means for any revert.

The override is stored as Course.customCourseName (nullable). Course.courseName keeps holding the derived default so applyAbbreviations and the relabel pass work unchanged. Course.displayName resolves to override-or-default and replaces courseName reads in every render path: class-table cells, course cards, home time slider, conflict picker, course-detail dialog, all home-screen widgets, live activities, class-prep notification, and every wear surface (tile, complication, NowNext, Today, CourseDetail).

The override carries forward across remote refresh (alongside the existing customColorHex/isManual carry-forward) and persists via the existing Course serialization in DataCache — no new file or migration.

Bumps the localization submodule for two new shared keys (class_table_rename_default_label, class_table_rename_revert) translated across all 55 source locales.