### PR TITLE
Fix R8 renaming issue and upgrade crash in v1.4.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 18
-        versionName = "1.4.0"
+        versionCode = 19
+        versionName = "1.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,6 +1,12 @@
 # Add project specific ProGuard rules here.
 -keep class org.ntust.app.tigerduck.network.model.** { *; }
 -keep class org.ntust.app.tigerduck.data.model.** { *; }
+# Course moved from data.model to :shared in v1.4.0. Without this keep,
+# R8 renames Course's fields and Gson can't repopulate them from cache
+# files written by v1.3.x — every reference field deserializes as null
+# and WearScheduleBridge$CourseDto.<init> NPEs from TigerDuckApp.onCreate
+# on the first open after upgrade.
+-keep class org.ntust.app.tigerduck.shared.** { *; }
 # Gson DTOs that live outside the model.** packages. Most fields here lack
 # @SerializedName, so without { *; } R8 renames the JVM fields and Gson
 # silently deserializes nulls — same failure mode as the TypeToken bug.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,10 @@
 -keep class org.ntust.app.tigerduck.announcements.SubscriptionsResponse { *; }
 -keep class org.ntust.app.tigerduck.announcements.SubscriptionsPutRequest { *; }
 -keep class org.ntust.app.tigerduck.data.cache.DataCache$* { *; }
