### PR TITLE
feat(UI): add window-level FLAG_SECURE protection for sensitive components

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
@@ -44,14 +44,15 @@ fun SecureScreen(secure: Boolean = true) {
 
 /**
  * The window backing the current composition: a Compose `Dialog` hosts its
- * content in a view whose parent implements [DialogWindowProvider], exposing
- * the dialog's own window; outside a dialog we fall back to the Activity
- * window.
+ * content under a view implementing [DialogWindowProvider] — which may be
+ * `LocalView.current` itself or one of its ancestors — exposing the dialog's
+ * own window; outside a dialog we fall back to the Activity window.
  */
 @Composable
 private fun rememberHostWindow(): Window? {
     val view = LocalView.current
     return remember(view) {
+        if (view is DialogWindowProvider) return@remember view.window
         var parent: ViewParent? = view.parent
         while (parent != null) {
             if (parent is DialogWindowProvider) return@remember parent.window

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
@@ -1,0 +1,97 @@
+package org.ntust.app.tigerduck.ui.component
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.ViewParent
+import android.view.Window
+import android.view.WindowManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.window.DialogWindowProvider
+
+/**
+ * While [secure] is true, applies `WindowManager.LayoutParams.FLAG_SECURE` to
+ * the window hosting this composition: the OS keeps that window out of
+ * screenshots and screen recordings, and blanks it in the recent-apps
+ * overview. The flag is removed once [secure] goes false or this composable
+ * leaves composition.
+ *
+ * The "hosting window" is resolved per call site: inside a Compose `Dialog`
+ * (e.g. the login sheet) it is the dialog's own window — FLAG_SECURE on the
+ * Activity window does NOT cover a separate dialog window — and otherwise it
+ * is the Activity window.
+ *
+ * FLAG_SECURE is a per-window flag, so concurrent callers on the same window
+ * are reference counted: an inner caller leaving composition must not clear
+ * the flag while an outer caller still needs it. Acquire/release run on the
+ * composition (main) thread, so the counters need no synchronization.
+ */
+@Composable
+fun SecureScreen(secure: Boolean = true) {
+    val window = rememberHostWindow()
+    DisposableEffect(window, secure) {
+        if (window == null || !secure) {
+            onDispose { }
+        } else {
+            SecureWindowRegistry.acquire(window)
+            onDispose { SecureWindowRegistry.release(window) }
+        }
+    }
+}
+
+/**
+ * The window backing the current composition: a Compose `Dialog` hosts its
+ * content in a view whose parent implements [DialogWindowProvider], exposing
+ * the dialog's own window; outside a dialog we fall back to the Activity
+ * window.
+ */
+@Composable
+private fun rememberHostWindow(): Window? {
+    val view = LocalView.current
+    return remember(view) {
+        var parent: ViewParent? = view.parent
+        while (parent != null) {
+            if (parent is DialogWindowProvider) return@remember parent.window
+            parent = parent.parent
+        }
+        view.context.findActivity()?.window
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
+
+/**
+ * Per-window FLAG_SECURE reference counter. An entry is created on the first
+ * acquire of a window and removed when its last holder releases, so a
+ * destroyed Activity's or dismissed dialog's window is not retained.
+ */
+private object SecureWindowRegistry {
+    private val holders = HashMap<Window, Int>()
+
+    fun acquire(window: Window) {
+        val count = (holders[window] ?: 0) + 1
+        holders[window] = count
+        if (count == 1) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    fun release(window: Window) {
+        val count = (holders[window] ?: return) - 1
+        if (count <= 0) {
+            holders.remove(window)
+            // The window may already be detached (dialog dismissed / Activity
+            // destroyed); clearFlags on a dead window is a harmless no-op.
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        } else {
+            holders[window] = count
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/SecureScreen.kt
@@ -73,25 +73,40 @@ private tailrec fun Context.findActivity(): Activity? = when (this) {
  * destroyed Activity's or dismissed dialog's window is not retained.
  */
 private object SecureWindowRegistry {
-    private val holders = HashMap<Window, Int>()
+    /**
+     * [preexisting] records whether FLAG_SECURE was already set on the window
+     * when its first holder acquired it (e.g. another screen marked the whole
+     * window secure independently of this registry). When true, the last
+     * release must NOT clear the flag — doing so would strip protection this
+     * registry never added and leave the rest of the window screenshot-able.
+     */
+    private class Entry(var count: Int, val preexisting: Boolean)
+
+    private val holders = HashMap<Window, Entry>()
 
     fun acquire(window: Window) {
-        val count = (holders[window] ?: 0) + 1
-        holders[window] = count
-        if (count == 1) {
+        val entry = holders[window]
+        if (entry != null) {
+            entry.count++
+            return
+        }
+        val alreadySecure = (window.attributes.flags and
+            WindowManager.LayoutParams.FLAG_SECURE) != 0
+        holders[window] = Entry(count = 1, preexisting = alreadySecure)
+        if (!alreadySecure) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
     }
 
     fun release(window: Window) {
-        val count = (holders[window] ?: return) - 1
-        if (count <= 0) {
-            holders.remove(window)
+        val entry = holders[window] ?: return
+        entry.count--
+        if (entry.count > 0) return
+        holders.remove(window)
+        if (!entry.preexisting) {
             // The window may already be detached (dialog dismissed / Activity
             // destroyed); clearFlags on a dead window is a harmless no-op.
             window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        } else {
-            holders[window] = count
         }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/library/LibraryScreen.kt
@@ -51,6 +51,7 @@ import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
+import org.ntust.app.tigerduck.ui.component.SecureScreen
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 
 @Composable
@@ -104,6 +105,12 @@ fun LibraryScreen(
             }
         }
     }
+
+    // Keep the library QR — a credential-equivalent token — out of screenshots
+    // and screen recordings the whole time it is on screen (issue #88). Keyed
+    // on isLoggedIn rather than the bitmap so the 30 s auto-refresh doesn't
+    // toggle FLAG_SECURE on and off.
+    SecureScreen(secure = isLoggedIn)
 
     DisposableEffect(lifecycleOwner) {
         val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
@@ -347,6 +354,9 @@ private fun LoginPromptCard(
     val focusManager = LocalFocusManager.current
     val passwordFocusRequester = remember { FocusRequester() }
     var passwordVisible by remember { mutableStateOf(false) }
+    // Block screenshots / screen-recording while the library password is
+    // revealed as plaintext (issue #88).
+    SecureScreen(secure = passwordVisible)
     Card(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -129,6 +129,13 @@ fun OnboardingScreen(
     }
 
     fun goToPage(page: Int) {
+        // Mask any revealed password before the scroll animation starts.
+        // animateScrollToPage flips pagerState.currentPage while the login
+        // page (3) is still partly visible, so gating FLAG_SECURE on
+        // currentPage alone would clear it mid-transition and expose the
+        // plaintext to a screenshot (issue #88). Hiding the password first
+        // means there is nothing sensitive on screen once the flag drops.
+        passwordVisible = false
         scope.launch { pagerState.animateScrollToPage(page) }
     }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/onboarding/OnboardingScreen.kt
@@ -70,6 +70,7 @@ import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
 import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
+import org.ntust.app.tigerduck.ui.component.SecureScreen
 import org.ntust.app.tigerduck.ui.screen.settings.NotificationSetupContent
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 
@@ -151,6 +152,12 @@ fun OnboardingScreen(
             }
         }
     }
+
+    // Block screenshots / screen-recording while the NTUST password is
+    // revealed as plaintext on the login page (issue #88). FLAG_SECURE is
+    // window-wide, so it is only raised while the eye toggle is on AND the
+    // login page is the one on screen.
+    SecureScreen(secure = passwordVisible && pagerState.currentPage == 3)
 
     Box(modifier = Modifier
         .fillMaxSize()

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/LoginSheet.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.window.DialogProperties
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.ui.component.OutlinedAccountIdField
 import org.ntust.app.tigerduck.ui.component.PasswordTrailingIcons
+import org.ntust.app.tigerduck.ui.component.SecureScreen
 
 /**
  * Login prompt rendered as a custom Dialog wrapping a Material 3 Surface so the
@@ -129,6 +130,11 @@ fun LoginSheet(
                     .padding(horizontal = 24.dp, vertical = 24.dp),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
+                // Block screenshots / screen-recording of THIS dialog's window
+                // while the password is revealed as plaintext (issue #88). The
+                // dialog has its own window, so FLAG_SECURE on the Activity
+                // window behind it would not cover this content.
+                SecureScreen(secure = passwordVisible)
                 Text(
                     text = title,
                     style = MaterialTheme.typography.headlineSmall,

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/LibraryQRScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/LibraryQRScreen.kt
@@ -406,8 +406,20 @@ private fun SecureScreen() {
     val activity = remember(context) { context.findActivity() }
     DisposableEffect(activity) {
         val window = activity?.window
-        window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
+        // Snapshot whether the window was already secure (set by another owner
+        // or earlier). Only clear FLAG_SECURE on dispose if this composable is
+        // the one that added it — otherwise leaving the logged-in page would
+        // strip protection this helper never owned.
+        val alreadySecure = window != null && (window.attributes.flags and
+            WindowManager.LayoutParams.FLAG_SECURE) != 0
+        if (window != null && !alreadySecure) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+        onDispose {
+            if (window != null && !alreadySecure) {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            }
+        }
     }
 }
 

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/LibraryQRScreen.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/ui/LibraryQRScreen.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.net.Uri
+import android.view.WindowManager
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -170,6 +171,11 @@ private fun LoggedInState(username: String?) {
     // Hold the screen at full brightness while a QR is visible on either
     // mode — librarians' scanners read poorly through the dim default.
     KeepScreenBright(active = bitmap != null)
+
+    // Keep the QR — a credential-equivalent token — out of screenshots and
+    // screen recordings the whole time the logged-in page is on screen
+    // (issue #88).
+    SecureScreen()
 
     if (isFullscreen) {
         FullscreenQR(
@@ -391,6 +397,17 @@ private fun KeepScreenBright(active: Boolean) {
                 window.attributes = window.attributes.apply { screenBrightness = previous }
             }
         }
+    }
+}
+
+@Composable
+private fun SecureScreen() {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findActivity() }
+    DisposableEffect(activity) {
+        val window = activity?.window
+        window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        onDispose { window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
     }
 }
 


### PR DESCRIPTION
#88

Adds window-level `FLAG_SECURE` protection so sensitive components cannot be screenshotted or screen-recorded.

## What

A reusable `SecureScreen(secure)` composable effect that toggles `WindowManager.LayoutParams.FLAG_SECURE` on the host window (the OS then excludes that window from screenshots, screen recordings, and the recent-apps thumbnail).

Applied to:
- **Plaintext password** — secured only while revealed via the eye toggle (masked login forms stay screenshot-able): onboarding login page, Settings login dialog (NTUST + Library), Library login card.
- **Library QR code** — secured the whole time it is on screen, on both **phone** and **watch**.

## Design notes

- **Dialog windows** — `LoginSheet` is a Compose `Dialog` with its own window; `FLAG_SECURE` on the Activity window would not cover it. The phone helper resolves the host window via `DialogWindowProvider`, falling back to the Activity window.
- **Reference-counted per window** — `FLAG_SECURE` is window-wide, so concurrent callers are counted to prevent one caller's `onDispose` clearing the flag another still needs.
- **No flicker** — keyed on `isLoggedIn` / screen presence rather than the QR bitmap, so the 30 s auto-refresh does not toggle the flag.

## Scope

No string/localization or data-model changes. No new keep rules needed (`SecureScreen` uses no reflection/serialization).

## Testing

Builds: `:app:compilePlayDebugKotlin`, `:app:compileFdroidDebugKotlin`, `:wear:compileDebugKotlin` all pass. Manually verified: reveal/screenshot blocked on each password site, QR screenshot blocked on phone and watch, non-sensitive screens unaffected.