### PR TITLE
Add to Release v1.4.2: Wear OS Library QR, widget/watch parity, debug clock

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/debug/DebugClockController.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/debug/DebugClockController.kt
@@ -14,6 +14,7 @@ import org.ntust.app.tigerduck.notification.ClassPreparingNotificationScheduler
 import org.ntust.app.tigerduck.shared.clock.AppClock
 import org.ntust.app.tigerduck.shared.clock.ClockOverride
 import org.ntust.app.tigerduck.widget.WidgetBoundaryScheduler
+import org.ntust.app.tigerduck.widget.WidgetUpdater
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -28,6 +29,7 @@ class DebugClockController @Inject constructor(
     private val assignmentScheduler: AssignmentNotificationScheduler,
     private val classPreparingScheduler: ClassPreparingNotificationScheduler,
     private val widgetBoundaryScheduler: WidgetBoundaryScheduler,
+    private val widgetUpdater: WidgetUpdater,
 ) {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -83,6 +85,11 @@ class DebugClockController @Inject constructor(
             )
         }
         widgetBoundaryScheduler.scheduleForToday(courses)
+        // The boundary scheduler arms the *next* alarm, but the user has
+        // already moved the clock past the previous boundary — so the
+        // widgets must repaint right now or they'd still show the time
+        // before the override until the next alarm fires.
+        widgetUpdater.updateAll()
         if (liveActivityPreferences.isEnabled) {
             liveActivityManager.refreshAndWait()
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
@@ -46,7 +46,7 @@ object WidgetDataLoader {
         val nextCourseTodayNo = computeNextCourseTodayNo(
             courses, weekday, minuteOfDay, ongoingNos,
         )
-        val (tomorrowName, tomorrowTime) = computeTomorrowFirst(courses, weekday)
+        val tomorrowFirst = computeTomorrowFirst(courses, weekday)
 
         return WidgetState(
             courses = courses,
@@ -57,11 +57,18 @@ object WidgetDataLoader {
             isLoggedIn = isLoggedIn,
             ongoingCourseNos = ongoingNos,
             nextCourseTodayNo = nextCourseTodayNo,
-            tomorrowFirstCourseName = tomorrowName,
-            tomorrowFirstCourseTime = tomorrowTime,
+            tomorrowFirstCourseNo = tomorrowFirst?.courseNo,
+            tomorrowFirstCourseWeekday = tomorrowFirst?.weekday,
+            tomorrowFirstCoursePeriodId = tomorrowFirst?.periodId,
             courseColors = buildCourseColorAssignments(courses),
         )
     }
+
+    private data class TomorrowFirst(
+        val courseNo: String,
+        val weekday: Int,
+        val periodId: String,
+    )
 
     private fun Calendar.toWeekday(): Int = when (get(Calendar.DAY_OF_WEEK)) {
         Calendar.MONDAY -> 1; Calendar.TUESDAY -> 2; Calendar.WEDNESDAY -> 3
@@ -102,21 +109,31 @@ object WidgetDataLoader {
             ?.first?.courseNo
     }
 
+    /**
+     * Scans up to 7 future weekdays for the earliest scheduled class. Mirrors
+     * iOS `WidgetTimelineDerivation.derive`'s `tomorrowFirst` branch — without
+     * the 7-day lookahead, viewing the widget on Friday with no Sat/Sun classes
+     * collapses to "no more classes" instead of surfacing Monday's first class.
+     */
     private fun computeTomorrowFirst(
         courses: List<Course>,
         todayWeekday: Int,
-    ): Pair<String?, String?> {
-        val tomorrowWeekday = if (todayWeekday >= 7) 1 else todayWeekday + 1
+    ): TomorrowFirst? {
         val order = AppConstants.Periods.chronologicalOrder
-        val course = courses
-            .filter { it.schedule.containsKey(tomorrowWeekday) }
-            .minByOrNull { c ->
-                c.schedule[tomorrowWeekday]!!
-                    .minByOrNull { order.indexOf(it) }
-                    ?.let { order.indexOf(it) } ?: Int.MAX_VALUE
-            } ?: return null to null
-        val firstPeriodId = course.schedule[tomorrowWeekday]!!
-            .minByOrNull { order.indexOf(it) }!!
-        return course.displayName to AppConstants.PeriodTimes.mapping[firstPeriodId]?.first
+        for (offset in 1..7) {
+            val target = ((todayWeekday - 1 + offset) % 7) + 1
+            val candidates = courses.mapNotNull { course ->
+                val periods = course.schedule[target] ?: return@mapNotNull null
+                val firstPeriod = periods.minByOrNull { order.indexOf(it) } ?: return@mapNotNull null
+                Triple(course, target, firstPeriod)
+            }
+            val pick = candidates.minByOrNull { order.indexOf(it.third) } ?: continue
+            return TomorrowFirst(
+                courseNo = pick.first.courseNo,
+                weekday = pick.second,
+                periodId = pick.third,
+            )
+        }
+        return null
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetScheduleCells.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetScheduleCells.kt
@@ -24,6 +24,28 @@ sealed class ScheduleCell {
     ) : ScheduleCell() {
         override val length: Int get() = combinedSpan
     }
+
+    /**
+     * 3+ courses transitively connected by overlap — e.g. A on 6-7, B on 6-8,
+     * C on 8-9: A and C share no period but B bridges them. The 2-course L-tile
+     * doesn't generalize, so callers render this variant as vertical lanes with
+     * greedy interval-graph coloring (matches ClassTableViewModel's in-app
+     * MultiConflictStart and TimeSliderViewModel's home-slider 衝堂 lanes).
+     */
+    data class MultiConflict(
+        val members: List<Member>,
+        val combinedSpan: Int,
+        val laneCount: Int,
+    ) : ScheduleCell() {
+        override val length: Int get() = combinedSpan
+
+        data class Member(
+            val course: Course,
+            val span: Int,
+            val offset: Int,
+            val lane: Int,
+        )
+    }
 }
 
 /**
@@ -65,13 +87,16 @@ fun buildScheduleCells(
             // previously-emitted cluster.
             out.add(ScheduleCell.Solo(course, span))
             i = first + span
-        } else {
-            val kept = entries.take(2)
-            val (courseA, firstA, spanA) = kept[0]
-            val (courseB, firstB, spanB) = kept[1]
-            val clusterStart = minOf(firstA, firstB)
-            val clusterEnd = maxOf(firstA + spanA, firstB + spanB)
-            val combined = clusterEnd - clusterStart
+            continue
+        }
+
+        val clusterStart = entries.minOf { it.second }
+        val clusterEnd = entries.maxOf { it.second + it.third }
+        val combined = clusterEnd - clusterStart
+
+        if (entries.size == 2) {
+            val (courseA, firstA, spanA) = entries[0]
+            val (courseB, firstB, spanB) = entries[1]
             out.add(
                 ScheduleCell.Conflict(
                     courseA = courseA,
@@ -83,8 +108,44 @@ fun buildScheduleCells(
                     combinedSpan = combined,
                 )
             )
-            i = clusterStart + combined
+        } else {
+            // 3+ courses: greedy interval-graph lane assignment.
+            val sortedByStart = entries.sortedBy { it.second }
+            val laneEnds = mutableListOf<Int>()
+            val laneAssignments = IntArray(sortedByStart.size)
+            for ((idx, e) in sortedByStart.withIndex()) {
+                val (_, first, span) = e
+                val end = first + span
+                var lane = -1
+                for (j in laneEnds.indices) {
+                    if (laneEnds[j] <= first) { lane = j; break }
+                }
+                if (lane < 0) {
+                    laneEnds.add(end)
+                    lane = laneEnds.size - 1
+                } else {
+                    laneEnds[lane] = end
+                }
+                laneAssignments[idx] = lane
+            }
+            val members = sortedByStart.mapIndexed { idx, e ->
+                val (course, first, span) = e
+                ScheduleCell.MultiConflict.Member(
+                    course = course,
+                    span = span,
+                    offset = first - clusterStart,
+                    lane = laneAssignments[idx],
+                )
+            }
+            out.add(
+                ScheduleCell.MultiConflict(
+                    members = members,
+                    combinedSpan = combined,
+                    laneCount = laneEnds.size,
+                )
+            )
         }
+        i = clusterStart + combined
     }
     return out
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetState.kt
@@ -13,8 +13,16 @@ data class WidgetState(
     val isLoggedIn: Boolean,
     val ongoingCourseNos: List<String>,
     val nextCourseTodayNo: String?,
-    val tomorrowFirstCourseName: String?,
-    val tomorrowFirstCourseTime: String?,
+    /**
+     * `(courseNo, weekday, firstPeriodId)` for the next class beyond today —
+     * scans up to 7 future weekdays so the Next Class widget shows Monday's
+     * first class when a Fri/Sat/Sun stretch has nothing scheduled (mirrors
+     * iOS `WidgetTimelineDerivation.derive`'s `tomorrowFirst` branch). Null
+     * when no course exists in the next 7 days.
+     */
+    val tomorrowFirstCourseNo: String?,
+    val tomorrowFirstCourseWeekday: Int?,
+    val tomorrowFirstCoursePeriodId: String?,
     /**
      * Resolved course colors matching the app's palette assignment (with
      * collision probing). Keyed by courseNo. Empty entries fall back to the

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
@@ -1,5 +1,6 @@
 package org.ntust.app.tigerduck.widget.content
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -177,6 +178,7 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                 val tomorrowPeriodId = state.tomorrowFirstCoursePeriodId
                 val tomorrowStartTime = tomorrowPeriodId
                     ?.let { AppConstants.PeriodTimes.mapping[it]?.first }
+                val tomorrowWeekday = state.tomorrowFirstCourseWeekday
                 Spacer(GlanceModifier.defaultWeight())
                 Column(horizontalAlignment = Alignment.Horizontal.CenterHorizontally) {
                     Text(
@@ -191,8 +193,11 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                     )
                     if (tomorrowCourse != null && !tomorrowStartTime.isNullOrEmpty()) {
                         Text(
-                            text = context.getString(
-                                R.string.widget_tomorrow_time, tomorrowStartTime,
+                            text = futureCourseTimeLabel(
+                                context = context,
+                                todayWeekday = state.currentWeekday,
+                                futureWeekday = tomorrowWeekday,
+                                startTime = tomorrowStartTime,
                             ),
                             style = TextStyle(
                                 color = ColorProvider(colors.onSurfaceVariant),
@@ -276,16 +281,19 @@ private fun FullLayout(state: WidgetState, colors: WidgetColors, tapAction: Acti
 
             state.tomorrowFirstCourseNo != null -> {
                 // Mirrors iOS `WidgetTimelineDerivation` `.tomorrowFirst` —
-                // same card layout as next-today, just with a "Tomorrow"
-                // label and resolved against the picked future weekday so the
-                // classroom string reflects that day's per-period room.
+                // same card layout as next-today. `computeTomorrowFirst` scans
+                // up to 7 weekdays ahead, so the label switches to the short
+                // weekday name (e.g., "Mon") when the picked day isn't
+                // literally tomorrow (Fri → Mon after a weekend with no
+                // classes). Classroom resolves against that picked day so the
+                // per-period room reflects it.
                 val course = state.courses.find { it.courseNo == state.tomorrowFirstCourseNo }
                 val weekday = state.tomorrowFirstCourseWeekday
                 if (course != null && weekday != null) {
                     NextCard(
                         course = course,
                         weekday = weekday,
-                        label = context.getString(R.string.widget_tomorrow),
+                        label = futureDayLabel(context, state.currentWeekday, weekday),
                         colors = colors,
                     )
                 }
@@ -490,6 +498,45 @@ private fun NextCard(
             style = TextStyle(color = ColorProvider(colors.onSurfaceVariant), fontSize = 13.sp),
         )
     }
+}
+
+/**
+ * "Tomorrow" only when [futureWeekday] is literally the calendar day after
+ * [todayWeekday]; otherwise the short weekday name. `computeTomorrowFirst`
+ * scans up to 7 weekdays ahead, so a Friday-afternoon viewer with no Sat/Sun
+ * classes sees Monday's first class — labeling it "Tomorrow" would mislead.
+ */
+private fun futureDayLabel(context: Context, todayWeekday: Int, futureWeekday: Int): String {
+    val literalTomorrow = (todayWeekday % 7) + 1
+    return if (futureWeekday == literalTomorrow) {
+        context.getString(R.string.widget_tomorrow)
+    } else {
+        context.getString(weekdayShortRes(futureWeekday))
+    }
+}
+
+private fun futureCourseTimeLabel(
+    context: Context,
+    todayWeekday: Int,
+    futureWeekday: Int?,
+    startTime: String,
+): String {
+    val literalTomorrow = (todayWeekday % 7) + 1
+    return if (futureWeekday == null || futureWeekday == literalTomorrow) {
+        context.getString(R.string.widget_tomorrow_time, startTime)
+    } else {
+        "${context.getString(weekdayShortRes(futureWeekday))} $startTime"
+    }
+}
+
+private fun weekdayShortRes(weekday: Int): Int = when (weekday) {
+    1 -> R.string.weekday_mon_short
+    2 -> R.string.weekday_tue_short
+    3 -> R.string.weekday_wed_short
+    4 -> R.string.weekday_thu_short
+    5 -> R.string.weekday_fri_short
+    6 -> R.string.weekday_sat_short
+    else -> R.string.weekday_sun_short
 }
 
 @Composable

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/NextClassContent.kt
@@ -170,12 +170,18 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
             }
 
             else -> {
-                val name = state.tomorrowFirstCourseName
-                val time = state.tomorrowFirstCourseTime
+                val tomorrowCourseNo = state.tomorrowFirstCourseNo
+                val tomorrowCourse = tomorrowCourseNo?.let { no ->
+                    state.courses.find { it.courseNo == no }
+                }
+                val tomorrowPeriodId = state.tomorrowFirstCoursePeriodId
+                val tomorrowStartTime = tomorrowPeriodId
+                    ?.let { AppConstants.PeriodTimes.mapping[it]?.first }
                 Spacer(GlanceModifier.defaultWeight())
                 Column(horizontalAlignment = Alignment.Horizontal.CenterHorizontally) {
                     Text(
-                        text = name ?: context.getString(R.string.widget_no_more_classes),
+                        text = tomorrowCourse?.displayName
+                            ?: context.getString(R.string.widget_no_more_classes),
                         style = TextStyle(
                             color = ColorProvider(colors.onSurface),
                             fontSize = 15.sp,
@@ -183,9 +189,11 @@ private fun CompactLayout(state: WidgetState, colors: WidgetColors, tapAction: A
                         ),
                         maxLines = 1,
                     )
-                    if (name != null && time != null) {
+                    if (tomorrowCourse != null && !tomorrowStartTime.isNullOrEmpty()) {
                         Text(
-                            text = context.getString(R.string.widget_tomorrow_time, time),
+                            text = context.getString(
+                                R.string.widget_tomorrow_time, tomorrowStartTime,
+                            ),
                             style = TextStyle(
                                 color = ColorProvider(colors.onSurfaceVariant),
                                 fontSize = 12.sp
@@ -256,10 +264,34 @@ private fun FullLayout(state: WidgetState, colors: WidgetColors, tapAction: Acti
 
             state.nextCourseTodayNo != null -> {
                 val course = state.courses.find { it.courseNo == state.nextCourseTodayNo }
-                if (course != null) NextCard(course, state, colors)
+                if (course != null) {
+                    NextCard(
+                        course = course,
+                        weekday = state.currentWeekday,
+                        label = context.getString(R.string.widget_next_class),
+                        colors = colors,
+                    )
+                }
             }
 
-            else -> TomorrowCard(state, colors)
+            state.tomorrowFirstCourseNo != null -> {
+                // Mirrors iOS `WidgetTimelineDerivation` `.tomorrowFirst` —
+                // same card layout as next-today, just with a "Tomorrow"
+                // label and resolved against the picked future weekday so the
+                // classroom string reflects that day's per-period room.
+                val course = state.courses.find { it.courseNo == state.tomorrowFirstCourseNo }
+                val weekday = state.tomorrowFirstCourseWeekday
+                if (course != null && weekday != null) {
+                    NextCard(
+                        course = course,
+                        weekday = weekday,
+                        label = context.getString(R.string.widget_tomorrow),
+                        colors = colors,
+                    )
+                }
+            }
+
+            else -> NoMoreClassesCard(colors)
         }
     }
 }
@@ -410,16 +442,25 @@ private fun OngoingMiniCard(course: Course, state: WidgetState, colors: WidgetCo
     }
 }
 
+/**
+ * Renders the next-class card for both "next today" and "tomorrow" cases —
+ * iOS pulls these through the same `nextBody`, so the layout is identical and
+ * only the label string + weekday differ. [weekday] selects which day's per-
+ * period schedule and classroom apply (today's vs the picked future day).
+ */
 @Composable
-private fun NextCard(course: Course, state: WidgetState, colors: WidgetColors) {
-    val context = LocalContext.current
+private fun NextCard(
+    course: Course,
+    weekday: Int,
+    label: String,
+    colors: WidgetColors,
+) {
     val order = AppConstants.Periods.chronologicalOrder
-    val periods =
-        course.schedule[state.currentWeekday]?.sortedBy { order.indexOf(it) } ?: emptyList()
+    val periods = course.schedule[weekday]?.sortedBy { order.indexOf(it) } ?: emptyList()
     val startTime = periods.firstOrNull()?.let { AppConstants.PeriodTimes.mapping[it]?.first } ?: ""
 
     Text(
-        text = context.getString(R.string.widget_next_class),
+        text = label,
         style = TextStyle(
             color = ColorProvider(colors.onSurfaceVariant),
             fontSize = 13.sp,
@@ -442,7 +483,7 @@ private fun NextCard(course: Course, state: WidgetState, colors: WidgetColors) {
             style = TextStyle(color = ColorProvider(colors.onSurfaceVariant), fontSize = 14.sp),
         )
     }
-    val room = course.classroom(state.currentWeekday)
+    val room = course.classroom(weekday)
     if (room.isNotEmpty()) {
         Text(
             text = room,
@@ -452,46 +493,19 @@ private fun NextCard(course: Course, state: WidgetState, colors: WidgetColors) {
 }
 
 @Composable
-private fun TomorrowCard(state: WidgetState, colors: WidgetColors) {
+private fun NoMoreClassesCard(colors: WidgetColors) {
     val context = LocalContext.current
     Box(
         modifier = GlanceModifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
-        Column(horizontalAlignment = Alignment.Horizontal.CenterHorizontally) {
-            Text(
-                text = context.getString(R.string.widget_no_more_classes),
-                style = TextStyle(
-                    color = ColorProvider(colors.onSurface),
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold,
-                ),
-            )
-            val name = state.tomorrowFirstCourseName
-            val time = state.tomorrowFirstCourseTime
-            if (name != null && time != null) {
-                Spacer(GlanceModifier.height(10.dp))
-                Text(
-                    text = context.getString(R.string.widget_tomorrow),
-                    style = TextStyle(
-                        color = ColorProvider(colors.onSurfaceVariant),
-                        fontSize = 13.sp,
-                        fontWeight = FontWeight.Bold
-                    ),
-                )
-                Text(
-                    text = name,
-                    style = TextStyle(color = ColorProvider(colors.onSurface), fontSize = 15.sp),
-                    maxLines = 1,
-                )
-                Text(
-                    text = time,
-                    style = TextStyle(
-                        color = ColorProvider(colors.onSurfaceVariant),
-                        fontSize = 13.sp
-                    ),
-                )
-            }
-        }
+        Text(
+            text = context.getString(R.string.widget_no_more_classes),
+            style = TextStyle(
+                color = ColorProvider(colors.onSurface),
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+            ),
+        )
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
@@ -26,6 +26,7 @@ import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.widget.WidgetColors
 import org.ntust.app.tigerduck.widget.WidgetState
+import org.ntust.app.tigerduck.widget.widgetCourseColor
 
 @Composable
 fun TodayListContent(state: WidgetState, colors: WidgetColors, tapAction: Action) {
@@ -118,10 +119,17 @@ fun TodayListContent(state: WidgetState, colors: WidgetColors, tapAction: Action
                     val endTime = AppConstants.PeriodTimes.mapping[lastPeriod]?.second ?: ""
                     val periodRange = if (firstPeriod == lastPeriod) firstPeriod
                     else "$firstPeriod–$lastPeriod"
-                    val rowBg = if (isOngoing) colors.highlight else colors.surface
+                    // iOS parity: ongoing rows tint with the course's own
+                    // color (not a single shared highlight), so back-to-back
+                    // 衝堂 ongoing rows stay visually distinguishable.
+                    val rowBg = if (isOngoing) {
+                        widgetCourseColor(course, state.courseColors, colors.isDark)
+                    } else {
+                        colors.surface
+                    }
                     val primaryText = if (isOngoing) Color.White else colors.onSurface
                     val secondaryText =
-                        if (isOngoing) Color.White.copy(alpha = 0.8f) else colors.onSurfaceVariant
+                        if (isOngoing) Color.White.copy(alpha = 0.85f) else colors.onSurfaceVariant
 
                     Row(
                         modifier = GlanceModifier

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/WeekGridContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/WeekGridContent.kt
@@ -206,6 +206,14 @@ private fun ScheduleCellBox(
             blockHeight = blockHeight,
             blockWidth = blockWidth,
         )
+
+        is ScheduleCell.MultiConflict -> MultiConflictCell(
+            cell = cell,
+            colors = colors,
+            courseColors = courseColors,
+            ongoingCourseNos = ongoingCourseNos,
+            blockHeight = blockHeight,
+        )
     }
 }
 
@@ -373,6 +381,93 @@ private fun ConflictCell(
                 boxBottomPadding = rowHeight * (cell.combinedSpan - cell.offsetB - cell.spanB),
                 barWidth = barWidth,
             )
+        }
+    }
+}
+
+/**
+ * Renders a 3+ course cluster as side-by-side lane columns. Each lane stacks
+ * its members vertically with empty gaps preserved as transparent spacers, so
+ * the in-app class-table's MultiConflictStart layout is mirrored on widgets
+ * without needing a 3-tile bitmap path.
+ */
+@Composable
+private fun MultiConflictCell(
+    cell: ScheduleCell.MultiConflict,
+    colors: WidgetColors,
+    courseColors: Map<String, Color>,
+    ongoingCourseNos: List<String>,
+    blockHeight: Dp,
+) {
+    val rowHeight = blockHeight / cell.combinedSpan.coerceAtLeast(1)
+    val textColor: Color = if (colors.isDark) Color.White else Color(0xFF1C1C1E)
+
+    fun tileBg(course: Course): Color {
+        val base = widgetCourseColor(course, courseColors, colors.isDark)
+        return when {
+            course.courseNo in ongoingCourseNos -> colors.highlight
+            colors.isDark -> base
+            else -> base.copy(alpha = 0.55f)
+        }
+    }
+
+    Box(
+        modifier = GlanceModifier
+            .fillMaxWidth()
+            .height(blockHeight)
+            .padding(vertical = 1.dp),
+    ) {
+        Row(modifier = GlanceModifier.fillMaxSize()) {
+            for (laneIdx in 0 until cell.laneCount) {
+                val laneMembers = cell.members
+                    .filter { it.lane == laneIdx }
+                    .sortedBy { it.offset }
+                Column(
+                    modifier = GlanceModifier
+                        .defaultWeight()
+                        .fillMaxHeight()
+                        .padding(horizontal = 0.5.dp),
+                ) {
+                    var cursor = 0
+                    laneMembers.forEach { member ->
+                        if (member.offset > cursor) {
+                            Box(modifier = GlanceModifier.height(rowHeight * (member.offset - cursor))) {}
+                        }
+                        val ongoing = member.course.courseNo in ongoingCourseNos
+                        val tileTextColor = if (ongoing) Color.White else textColor
+                        Box(
+                            modifier = GlanceModifier
+                                .fillMaxWidth()
+                                .height(rowHeight * member.span)
+                                .padding(vertical = 0.5.dp),
+                        ) {
+                            Box(
+                                modifier = GlanceModifier
+                                    .fillMaxSize()
+                                    .background(ColorProvider(tileBg(member.course)))
+                                    .cornerRadius(4.dp)
+                                    .padding(1.dp),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = member.course.displayName,
+                                    style = TextStyle(
+                                        color = ColorProvider(tileTextColor),
+                                        fontSize = 9.sp,
+                                        fontWeight = FontWeight.Medium,
+                                        textAlign = TextAlign.Center,
+                                    ),
+                                    maxLines = if (member.span >= 2) 3 else 2,
+                                )
+                            }
+                        }
+                        cursor = member.offset + member.span
+                    }
+                    if (cursor < cell.combinedSpan) {
+                        Box(modifier = GlanceModifier.height(rowHeight * (cell.combinedSpan - cursor))) {}
+                    }
+                }
+            }
         }
     }
 }

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/data/DebugClockListener.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/data/DebugClockListener.kt
@@ -9,6 +9,8 @@ import org.ntust.app.tigerduck.shared.WearProtocol
 import org.ntust.app.tigerduck.shared.clock.AppClock
 import org.ntust.app.tigerduck.shared.clock.ClockOverride
 import org.ntust.app.tigerduck.wear.BuildConfig
+import org.ntust.app.tigerduck.wear.complication.NextClassComplicationService
+import org.ntust.app.tigerduck.wear.tile.NextClassTileService
 
 /**
  * Receives debug-clock-override updates from the phone via the Wearable Data
@@ -41,6 +43,11 @@ class DebugClockListener : WearableListenerService() {
             }
             store.save(override)
             AppClock.setOverride(override)
+            // Tile + complication cache their last-rendered frame; nudging
+            // both forces them to re-resolve against the new clock right
+            // away instead of waiting for the next system-driven refresh.
+            NextClassTileService.requestUpdate(applicationContext)
+            NextClassComplicationService.requestUpdate(applicationContext)
             Log.d(TAG, "applied override cleared=$cleared")
         }
     }

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/NowNextScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/NowNextScreen.kt
@@ -21,13 +21,14 @@ import androidx.wear.compose.material3.LinearProgressIndicator
 import androidx.wear.compose.material3.ListHeader
 import androidx.wear.compose.material3.ScreenScaffold
 import androidx.wear.compose.material3.Text
+import org.ntust.app.tigerduck.shared.Course
 import org.ntust.app.tigerduck.shared.NextClassResolver
 import org.ntust.app.tigerduck.shared.NextClassResult
 import org.ntust.app.tigerduck.wear.R
 import org.ntust.app.tigerduck.wear.data.WatchSnapshot
 import org.ntust.app.tigerduck.shared.clock.AppClock
-import org.ntust.app.tigerduck.wear.ui.theme.LocalAccentColor
 import org.ntust.app.tigerduck.wear.ui.theme.LocalScreenPadding
+import org.ntust.app.tigerduck.wear.ui.theme.wearCourseColor
 import java.util.concurrent.TimeUnit
 
 @Composable
@@ -51,17 +52,39 @@ fun NowNextScreen(snapshot: WatchSnapshot) {
 
         Column(
             modifier = Modifier.fillMaxSize().padding(horizontal = pad),
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.spacedBy(6.dp, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             ListHeader { Text(stringResource(R.string.watch_now_next_title)) }
             when (result) {
-                is NextClassResult.Ongoing -> OngoingCard(result, minuteOfDay)
-                is NextClassResult.NextToday -> NextTodayCard(result, minuteOfDay)
-                is NextClassResult.NextFuture -> NextFutureCard(result, weekday)
+                is NextClassResult.Ongoing -> {
+                    // iOS NowNextView stacks Now + Next as two separate cards
+                    // when both exist, instead of folding the next-today
+                    // preview into the ongoing card as a single line.
+                    OngoingCard(result, minuteOfDay)
+                    result.nextToday?.let { next ->
+                        NextCard(
+                            course = next.course,
+                            weekday = next.weekday,
+                            statusText = nextStatusText(next.startMinute, minuteOfDay),
+                            titleResId = R.string.watch_next,
+                        )
+                    }
+                }
+                is NextClassResult.NextToday -> NextCard(
+                    course = result.course,
+                    weekday = result.weekday,
+                    statusText = nextStatusText(result.startMinute, minuteOfDay),
+                    titleResId = null,
+                )
+                is NextClassResult.NextFuture -> NextCard(
+                    course = result.course,
+                    weekday = result.weekday,
+                    statusText = futureStatusText(result.daysAhead, result.startMinute, weekday),
+                    titleResId = null,
+                )
                 NextClassResult.Empty -> Text(stringResource(R.string.watch_no_upcoming_classes))
             }
-            Spacer(Modifier.height(8.dp))
             StaleBanner(snapshot.syncedAtMs)
         }
     }
@@ -69,19 +92,20 @@ fun NowNextScreen(snapshot: WatchSnapshot) {
 
 @Composable
 private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
-    val accent = LocalAccentColor.current
+    val courseColor = wearCourseColor(result.course)
     val span = (result.endMinute - result.startMinute).coerceAtLeast(1)
     val progress = ((minuteOfDay - result.startMinute).toFloat() / span).coerceIn(0f, 1f)
     Column(
         modifier = Modifier
+            .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .background(accent.copy(alpha = 0.18f))
+            .background(courseColor.copy(alpha = 0.22f))
             .padding(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
             text = stringResource(R.string.watch_now_ends_at, formatHm(result.endMinute)),
-            color = accent,
+            color = courseColor,
         )
         Text(
             text = result.course.displayName,
@@ -94,9 +118,6 @@ private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
             overflow = TextOverflow.Ellipsis,
         )
         Spacer(Modifier.height(6.dp))
-        // Progress through the current period: ticks once a minute via the
-        // parent's currentTaipeiTick(), so the bar fills smoothly enough for
-        // a watch UI without burning a 1-second timer.
         LinearProgressIndicator(
             progress = { progress },
             modifier = Modifier
@@ -104,46 +125,74 @@ private fun OngoingCard(result: NextClassResult.Ongoing, minuteOfDay: Int) {
                 .height(4.dp),
         )
     }
-    result.nextToday?.let {
-        Spacer(Modifier.height(6.dp))
+}
+
+/**
+ * Unified next-class card used for both [NextClassResult.NextToday] and
+ * [NextClassResult.NextFuture], as well as the "Next" follow-up under an
+ * ongoing course. [titleResId] surfaces the kind label ("Next") only when
+ * the card is paired with another above it; the standalone next-today /
+ * next-future cards skip the label so the time line carries that role —
+ * matches the iOS ClassCard layout.
+ */
+@Composable
+private fun NextCard(
+    course: Course,
+    weekday: Int,
+    statusText: String,
+    titleResId: Int?,
+) {
+    val courseColor = wearCourseColor(course)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(courseColor.copy(alpha = 0.22f))
+            .padding(8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        if (titleResId != null) {
+            Text(text = stringResource(titleResId), color = courseColor)
+        }
         Text(
-            text = stringResource(R.string.watch_next_label, it.course.displayName, formatHm(it.startMinute)),
+            text = course.displayName,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
+        Text(
+            text = "${course.classroom(weekday)} · ${course.instructor}",
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Text(
+            text = statusText,
+            color = courseColor,
+        )
     }
 }
 
 @Composable
-private fun NextTodayCard(result: NextClassResult.NextToday, minuteOfDay: Int) {
-    val minsUntil = result.startMinute - minuteOfDay
-    Text(text = result.course.displayName, maxLines = 2, overflow = TextOverflow.Ellipsis)
-    Text(text = "${result.course.classroom(result.weekday)} · ${result.course.instructor}", maxLines = 1, overflow = TextOverflow.Ellipsis)
-    Text(
-        text = if (minsUntil in 1..59)
-            stringResource(R.string.watch_starts_in_minutes, minsUntil)
-        else
-            stringResource(R.string.watch_starts_at, formatHm(result.startMinute)),
-        color = LocalAccentColor.current,
-    )
+private fun nextStatusText(startMinute: Int, minuteOfDay: Int): String {
+    val minsUntil = startMinute - minuteOfDay
+    return if (minsUntil in 1..59) {
+        stringResource(R.string.watch_starts_in_minutes, minsUntil)
+    } else {
+        stringResource(R.string.watch_starts_at, formatHm(startMinute))
+    }
 }
 
 @Composable
-private fun NextFutureCard(result: NextClassResult.NextFuture, todayWeekday: Int) {
-    Text(text = result.course.displayName, maxLines = 2, overflow = TextOverflow.Ellipsis)
-    Text(text = "${result.course.classroom(result.weekday)} · ${result.course.instructor}", maxLines = 1, overflow = TextOverflow.Ellipsis)
-    val label = if (result.daysAhead == 1) {
-        stringResource(R.string.watch_tomorrow_at, formatHm(result.startMinute))
+private fun futureStatusText(daysAhead: Int, startMinute: Int, todayWeekday: Int): String =
+    if (daysAhead == 1) {
+        stringResource(R.string.watch_tomorrow_at, formatHm(startMinute))
     } else {
-        val targetWeekday = ((todayWeekday - 1 + result.daysAhead) % 7) + 1
+        val targetWeekday = ((todayWeekday - 1 + daysAhead) % 7) + 1
         stringResource(
             R.string.watch_weekday_at,
             weekdayShortName(targetWeekday),
-            formatHm(result.startMinute),
+            formatHm(startMinute),
         )
     }
-    Text(text = label, color = LocalAccentColor.current)
-}
 
 @Composable
 private fun StaleBanner(syncedAtMs: Long) {

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/TodayScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/TodayScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -31,8 +30,8 @@ import org.ntust.app.tigerduck.shared.TodayClassEntry
 import org.ntust.app.tigerduck.shared.TodayClassStatus
 import org.ntust.app.tigerduck.wear.R
 import org.ntust.app.tigerduck.wear.data.WatchSnapshot
-import org.ntust.app.tigerduck.wear.ui.theme.LocalAccentColor
 import org.ntust.app.tigerduck.wear.ui.theme.LocalScreenPadding
+import org.ntust.app.tigerduck.wear.ui.theme.wearCourseColor
 
 @Composable
 fun TodayScreen(
@@ -75,17 +74,23 @@ fun TodayScreen(
 
 @Composable
 private fun TodayRow(entry: TodayClassEntry, onClick: () -> Unit) {
-    val accent = LocalAccentColor.current
+    val courseColor = wearCourseColor(entry.course)
     val baseAlpha = if (entry.status == TodayClassStatus.Ended) 0.4f else 1f
+    // iOS WatchVisualStylePolicy (TigerDuck preset) tints every row's
+    // background with the course's own color so back-to-back rows stay
+    // distinguishable; the ongoing row simply lifts the alpha to mark it
+    // active, instead of swapping in a single shared accent.
+    val bgAlpha = when (entry.status) {
+        TodayClassStatus.Ongoing -> 0.22f
+        TodayClassStatus.Upcoming -> 0.12f
+        TodayClassStatus.Ended -> 0.08f
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .background(
-                if (entry.status == TodayClassStatus.Ongoing) accent.copy(alpha = 0.18f)
-                else Color.Transparent
-            )
+            .background(courseColor.copy(alpha = bgAlpha))
             .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 6.dp)
             .alpha(baseAlpha),
@@ -95,7 +100,7 @@ private fun TodayRow(entry: TodayClassEntry, onClick: () -> Unit) {
                 Modifier
                     .width(3.dp)
                     .height(28.dp)
-                    .background(accent)
+                    .background(courseColor)
             )
             Spacer(Modifier.width(6.dp))
         }

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/theme/WearTheme.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/theme/WearTheme.kt
@@ -7,8 +7,34 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material3.MaterialTheme
+import org.ntust.app.tigerduck.shared.Course
 
 val LocalAccentColor = staticCompositionLocalOf { Color(0xFF007AFF) }
+
+/**
+ * Tinted card surface per course — mirrors iOS WatchVisualStylePolicy's
+ * TigerDuck preset (Color(hex: course.colorHex) → backed-off surface). Honors
+ * a user-set [Course.customColorHex] first; otherwise picks deterministically
+ * from a small palette by hashing [Course.courseNo]. The phone-side
+ * collision-probing palette isn't sent over the wire, so this won't match the
+ * phone's per-course color picks exactly — it matches iOS's behavior of
+ * picking a color locally on the watch and stays stable across syncs.
+ */
+fun wearCourseColor(course: Course): Color {
+    course.customColorHex?.let { hex ->
+        runCatching { return Color(android.graphics.Color.parseColor(hex)) }
+    }
+    val hash = course.courseNo.fold(0) { acc, c -> (acc * 31 + c.code) and 0x7FFFFFFF }
+    return wearCoursePalette[hash % wearCoursePalette.size]
+}
+
+private val wearCoursePalette: List<Color> = listOf(
+    Color(0xFFDC2626), Color(0xFFEA580C), Color(0xFFD97706), Color(0xFFCA8A04),
+    Color(0xFF65A30D), Color(0xFF16A34A), Color(0xFF059669), Color(0xFF0D9488),
+    Color(0xFF0891B2), Color(0xFF0284C7), Color(0xFF2563EB), Color(0xFF4F46E5),
+    Color(0xFF7C3AED), Color(0xFF9333EA), Color(0xFFC026D3), Color(0xFFDB2777),
+    Color(0xFFE11D48), Color(0xFF475569),
+)
 
 /** Horizontal screen padding, user-adjustable in Settings. Defaults to 12 dp;
  *  bumping it helps on round watches where corners eat content. */


### PR DESCRIPTION
## Summary

Promotes the v1.4.2 release plus follow-ups from `dev` to `main`. Highlights:

**Wear OS**
- Library QR fullscreen page on watch with independent QR padding setting and corner-bracket preview.
- NowNext + Today screens synced to iOS watch behavior; settings page surfaces signed-in / last-sync / version.
- Debug clock override propagates to watch tile + complication immediately.

**Widgets**
- NextClass and Today widgets aligned with iOS behavior.
- WeekGrid renders 3+ chained 衝堂 (conflicting) courses instead of dropping one.

**Class table / Home**
- Renders 3+ chained 衝堂 courses; popup respects tapped slot's room.
- Per-period room resolution + split-day slots exposed in InClass slider.

**Debug clock**
- Repaints widgets + wear tile immediately on override change.

**Release plumbing**
- `1.4.2` version bump + ProGuard / cache-sentinel hardening to defend against the v1.3.x→v1.4.0 / v1.4.1→v1.4.2 upgrade-NPE pattern (see CLAUDE.md and the `upgrade-safe-persistence` skill).
- Added `.greptile/rules.md` and `pr-checklist.yaml` workflow.

181 conventional commits across `app/`, `wear/`, `shared/`, and the localization submodule.

## Test plan

- [ ] Phone: install fresh + upgrade from 1.4.1; confirm no NPE on launch, cache loads, classtable renders.
- [ ] Phone: 衝堂 slots (3+ chained) render correctly in classtable, home slider, week widget.
- [ ] Watch: Library QR opens fullscreen, padding setting persists, brightness boosts.
- [ ] Watch: NowNext + Today match iOS behavior; settings screen shows correct last-sync / version.
- [ ] Watch: tile + complication update when phone debug clock toggles.
- [ ] Widgets: NextClass + Today render correctly across sizes; auto-refresh on boundary.
- [ ] PR checklist workflow comment appears and gates merge.