+# Wire DTO Gson-serializes to the watch. Unannotated fields, so R8 must
+# not rename them — otherwise the phone sends obfuscated JSON keys the
+# watch-side CourseWire can't recognize.
+-keep class org.ntust.app.tigerduck.wear.WearScheduleBridge$* { *; }
 -dontrepackage
 
 # Gson — TypeToken<List<Course>>() {} anonymous subclasses lose their generic

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
+import java.io.File
 
 /**
  * One-shot runner for on-device data migrations.
@@ -62,6 +63,7 @@ class DataMigration(
         while (current < CURRENT_SCHEMA) {
             when (current) {
                 0 -> migrate0to1()
+                1 -> migrate1to2()
             }
             current++
             prefs.dataSchemaVersion = current
@@ -77,11 +79,67 @@ class DataMigration(
             .onFailure { Log.w(TAG, "Failed to delete orphaned tigerduck.db", it) }
     }
 
+    /**
+     * v1.4.0 shipped without a keep rule for the moved `:shared.Course`
+     * class, so R8 renamed its JVM fields. Any `courses_*.json` /
+     * `manual_courses_*.json` / legacy `courses.json` saved by that build
+     * has obfuscated keys (e.g. `{"a":"...","b":"..."}`) which v1.4.1
+     * deserializes into null-field Course objects — callers then NPE the
+     * first time they read `courseNo` or `displayName`.
+     *
+     * Detect by content rather than by file presence: if the JSON contains
+     * `"courseNo"` it was written by a build with un-obfuscated field
+     * names (any v1.3.x, or v1.4.1+), and we keep it. Otherwise wipe so
+     * the next sync repopulates from network with the correct schema.
+     * This avoids destroying v1.3.x → v1.4.1 direct upgraders' manual
+     * courses, which still have the original keys on disk.
+     */
+    private fun migrate1to2() {
+        val cacheDir = File(context.cacheDir, CACHE_SUBDIR)
+        val userDataDir = File(context.filesDir, USER_DATA_SUBDIR)
+        sweepCourseFiles(cacheDir) { name ->
+            name == LEGACY_COURSES_FILENAME ||
+                (name.startsWith(COURSES_PREFIX) && name.endsWith(".json"))
+        }
+        sweepCourseFiles(userDataDir) { name ->
+            name.startsWith(MANUAL_COURSES_PREFIX) && name.endsWith(".json")
+        }
+    }
+
+    private fun sweepCourseFiles(dir: File, accept: (String) -> Boolean) {
+        if (!dir.isDirectory) return
+        dir.listFiles()
+            ?.filter { it.isFile && accept(it.name) }
+            ?.forEach { file ->
+                runCatching {
+                    if (!file.readText().contains(COURSE_NO_TOKEN)) {
+                        if (file.delete()) {
+                            Log.i(TAG, "Wiped obfuscated v1.4.0 cache: ${file.name}")
+                        }
+                    }
+                }.onFailure { Log.w(TAG, "Failed to inspect ${file.name}", it) }
+            }
+    }
+
     companion object {
         private const val TAG = "DataMigration"
 
+        // Mirrors DataCache. Kept in sync deliberately — DataMigration must
+        // run before any DataCache access, so we don't import the cache
+        // class here to avoid pulling DI into the migration boot path.
+        private const val CACHE_SUBDIR = "TigerDuckCache"
+        private const val USER_DATA_SUBDIR = "TigerDuckData"
+        private const val LEGACY_COURSES_FILENAME = "courses.json"
+        private const val COURSES_PREFIX = "courses_"
+        private const val MANUAL_COURSES_PREFIX = "manual_courses_"
+
+        // Presence of this literal in the raw file means the writer used
+        // un-obfuscated field names. Absence means an R8-obfuscated v1.4.0
+        // writer or some other corrupt state — either way, drop it.
+        private const val COURSE_NO_TOKEN = "\"courseNo\""
+
         /** Highest schema this build writes. Bump when adding a new step. */
-        const val CURRENT_SCHEMA = 1
+        const val CURRENT_SCHEMA = 2
 
         /**
          * Lowest schema this build can migrate forward from. Anything below

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -136,7 +136,10 @@ class DataMigration(
         // Presence of this literal in the raw file means the writer used
         // un-obfuscated field names. Absence means an R8-obfuscated v1.4.0
         // writer or some other corrupt state — either way, drop it.
-        private const val COURSE_NO_TOKEN = "\"courseNo\""
+        // Trailing `:` anchors the match to an object key — payload
+        // string values cannot legitimately contain an unescaped
+        // quote+colon pair, so they can't masquerade as un-obfuscated.
+        private const val COURSE_NO_TOKEN = "\"courseNo\":"
 
         /** Highest schema this build writes. Bump when adding a new step. */
         const val CURRENT_SCHEMA = 2

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -77,9 +77,24 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         absorbLegacyCourseCache()
         migrateManualCoursesToUserData(semester)
         val type = object : TypeToken<List<Course>>() {}.type
-        val remote = load<List<Course>>(type, coursesFilename(semester)) ?: emptyList()
-        val manual =
-            loadFromUserData<List<Course>>(type, manualCoursesFilename(semester)) ?: emptyList()
+        // requireContent: v1.4.0 shipped without a keep rule for the moved
+        // shared.Course, so cache files written by that build have R8-
+        // obfuscated keys. Deserializing them returns Course objects with
+        // null-typed-as-non-null Strings — the first caller that reads
+        // `courseNo` / `displayName` NPEs. DataMigration sweeps these
+        // files on first injection of AppState, but Application.onCreate
+        // launches wearBridge.publish() on Dispatchers.IO and can race
+        // ahead of MainActivity-triggered migration. Guard at every read.
+        val remote = load<List<Course>>(
+            type,
+            coursesFilename(semester),
+            requireContent = COURSE_NO_TOKEN,
+        ) ?: emptyList()
+        val manual = loadFromUserData<List<Course>>(
+            type,
+            manualCoursesFilename(semester),
+            requireContent = COURSE_NO_TOKEN,
+        ) ?: emptyList()
         if (manual.isEmpty()) return remote
         val manualNos = manual.map { it.courseNo }.toSet()
         return remote.filter { it.courseNo !in manualNos } + manual
@@ -99,9 +114,17 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
      */
     private suspend fun migrateManualCoursesToUserData(semester: String) {
         val type = object : TypeToken<List<Course>>() {}.type
-        val existing = loadFromUserData<List<Course>>(type, manualCoursesFilename(semester))
+        val existing = loadFromUserData<List<Course>>(
+            type,
+            manualCoursesFilename(semester),
+            requireContent = COURSE_NO_TOKEN,
+        )
         if (!existing.isNullOrEmpty()) return
-        val cached = load<List<Course>>(type, coursesFilename(semester)) ?: return
+        val cached = load<List<Course>>(
+            type,
+            coursesFilename(semester),
+            requireContent = COURSE_NO_TOKEN,
+        ) ?: return
         val manual = cached.filter { it.isManual }
         if (manual.isEmpty()) return
         saveToUserData(manual, manualCoursesFilename(semester))
@@ -318,13 +341,21 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         }
     }
 
-    private suspend fun <T> load(type: java.lang.reflect.Type, filename: String): T? =
+    private suspend fun <T> load(
+        type: java.lang.reflect.Type,
+        filename: String,
+        requireContent: String? = null,
+    ): T? =
         cacheMutex.withLock {
             withContext(Dispatchers.IO) {
                 try {
                     val file = File(cacheDir, filename)
                     if (!file.exists()) return@withContext null
-                    gson.fromJson(file.readText(), type)
+                    val text = file.readText()
+                    if (requireContent != null && !text.contains(requireContent)) {
+                        return@withContext null
+                    }
+                    gson.fromJson(text, type)
                 } catch (e: Exception) {
                     null
                 }
@@ -340,16 +371,31 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         }
     }
 
-    private suspend fun <T> loadFromUserData(type: java.lang.reflect.Type, filename: String): T? =
+    private suspend fun <T> loadFromUserData(
+        type: java.lang.reflect.Type,
+        filename: String,
+        requireContent: String? = null,
+    ): T? =
         userDataMutex.withLock {
             withContext(Dispatchers.IO) {
                 try {
                     val file = File(userDataDir, filename)
                     if (!file.exists()) return@withContext null
-                    gson.fromJson(file.readText(), type)
+                    val text = file.readText()
+                    if (requireContent != null && !text.contains(requireContent)) {
+                        return@withContext null
+                    }
+                    gson.fromJson(text, type)
                 } catch (e: Exception) {
                     null
                 }
             }
         }
+
+    private companion object {
+        // Sentinel literal present in any course JSON written by a build
+        // with un-obfuscated field names. Used by loadCourses to reject
+        // R8-obfuscated v1.4.0 cache files before they reach Gson.
+        const val COURSE_NO_TOKEN = "\"courseNo\""
+    }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -396,6 +396,10 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         // Sentinel literal present in any course JSON written by a build
         // with un-obfuscated field names. Used by loadCourses to reject
         // R8-obfuscated v1.4.0 cache files before they reach Gson.
-        const val COURSE_NO_TOKEN = "\"courseNo\""
+        // Trailing `:` keeps this anchored to an object key — a payload
+        // string value that contains the substring `courseNo` would not
+        // include an unescaped quote+colon pair, so it can't satisfy the
+        // check and slip past as if the keys were un-obfuscated.
+        const val COURSE_NO_TOKEN = "\"courseNo\":"
     }
 }

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.4.0-fdroid
-    versionCode: 18
+  - versionName: 1.4.1-fdroid
+    versionCode: 19
     commit: <will be replaced by GitHub Action when creating release>
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.0-fdroid
-CurrentVersionCode: 18
+CurrentVersion: 1.4.1-fdroid
+CurrentVersionCode: 19

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 30
         targetSdk = 36
-        versionCode = 18
-        versionName = "1.4.0"
+        versionCode = 19
+        versionName = "1.4.1"
     }
 
     buildTypes {

--- a/wear/proguard-rules.pro
+++ b/wear/proguard-rules.pro
@@ -1,0 +1,23 @@
+# SchedulePersistence$CourseWire is Gson-deserialized from the phone-sent
+# JSON. Without { *; } R8 renames the JVM fields and Gson silently leaves
+# every reference field null — the constructor map to Course then NPEs and
+# the cached schedule disappears from the watch.
+-keep class org.ntust.app.tigerduck.wear.data.SchedulePersistence$* { *; }
+
+# TypeToken<List<CourseWire>> needs its generic signature to survive R8
+# full mode (default since AGP 8.x), otherwise Gson falls back to
+# LinkedTreeMap. Same failure mode the phone-side rules guard against.
+-keepattributes Signature
+-keepattributes *Annotation*
+
+-keep class * extends com.google.gson.TypeAdapter { *; }
+-keep class * extends com.google.gson.TypeAdapterFactory { *; }
+-keep class * extends com.google.gson.JsonSerializer { *; }
+-keep class * extends com.google.gson.JsonDeserializer { *; }
+
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+
+-keep,allowobfuscation,allowshrinking,allowoptimization class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowshrinking,allowoptimization class * extends com.google.gson.reflect.TypeToken

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt
@@ -90,10 +90,19 @@ class SchedulePersistence(private val context: Context) {
         // and `toCourse()` NPEs through Course's non-null constructor.
         // The watch's launch-time sync request will replace this snapshot
         // shortly, so dropping it on the floor is the safest fallback.
+        // Sentinel requires the trailing `:` so a value that happens to
+        // contain the substring `courseNo` cannot fake an object key.
+        // Parse is also try/caught: a truncated or otherwise malformed
+        // payload that still contains the token must not bubble an
+        // exception up through the snapshot flow.
         if (!json.contains(COURSE_NO_TOKEN)) return emptyList()
-        val type = object : TypeToken<List<CourseWire>>() {}.type
-        val wire: List<CourseWire> = gson.fromJson(json, type) ?: emptyList()
-        return wire.map { it.toCourse() }
+        return try {
+            val type = object : TypeToken<List<CourseWire>>() {}.type
+            val wire: List<CourseWire> = gson.fromJson(json, type) ?: emptyList()
+            wire.map { it.toCourse() }
+        } catch (_: Exception) {
+            emptyList()
+        }
     }
 
     private fun decompress(gz: ByteArray): String =
@@ -130,7 +139,12 @@ class SchedulePersistence(private val context: Context) {
         const val MIN_PADDING_DP = 0
         const val MAX_PADDING_DP = 24
         // Sentinel for detecting un-obfuscated wire format; see parseCourses.
-        private const val COURSE_NO_TOKEN = "\"courseNo\""
+        // Trailing `:` proves this is an object key rather than a string
+        // value that incidentally spells `courseNo` (Gson default emits
+        // compact JSON with no whitespace, and any `"` inside a string
+        // value is escaped as `\"`, so the unescaped quote+colon pair
+        // cannot collide with payload content).
+        private const val COURSE_NO_TOKEN = "\"courseNo\":"
         private val KEY_COURSES_JSON = stringPreferencesKey("courses_json")
         private val KEY_ACCENT_HEX = stringPreferencesKey("accent_hex")
         private val KEY_SYNCED_AT = longPreferencesKey("synced_at_ms")

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt
@@ -83,6 +83,14 @@ class SchedulePersistence(private val context: Context) {
     }
 
     private fun parseCourses(json: String): List<Course> {
+        // v1.4.0 phone shipped without a keep rule for CourseDto, so its
+        // wire JSON used R8-obfuscated keys (e.g. `{"a":"..."}`). v1.4.1
+        // wear expects `"courseNo"` etc. — if the DataStore snapshot was
+        // written by v1.4.0, Gson populates CourseWire with null Strings
+        // and `toCourse()` NPEs through Course's non-null constructor.
+        // The watch's launch-time sync request will replace this snapshot
+        // shortly, so dropping it on the floor is the safest fallback.
+        if (!json.contains(COURSE_NO_TOKEN)) return emptyList()
         val type = object : TypeToken<List<CourseWire>>() {}.type
         val wire: List<CourseWire> = gson.fromJson(json, type) ?: emptyList()
         return wire.map { it.toCourse() }
@@ -121,6 +129,8 @@ class SchedulePersistence(private val context: Context) {
         const val DEFAULT_PADDING_DP = 12
         const val MIN_PADDING_DP = 0
         const val MAX_PADDING_DP = 24
+        // Sentinel for detecting un-obfuscated wire format; see parseCourses.
+        private const val COURSE_NO_TOKEN = "\"courseNo\""
         private val KEY_COURSES_JSON = stringPreferencesKey("courses_json")
         private val KEY_ACCENT_HEX = stringPreferencesKey("accent_hex")
         private val KEY_SYNCED_AT = longPreferencesKey("synced_at_ms")


### PR DESCRIPTION
This pull request addresses a critical data migration bug introduced in v1.4.0, where missing ProGuard keep rules caused R8 to obfuscate field names of the `Course` class after it was moved to `:shared`. This led to corrupted cached JSON files that could not be deserialized by Gson, resulting in null fields and app crashes (NPEs) after upgrading. The patch ensures corrupted caches are detected and wiped, adds defensive checks on all cache reads, and restores the necessary ProGuard rules to prevent future issues. It also bumps the version to 1.4.1 and updates F-Droid metadata.

**Data migration and cache validation:**
* Adds a migration step (`migrate1to2`) in `DataMigration.kt` that scans course cache files for obfuscated content (missing `"courseNo"` key) and deletes them, ensuring corrupted caches from v1.4.0 are wiped on upgrade. [[1]](diffhunk://#diff-487c3256579fac2ff98f8cc5129e1b445b9e46443b45cc5b3804f768ab90a653R66) [[2]](diffhunk://#diff-487c3256579fac2ff98f8cc5129e1b445b9e46443b45cc5b3804f768ab90a653R82-R142)
* Updates `DataCache` to require the presence of `"courseNo"` in course cache files before deserializing, preventing NPEs from corrupted data and guarding against race conditions where migration and reads may overlap. [[1]](diffhunk://#diff-2ff18d51ad0cf6578e40efe84ddee1d9c213e92501f9c1178efef7beb65e12b8L80-R97) [[2]](diffhunk://#diff-2ff18d51ad0cf6578e40efe84ddee1d9c213e92501f9c1178efef7beb65e12b8L102-R127) [[3]](diffhunk://#diff-2ff18d51ad0cf6578e40efe84ddee1d9c213e92501f9c1178efef7beb65e12b8L321-R358) [[4]](diffhunk://#diff-2ff18d51ad0cf6578e40efe84ddee1d9c213e92501f9c1178efef7beb65e12b8L343-R400)

**ProGuard/R8 configuration:**
* Restores and adds missing ProGuard keep rules for `:shared.Course`, `WearScheduleBridge$CourseDto`, and related wire classes on both phone and wear modules, ensuring Gson field names are preserved and cross-version cache compatibility is maintained. [[1]](diffhunk://#diff-24fc40bbf6fe503c74604e0477ff8f55aeab48cb521e1a844b9efa6c3771c15eR4-R9) [[2]](diffhunk://#diff-24fc40bbf6fe503c74604e0477ff8f55aeab48cb521e1a844b9efa6c3771c15eR23-R26) [[3]](diffhunk://#diff-901cea0e97276ef92341d138e3b027fc1c1bd96f7eaa3479b90af9ea4f659a0cR1-R23)

**Wear app compatibility:**
* Updates `SchedulePersistence` on wear to reject and ignore corrupted course JSON (missing `"courseNo"`), preventing crashes on the watch and allowing a clean resync. [[1]](diffhunk://#diff-54ea1605bd44c2c30fad824d5ed143fbedffdf7194d3ac478cdaa1930228a805R86-R93) [[2]](diffhunk://#diff-54ea1605bd44c2c30fad824d5ed143fbedffdf7194d3ac478cdaa1930228a805R132-R133)

**Version and metadata updates:**
* Bumps app and wear version to 1.4.1 (code 19) and updates F-Droid metadata accordingly. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46L49-R50) [[2]](diffhunk://#diff-c499ca55f776797c46b2c82b31d2e0b78e591b0dc602b0e9f8c4d26e8bea98a0L20-R21) [[3]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L19-R20) [[4]](diffhunk://#diff-87d6c5301fa969bc99cde63d293eed88f798ae4cd5980b8220d0fc42c9c272b0L29-R30)

**Other:**
* Minor import addition for `File` in `DataMigration.kt` to support new migration logic.