### PR TITLE
feat: update notifications & What's New dialog

### DIFF
--- a/.github/workflows/pr-checklist.yaml
+++ b/.github/workflows/pr-checklist.yaml
@@ -43,6 +43,7 @@ jobs:
             - [ ] I have tested on my phone (watch) / emulator that no existing functions are broken.
             - [ ] I have tested on my phone (watch) / emulator that upgrading from the previous version does not break the app.
             - [ ] I am confident that users upgrading from much older versions (3 versions behind) are unlikely to experience breakage or crashes.
+            - [ ] I have updated the \`whatsnew.json\` under \`app/src/main/assets/\`.
             `;
 
             // Resolve PR number for either trigger.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.4.2"
+        versionCode = 21
+        versionName = "1.4.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -187,6 +187,7 @@ tasks.matching { it.name.startsWith("merge") && it.name.endsWith("Assets") }
 dependencies {
     implementation(project(":shared"))
     "playImplementation"(libs.play.services.wearable)
+    "playImplementation"(libs.play.app.update.ktx)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,6 +20,10 @@
 -keep class org.ntust.app.tigerduck.announcements.SubscriptionsResponse { *; }
 -keep class org.ntust.app.tigerduck.announcements.SubscriptionsPutRequest { *; }
 -keep class org.ntust.app.tigerduck.data.cache.DataCache$* { *; }
+# What's-new content (assets/whatsnew.json) is Gson-deserialized into
+# WhatsNewContent. Without this keep, R8 renames its fields and Gson reads
+# nulls — same failure mode as the other unannotated DTOs above.
+-keep class org.ntust.app.tigerduck.update.WhatsNewContent { *; }
 # Wire DTO Gson-serializes to the watch. Unannotated fields, so R8 must
 # not rename them — otherwise the phone sends obfuscated JSON keys the
 # watch-side CourseWire can't recognize.

--- a/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -1,6 +1,8 @@
 package org.ntust.app.tigerduck.update
 
 import android.app.Activity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +25,9 @@ class UpdateChecker @Inject constructor() {
     /** Never flips — fdroid has no in-app update flow. */
     val installReady: StateFlow<Boolean> = MutableStateFlow(false).asStateFlow()
 
-    fun maybePromptForUpdate(activity: Activity) = Unit
+    fun maybePromptForUpdate(launcher: ActivityResultLauncher<IntentSenderRequest>) = Unit
+
+    fun onUpdateFlowResult(resultCode: Int) = Unit
 
     fun resume(activity: Activity) = Unit
 

--- a/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -1,0 +1,31 @@
+package org.ntust.app.tigerduck.update
+
+import android.app.Activity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * F-Droid stub. The fdroid flavor ships without Google Play Services, so
+ * Play's in-app update API is unavailable — and the F-Droid client notifies
+ * users of updates out-of-band anyway, making an in-app prompt redundant
+ * (issue #89).
+ *
+ * Same FQN as the play-flavor implementation so `MainActivity` in `main/` can
+ * inject and call it regardless of which flavor is being built — same pattern
+ * as `FcmBootstrap`. No GMS dependencies, so this compiles on fdroid.
+ */
+@Singleton
+class UpdateChecker @Inject constructor() {
+
+    /** Never flips — fdroid has no in-app update flow. */
+    val installReady: StateFlow<Boolean> = MutableStateFlow(false).asStateFlow()
+
+    fun maybePromptForUpdate(activity: Activity) = Unit
+
+    fun resume(activity: Activity) = Unit
+
+    fun completeUpdate() = Unit
+}

--- a/app/src/main/assets/whatsnew.json
+++ b/app/src/main/assets/whatsnew.json
@@ -1,0 +1,18 @@
+{
+  "21": {
+    "zh-TW": {
+      "title": "1.5.0 有什麼新功能",
+      "highlights": [
+        "新版本推出時會在 App 內提醒你更新。",
+        "升級後首次開啟會顯示這個「新功能」說明。"
+      ]
+    },
+    "en": {
+      "title": "What's new in 1.5.0",
+      "highlights": [
+        "The app now reminds you in-app when a new version is available.",
+        "After upgrading, this \"What's new\" summary appears on first launch."
+      ]
+    }
+  }
+}

--- a/app/src/main/assets/whatsnew.json
+++ b/app/src/main/assets/whatsnew.json
@@ -1,14 +1,14 @@
 {
   "21": {
     "zh-TW": {
-      "title": "1.5.0 有什麼新功能",
+      "title": "1.4.3 有什麼新功能",
       "highlights": [
         "新版本推出時會在 App 內提醒你更新。",
         "升級後首次開啟會顯示這個「新功能」說明。"
       ]
     },
     "en": {
-      "title": "What's new in 1.5.0",
+      "title": "What's new in 1.4.3",
       "highlights": [
         "The app now reminds you in-app when a new version is available.",
         "After upgrading, this \"What's new\" summary appears on first launch."

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -207,6 +207,7 @@ class MainActivity : AppCompatActivity() {
      * Decides whether to show the "What's new" dialog. Fresh installs
      * (sentinel last-seen versionCode) silently record the current version and
      * show nothing; upgrades show the dialog if `whatsnew.json` has an entry.
+     * The debug "Replay What's new" sentinel forces the newest authored entry.
      */
     private fun resolveWhatsNew() {
         val current = BuildConfig.VERSION_CODE
@@ -215,8 +216,13 @@ class MainActivity : AppCompatActivity() {
             appPreferences.lastSeenWhatsNewVersionCode = current
             return
         }
-        if (WhatsNewGate.shouldShow(lastSeen, current)) {
-            val languageTag = resources.configuration.locales[0].toLanguageTag()
+        val languageTag = resources.configuration.locales[0].toLanguageTag()
+        if (lastSeen == AppPreferences.WHATS_NEW_REPLAY) {
+            // Debug "Replay What's new": show the newest authored entry even if
+            // this build's versionCode predates it — whatsnew.json is usually
+            // written ahead of the version bump, so entryFor(current) would miss.
+            whatsNewContent.value = whatsNewRepository.latestEntry(languageTag)
+        } else if (WhatsNewGate.shouldShow(lastSeen, current)) {
             whatsNewContent.value = whatsNewRepository.entryFor(current, languageTag)
         }
         // Record regardless of whether an entry existed, so a missing entry

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -68,6 +68,14 @@ class MainActivity : AppCompatActivity() {
             if (granted) liveActivityManager.refresh()
         }
 
+    // Receives the result of Play's in-app update confirmation UI. Routing it
+    // back lets UpdateChecker attach its install listener only when the user
+    // accepted, so a cancelled flow leaves nothing registered (issue #89).
+    private val updateFlowLauncher =
+        registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
+            updateChecker.onUpdateFlowResult(result.resultCode)
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
@@ -87,7 +95,7 @@ class MainActivity : AppCompatActivity() {
         // Re-prompt for app updates only on a genuine fresh start, never on a
         // rotation/config-change recreation (issue #89).
         if (savedInstanceState == null) {
-            updateChecker.maybePromptForUpdate(this)
+            updateChecker.maybePromptForUpdate(updateFlowLauncher)
         }
         // Resolve "What's new" on every onCreate, including config-change
         // recreations: the dialog's versionCode is recorded only once the user

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -14,7 +14,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -81,12 +84,17 @@ class MainActivity : AppCompatActivity() {
 
         widgetStartRoute.value = resolveStartRoute(intent)
 
-        // Update prompt + "what's new" — only on the first creation, not on
-        // rotation/config-change recreations (issue #89).
+        // Re-prompt for app updates only on a genuine fresh start, never on a
+        // rotation/config-change recreation (issue #89).
         if (savedInstanceState == null) {
             updateChecker.maybePromptForUpdate(this)
-            resolveWhatsNew()
         }
+        // Resolve "What's new" on every onCreate, including config-change
+        // recreations: the dialog's versionCode is recorded only once the user
+        // dismisses it (see resolveWhatsNew), so re-deriving here re-shows a
+        // dialog the user had not yet dismissed instead of dropping it
+        // permanently on rotation (issue #89).
+        resolveWhatsNew()
 
         setContent {
             // Re-apply orientation whenever the user changes the setting
@@ -128,14 +136,27 @@ class MainActivity : AppCompatActivity() {
                         val updateSnackbarHostState = remember { SnackbarHostState() }
                         SnackbarHost(
                             updateSnackbarHostState,
-                            modifier = Modifier.align(Alignment.BottomCenter),
+                            // Bare SnackbarHost (unlike Scaffold) applies no
+                            // insets; pad it so the snackbar clears the system
+                            // navigation bar and the IME under enableEdgeToEdge.
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .windowInsetsPadding(WindowInsets.safeDrawing),
                         )
                         UpdateInstallSnackbar(updateChecker, updateSnackbarHostState)
 
                         whatsNewContent.value?.let { content ->
                             WhatsNewDialog(
                                 content = content,
-                                onDismiss = { whatsNewContent.value = null },
+                                onDismiss = {
+                                    whatsNewContent.value = null
+                                    // Record the seen versionCode only now: a
+                                    // dialog dropped by a config-change
+                                    // recreation before this runs is re-shown
+                                    // on the next onCreate (issue #89).
+                                    appPreferences.lastSeenWhatsNewVersionCode =
+                                        BuildConfig.VERSION_CODE
+                                },
                             )
                         }
                     }
@@ -208,6 +229,11 @@ class MainActivity : AppCompatActivity() {
      * (sentinel last-seen versionCode) silently record the current version and
      * show nothing; upgrades show the dialog if `whatsnew.json` has an entry.
      * The debug "Replay What's new" sentinel forces the newest authored entry.
+     *
+     * Safe to call on every onCreate: when a dialog is shown the last-seen
+     * versionCode is recorded on dismiss (not here), so a config-change
+     * recreation re-runs this and re-shows a still-pending dialog instead of
+     * dropping it permanently (issue #89).
      */
     private fun resolveWhatsNew() {
         val current = BuildConfig.VERSION_CODE
@@ -217,17 +243,23 @@ class MainActivity : AppCompatActivity() {
             return
         }
         val languageTag = resources.configuration.locales[0].toLanguageTag()
-        if (lastSeen == AppPreferences.WHATS_NEW_REPLAY) {
+        val content = when {
             // Debug "Replay What's new": show the newest authored entry even if
             // this build's versionCode predates it — whatsnew.json is usually
             // written ahead of the version bump, so entryFor(current) would miss.
-            whatsNewContent.value = whatsNewRepository.latestEntry(languageTag)
-        } else if (WhatsNewGate.shouldShow(lastSeen, current)) {
-            whatsNewContent.value = whatsNewRepository.entryFor(current, languageTag)
+            lastSeen == AppPreferences.WHATS_NEW_REPLAY ->
+                whatsNewRepository.latestEntry(languageTag)
+            WhatsNewGate.shouldShow(lastSeen, current) ->
+                whatsNewRepository.entryFor(current, languageTag)
+            else -> null
         }
-        // Record regardless of whether an entry existed, so a missing entry
-        // does not re-trigger the lookup on every launch.
-        appPreferences.lastSeenWhatsNewVersionCode = current
+        whatsNewContent.value = content
+        if (content == null) {
+            // Nothing to show — record now so a missing entry does not
+            // re-trigger the lookup on every launch. When a dialog *is* shown,
+            // its onDismiss records the versionCode instead.
+            appPreferences.lastSeenWhatsNewVersionCode = current
+        }
     }
 
     private fun requestNotificationPermissionIfNeeded() {

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -13,10 +13,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,8 +31,14 @@ import org.ntust.app.tigerduck.liveactivity.LiveActivityManager
 import org.ntust.app.tigerduck.notification.BackgroundSyncWorker
 import org.ntust.app.tigerduck.ui.AppState
 import org.ntust.app.tigerduck.ui.navigation.AppNavigation
+import org.ntust.app.tigerduck.ui.screen.whatsnew.WhatsNewDialog
 import org.ntust.app.tigerduck.ui.theme.TigerDuckAppTheme
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
+import org.ntust.app.tigerduck.update.UpdateChecker
+import org.ntust.app.tigerduck.update.UpdateInstallSnackbar
+import org.ntust.app.tigerduck.update.WhatsNewContent
+import org.ntust.app.tigerduck.update.WhatsNewGate
+import org.ntust.app.tigerduck.update.WhatsNewRepository
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -39,8 +50,15 @@ class MainActivity : AppCompatActivity() {
     lateinit var liveActivityManager: LiveActivityManager
     @Inject
     lateinit var authService: AuthService
+    @Inject
+    lateinit var updateChecker: UpdateChecker
+    @Inject
+    lateinit var whatsNewRepository: WhatsNewRepository
+    @Inject
+    lateinit var appPreferences: AppPreferences
 
     private val widgetStartRoute = mutableStateOf<String?>(null)
+    private val whatsNewContent = mutableStateOf<WhatsNewContent?>(null)
 
     private val requestNotificationPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
@@ -63,6 +81,13 @@ class MainActivity : AppCompatActivity() {
 
         widgetStartRoute.value = resolveStartRoute(intent)
 
+        // Update prompt + "what's new" — only on the first creation, not on
+        // rotation/config-change recreations (issue #89).
+        if (savedInstanceState == null) {
+            updateChecker.maybePromptForUpdate(this)
+            resolveWhatsNew()
+        }
+
         setContent {
             // Re-apply orientation whenever the user changes the setting
             // from within the app — Settings lives inside this Activity, so
@@ -79,21 +104,41 @@ class MainActivity : AppCompatActivity() {
 
             TigerDuckAppTheme(darkTheme = dark, accentColor = appState.accentColor(dark)) {
                 Surface(modifier = Modifier.fillMaxSize()) {
-                    AppNavigation(
-                        appState = appState,
-                        widgetStartRoute = widgetStartRoute.value,
-                        onStartRouteConsumed = {
-                            widgetStartRoute.value = null
-                            // Clear the deep-link payload so a later onCreate
-                            // (e.g. after rotation) doesn't re-navigate to the
-                            // route the user already consumed.
-                            intent?.let {
-                                it.data = null
-                                it.removeExtra("start_route")
-                                intent = it
-                            }
-                        },
-                    )
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        AppNavigation(
+                            appState = appState,
+                            widgetStartRoute = widgetStartRoute.value,
+                            onStartRouteConsumed = {
+                                widgetStartRoute.value = null
+                                // Clear the deep-link payload so a later onCreate
+                                // (e.g. after rotation) doesn't re-navigate to the
+                                // route the user already consumed.
+                                intent?.let {
+                                    it.data = null
+                                    it.removeExtra("start_route")
+                                    intent = it
+                                }
+                            },
+                        )
+
+                        // App-global snackbar host for the in-app update
+                        // "ready to install" prompt (issue #89). The app's
+                        // other snackbar hosts are per-screen; this one
+                        // outlives navigation.
+                        val updateSnackbarHostState = remember { SnackbarHostState() }
+                        SnackbarHost(
+                            updateSnackbarHostState,
+                            modifier = Modifier.align(Alignment.BottomCenter),
+                        )
+                        UpdateInstallSnackbar(updateChecker, updateSnackbarHostState)
+
+                        whatsNewContent.value?.let { content ->
+                            WhatsNewDialog(
+                                content = content,
+                                onDismiss = { whatsNewContent.value = null },
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -102,6 +147,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         liveActivityManager.refresh()
+        updateChecker.resume(this)
         // Pref may have changed in Settings (which itself can run while
         // landscape-locked). Re-apply on every resume so the new choice
         // takes effect without needing an Activity recreate.
@@ -155,6 +201,27 @@ class MainActivity : AppCompatActivity() {
             return "announcements/detail/$id"
         }
         return null
+    }
+
+    /**
+     * Decides whether to show the "What's new" dialog. Fresh installs
+     * (sentinel last-seen versionCode) silently record the current version and
+     * show nothing; upgrades show the dialog if `whatsnew.json` has an entry.
+     */
+    private fun resolveWhatsNew() {
+        val current = BuildConfig.VERSION_CODE
+        val lastSeen = appPreferences.lastSeenWhatsNewVersionCode
+        if (lastSeen == AppPreferences.WHATS_NEW_UNSET) {
+            appPreferences.lastSeenWhatsNewVersionCode = current
+            return
+        }
+        if (WhatsNewGate.shouldShow(lastSeen, current)) {
+            val languageTag = resources.configuration.locales[0].toLanguageTag()
+            whatsNewContent.value = whatsNewRepository.entryFor(current, languageTag)
+        }
+        // Record regardless of whether an entry existed, so a missing entry
+        // does not re-trigger the lookup on every launch.
+        appPreferences.lastSeenWhatsNewVersionCode = current
     }
 
     private fun requestNotificationPermissionIfNeeded() {

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -93,8 +93,9 @@ class MainActivity : AppCompatActivity() {
         // recreations: the dialog's versionCode is recorded only once the user
         // dismisses it (see resolveWhatsNew), so re-deriving here re-shows a
         // dialog the user had not yet dismissed instead of dropping it
-        // permanently on rotation (issue #89).
-        resolveWhatsNew()
+        // permanently on rotation (issue #89). freshStart keeps the debug
+        // "Replay" sentinel from being consumed by a mere recreation.
+        resolveWhatsNew(freshStart = savedInstanceState == null)
 
         setContent {
             // Re-apply orientation whenever the user changes the setting
@@ -225,31 +226,54 @@ class MainActivity : AppCompatActivity() {
     }
 
     /**
-     * Decides whether to show the "What's new" dialog. Fresh installs
-     * (sentinel last-seen versionCode) silently record the current version and
-     * show nothing; upgrades show the dialog if `whatsnew.json` has an entry.
-     * The debug "Replay What's new" sentinel forces the newest authored entry.
+     * Decides whether to show the "What's new" dialog. A fresh install records
+     * the current version and shows nothing; upgrades show the dialog if
+     * `whatsnew.json` has an entry. A user upgrading from a build that predates
+     * the last-seen pref has no recorded versionCode either, but — unlike a
+     * fresh install — has completed onboarding; that distinguishes the two so
+     * real upgrades still get the dialog once. The debug "Replay What's new"
+     * sentinel forces the newest authored entry.
      *
      * Safe to call on every onCreate: when a dialog is shown the last-seen
      * versionCode is recorded on dismiss (not here), so a config-change
      * recreation re-runs this and re-shows a still-pending dialog instead of
-     * dropping it permanently (issue #89).
+     * dropping it permanently (issue #89). [freshStart] is false for such
+     * recreations; the debug replay sentinel is only consumed when it is true,
+     * so rotating after tapping the debug row can't pop the dialog mid-session.
      */
-    private fun resolveWhatsNew() {
+    private fun resolveWhatsNew(freshStart: Boolean) {
         val current = BuildConfig.VERSION_CODE
         val lastSeen = appPreferences.lastSeenWhatsNewVersionCode
-        if (lastSeen == AppPreferences.WHATS_NEW_UNSET) {
+        val languageTag = resources.configuration.locales[0].toLanguageTag()
+
+        // Debug "Replay What's new": show the newest authored entry even if
+        // this build's versionCode predates it — whatsnew.json is usually
+        // written ahead of the version bump. Only consume the sentinel on a
+        // genuine process start; on a rotation/config-change recreation leave
+        // it set so the replay fires on the *next* launch as the Settings row
+        // promises, instead of popping the dialog the instant the device turns.
+        if (lastSeen == AppPreferences.WHATS_NEW_REPLAY) {
+            if (!freshStart) return
+            val replay = whatsNewRepository.latestEntry(languageTag)
+            whatsNewContent.value = replay
+            if (replay == null) appPreferences.lastSeenWhatsNewVersionCode = current
+            return
+        }
+
+        // No versionCode on record. A genuine fresh install shows nothing — a
+        // new user has missed nothing. A user upgrading from a build that
+        // predates this pref also has no record, but has completed onboarding;
+        // fall through and show the current version's entry once.
+        if (lastSeen == AppPreferences.WHATS_NEW_UNSET && !appPreferences.hasCompletedOnboarding) {
             appPreferences.lastSeenWhatsNewVersionCode = current
             return
         }
-        val languageTag = resources.configuration.locales[0].toLanguageTag()
+
         val content = when {
-            // Debug "Replay What's new": show the newest authored entry even if
-            // this build's versionCode predates it — whatsnew.json is usually
-            // written ahead of the version bump, so entryFor(current) would miss.
-            lastSeen == AppPreferences.WHATS_NEW_REPLAY ->
-                whatsNewRepository.latestEntry(languageTag)
-            WhatsNewGate.shouldShow(lastSeen, current) ->
+            // UNSET here means a pre-feature upgrade (onboarding already done);
+            // the normal gate only fires for a recorded older versionCode.
+            lastSeen == AppPreferences.WHATS_NEW_UNSET ||
+                WhatsNewGate.shouldShow(lastSeen, current) ->
                 whatsNewRepository.entryFor(current, languageTag)
             else -> null
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -70,9 +70,11 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
         set(value) = prefs.edit().putLong("lastUpdatePromptEpoch", value).apply()
 
     // --- "What's new" dialog ---
-    // WHATS_NEW_UNSET (-1) means "fresh install" — no prior version was seen,
-    // so the dialog is suppressed and this is silently set to the current
-    // versionCode on first launch.
+    // WHATS_NEW_UNSET (-1) means no versionCode has been recorded yet — either
+    // a fresh install or an upgrade from a build that predates this pref.
+    // MainActivity.resolveWhatsNew() tells the two apart via
+    // hasCompletedOnboarding: a fresh install is suppressed, a real upgrade
+    // shows the dialog once.
     // WHATS_NEW_REPLAY (0) is the debug "Replay What's new" sentinel — it is
     // not a real versionCode, and tells resolveWhatsNew() to show the newest
     // authored entry regardless of this build's versionCode.

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -73,6 +73,9 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
     // WHATS_NEW_UNSET (-1) means "fresh install" — no prior version was seen,
     // so the dialog is suppressed and this is silently set to the current
     // versionCode on first launch.
+    // WHATS_NEW_REPLAY (0) is the debug "Replay What's new" sentinel — it is
+    // not a real versionCode, and tells resolveWhatsNew() to show the newest
+    // authored entry regardless of this build's versionCode.
     var lastSeenWhatsNewVersionCode: Int
         get() = prefs.getInt("lastSeenWhatsNewVersionCode", WHATS_NEW_UNSET)
         set(value) = prefs.edit().putInt("lastSeenWhatsNewVersionCode", value).apply()
@@ -322,6 +325,7 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
 
     companion object {
         const val WHATS_NEW_UNSET = -1
+        const val WHATS_NEW_REPLAY = 0
 
         const val MIN_TUNABLE_HAPTIC_DURATION_MS = 5
         const val MAX_TUNABLE_HAPTIC_DURATION_MS = 60

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -59,6 +59,24 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
         get() = prefs.getBoolean("hasCompletedOnboarding", false)
         set(value) = prefs.edit().putBoolean("hasCompletedOnboarding", value).apply()
 
+    // --- Update notification (issue #89) ---
+    // Sentinel for "no update prompt shown yet".
+    var lastUpdatePromptVersionCode: Int
+        get() = prefs.getInt("lastUpdatePromptVersionCode", -1)
+        set(value) = prefs.edit().putInt("lastUpdatePromptVersionCode", value).apply()
+
+    var lastUpdatePromptEpoch: Long
+        get() = prefs.getLong("lastUpdatePromptEpoch", 0L)
+        set(value) = prefs.edit().putLong("lastUpdatePromptEpoch", value).apply()
+
+    // --- "What's new" dialog ---
+    // WHATS_NEW_UNSET (-1) means "fresh install" — no prior version was seen,
+    // so the dialog is suppressed and this is silently set to the current
+    // versionCode on first launch.
+    var lastSeenWhatsNewVersionCode: Int
+        get() = prefs.getInt("lastSeenWhatsNewVersionCode", WHATS_NEW_UNSET)
+        set(value) = prefs.edit().putInt("lastSeenWhatsNewVersionCode", value).apply()
+
     private val _accentColorChanged = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -303,6 +321,8 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
+        const val WHATS_NEW_UNSET = -1
+
         const val MIN_TUNABLE_HAPTIC_DURATION_MS = 5
         const val MAX_TUNABLE_HAPTIC_DURATION_MS = 60
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.AppFeature
@@ -93,6 +94,7 @@ fun SettingsScreen(
     val shouldShowEnglishAbbreviationToggle = AppLanguageManager.isCourseApiEnglish(appLanguage)
 
     val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
 
     val appVersion = remember { BuildConfig.VERSION_NAME }
 
@@ -408,6 +410,19 @@ fun SettingsScreen(
                             SettingsLinkRow("Time override") { onNavigateToDebug() }
                             HorizontalDivider()
                             SettingsLinkRow("Notification") { onNavigateToNotificationDebug() }
+                            HorizontalDivider()
+                            // Rewind the last-seen versionCode below the current
+                            // build so resolveWhatsNew() re-triggers the dialog on
+                            // the next process start. 0 (not WHATS_NEW_UNSET) makes
+                            // the gate treat this as an upgrade, not a fresh install.
+                            SettingsLinkRow("Replay \"What's new\" on next launch") {
+                                viewModel.prefs.lastSeenWhatsNewVersionCode = 0
+                                scope.launch {
+                                    snackbarHostState.showSnackbar(
+                                        "\"What's new\" will show on next app launch.",
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -411,12 +411,12 @@ fun SettingsScreen(
                             HorizontalDivider()
                             SettingsLinkRow("Notification") { onNavigateToNotificationDebug() }
                             HorizontalDivider()
-                            // Rewind the last-seen versionCode below the current
-                            // build so resolveWhatsNew() re-triggers the dialog on
-                            // the next process start. 0 (not WHATS_NEW_UNSET) makes
-                            // the gate treat this as an upgrade, not a fresh install.
+                            // Set the replay sentinel so resolveWhatsNew() shows
+                            // the newest whatsnew.json entry on the next process
+                            // start, regardless of this build's versionCode.
                             SettingsLinkRow("Replay \"What's new\" on next launch") {
-                                viewModel.prefs.lastSeenWhatsNewVersionCode = 0
+                                viewModel.prefs.lastSeenWhatsNewVersionCode =
+                                    AppPreferences.WHATS_NEW_REPLAY
                                 scope.launch {
                                     snackbarHostState.showSnackbar(
                                         "\"What's new\" will show on next app launch.",

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.update.WhatsNewContent
 
 /**
@@ -44,7 +43,8 @@ fun WhatsNewDialog(
         },
         confirmButton = {
             TextButton(onClick = onDismiss) {
-                Text(stringResource(R.string.action_got_it))
+                // Framework string — localized by the platform in every locale.
+                Text(stringResource(android.R.string.ok))
             }
         },
     )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
@@ -17,7 +17,7 @@ import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.update.WhatsNewContent
 
 /**
- * Shown on the first launch after an upgrade (issue #89). Content comes from
+ * Shown on the first launch after an upgrade. Content comes from
  * `assets/whatsnew.json` via `WhatsNewRepository`. Rendered as an AlertDialog
  * to match the rest of the app's dialogs (e.g. AddSectionDialog).
  */

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
@@ -1,0 +1,51 @@
+package org.ntust.app.tigerduck.ui.screen.whatsnew
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.update.WhatsNewContent
+
+/**
+ * Shown on the first launch after an upgrade (issue #89). Content comes from
+ * `assets/whatsnew.json` via `WhatsNewRepository`. Rendered as an AlertDialog
+ * to match the rest of the app's dialogs (e.g. AddSectionDialog).
+ */
+@Composable
+fun WhatsNewDialog(
+    content: WhatsNewContent,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(content.title.orEmpty()) },
+        text = {
+            Column(
+                modifier = Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                content.highlights.orEmpty().forEach { line ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("•", style = MaterialTheme.typography.bodyMedium)
+                        Text(line, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_got_it))
+            }
+        },
+    )
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/update/UpdateInstallSnackbar.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/UpdateInstallSnackbar.kt
@@ -1,0 +1,40 @@
+package org.ntust.app.tigerduck.update
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.ntust.app.tigerduck.R
+
+/**
+ * Observes [UpdateChecker.installReady]; once a FLEXIBLE update has downloaded,
+ * shows an indefinite snackbar with a "Restart" action that installs it.
+ *
+ * Flavor-safe: on fdroid `installReady` is permanently false, so this never
+ * shows anything.
+ */
+@Composable
+fun UpdateInstallSnackbar(
+    updateChecker: UpdateChecker,
+    snackbarHostState: SnackbarHostState,
+) {
+    val installReady by updateChecker.installReady.collectAsStateWithLifecycle()
+    val message = stringResource(R.string.update_ready_message)
+    val actionLabel = stringResource(R.string.update_restart_action)
+
+    LaunchedEffect(installReady) {
+        if (!installReady) return@LaunchedEffect
+        val result = snackbarHostState.showSnackbar(
+            message = message,
+            actionLabel = actionLabel,
+            duration = SnackbarDuration.Indefinite,
+        )
+        if (result == SnackbarResult.ActionPerformed) {
+            updateChecker.completeUpdate()
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/update/UpdatePromptGate.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/UpdatePromptGate.kt
@@ -1,0 +1,43 @@
+package org.ntust.app.tigerduck.update
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Pure gating logic for the in-app update prompt. Kept Android-free so it is
+ * unit-testable and so the flavor-specific [UpdateChecker] (play) only has to
+ * supply raw values from `AppUpdateInfo`.
+ *
+ * "Don't nag" policy (issue #89): only prompt for updates that are genuinely
+ * stale, and never re-prompt for the same available version inside a cooldown
+ * window — some users intentionally stay on an older version.
+ */
+object UpdatePromptGate {
+
+    /** Minimum days the installed version must be behind before prompting. */
+    const val STALENESS_THRESHOLD_DAYS = 3
+
+    /** Re-prompt cooldown for the same available versionCode. */
+    val COOLDOWN_MS: Long = TimeUnit.DAYS.toMillis(7)
+
+    /**
+     * @param stalenessDays Play's `clientVersionStalenessDays()` — null when
+     *   Play has not yet determined how stale the installed version is.
+     * @param availableVersionCode the versionCode Play is offering.
+     * @param lastPromptVersionCode the versionCode last prompted for (-1 if none).
+     * @param lastPromptEpoch epoch-ms of the last prompt (0 if none).
+     * @param now current epoch-ms.
+     */
+    fun shouldStartFlow(
+        stalenessDays: Int?,
+        availableVersionCode: Int,
+        lastPromptVersionCode: Int,
+        lastPromptEpoch: Long,
+        now: Long,
+    ): Boolean {
+        if ((stalenessDays ?: 0) < STALENESS_THRESHOLD_DAYS) return false
+        val sameVersionWithinCooldown =
+            availableVersionCode == lastPromptVersionCode &&
+                now - lastPromptEpoch < COOLDOWN_MS
+        return !sameVersionWithinCooldown
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/update/UpdatePromptGate.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/UpdatePromptGate.kt
@@ -21,7 +21,9 @@ object UpdatePromptGate {
 
     /**
      * @param stalenessDays Play's `clientVersionStalenessDays()` — null when
-     *   Play has not yet determined how stale the installed version is.
+     *   Play has not yet determined how stale the installed version is. A null
+     *   value does not block the prompt: Play already reported the update as
+     *   available, so missing staleness data must not suppress it.
      * @param availableVersionCode the versionCode Play is offering.
      * @param lastPromptVersionCode the versionCode last prompted for (-1 if none).
      * @param lastPromptEpoch epoch-ms of the last prompt (0 if none).
@@ -34,7 +36,7 @@ object UpdatePromptGate {
         lastPromptEpoch: Long,
         now: Long,
     ): Boolean {
-        if ((stalenessDays ?: 0) < STALENESS_THRESHOLD_DAYS) return false
+        if (stalenessDays != null && stalenessDays < STALENESS_THRESHOLD_DAYS) return false
         val sameVersionWithinCooldown =
             availableVersionCode == lastPromptVersionCode &&
                 now - lastPromptEpoch < COOLDOWN_MS

--- a/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewGate.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewGate.kt
@@ -1,0 +1,18 @@
+package org.ntust.app.tigerduck.update
+
+import org.ntust.app.tigerduck.data.preferences.AppPreferences
+
+/**
+ * Pure gating logic for the "What's new" dialog.
+ *
+ * The dialog is shown exactly once after an upgrade. A fresh install (last-seen
+ * versionCode is the [AppPreferences.WHATS_NEW_UNSET] sentinel) shows nothing —
+ * a brand-new user hasn't missed anything.
+ */
+object WhatsNewGate {
+
+    fun shouldShow(lastSeenVersionCode: Int, currentVersionCode: Int): Boolean {
+        if (lastSeenVersionCode == AppPreferences.WHATS_NEW_UNSET) return false
+        return lastSeenVersionCode < currentVersionCode
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewModels.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewModels.kt
@@ -1,0 +1,16 @@
+package org.ntust.app.tigerduck.update
+
+/**
+ * One localized "What's new" block, deserialized by Gson from
+ * `assets/whatsnew.json`.
+ *
+ * Fields are nullable as defensive practice for a Gson-deserialized class
+ * (see CLAUDE.md). This asset ships inside the APK and always matches the app
+ * version, so the upgrade-crash pattern does not apply — but [WhatsNewContent]
+ * still REQUIRES a `-keep` rule in `proguard-rules.pro` so R8 does not rename
+ * its fields out from under Gson.
+ */
+data class WhatsNewContent(
+    val title: String? = null,
+    val highlights: List<String>? = null,
+)

--- a/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
@@ -24,13 +24,27 @@ class WhatsNewRepository @Inject constructor(
      * for the version, or the entry is empty.
      */
     fun entryFor(versionCode: Int, languageTag: String): WhatsNewContent? {
-        val json = runCatching {
-            context.assets.open(ASSET_NAME).bufferedReader().use { it.readText() }
-        }.getOrElse {
-            Log.w(TAG, "whatsnew.json not readable", it)
-            return null
-        }
+        val json = readAsset() ?: return null
         return parse(json, versionCode, languageTag)
+    }
+
+    /**
+     * The [WhatsNewContent] for the newest versionCode present in the asset,
+     * ignoring the running build's versionCode. Backs the debug "Replay What's
+     * new" action, which must preview the latest authored entry even on a build
+     * whose versionCode predates it. Null if the asset is missing/malformed or
+     * holds no usable entry.
+     */
+    fun latestEntry(languageTag: String): WhatsNewContent? {
+        val json = readAsset() ?: return null
+        return parseLatest(json, languageTag)
+    }
+
+    private fun readAsset(): String? = runCatching {
+        context.assets.open(ASSET_NAME).bufferedReader().use { it.readText() }
+    }.getOrElse {
+        Log.w(TAG, "whatsnew.json not readable", it)
+        null
     }
 
     companion object {
@@ -39,22 +53,45 @@ class WhatsNewRepository @Inject constructor(
         private val gson = Gson()
 
         /**
-         * Pure parse step — no Android dependencies, unit-testable.
-         *
-         * Locale selection: a Chinese [languageTag] (`zh-*`) maps to the
-         * `zh-TW` block; everything else falls back to `en`.
+         * Pure parse step for [entryFor] — no Android dependencies,
+         * unit-testable. See [select] for locale resolution.
          */
         fun parse(json: String, versionCode: Int, languageTag: String): WhatsNewContent? {
-            val type = object : TypeToken<Map<String, Map<String, WhatsNewContent>>>() {}.type
-            val byVersion: Map<String, Map<String, WhatsNewContent>> = runCatching {
-                gson.fromJson<Map<String, Map<String, WhatsNewContent>>>(json, type)
-            }.getOrNull() ?: return null
+            val byVersion = deserialize(json) ?: return null
+            return select(byVersion[versionCode.toString()], languageTag)
+        }
 
-            val versionEntry = byVersion[versionCode.toString()] ?: return null
+        /**
+         * Pure variant of [parse] for the highest versionCode present in the
+         * asset — see [latestEntry]. Null if the asset is malformed or has no
+         * numeric version key.
+         */
+        fun parseLatest(json: String, languageTag: String): WhatsNewContent? {
+            val byVersion = deserialize(json) ?: return null
+            val latestKey = byVersion.keys.mapNotNull(String::toIntOrNull).maxOrNull() ?: return null
+            return select(byVersion[latestKey.toString()], languageTag)
+        }
+
+        private fun deserialize(json: String): Map<String, Map<String, WhatsNewContent>>? {
+            val type = object : TypeToken<Map<String, Map<String, WhatsNewContent>>>() {}.type
+            return runCatching {
+                gson.fromJson<Map<String, Map<String, WhatsNewContent>>>(json, type)
+            }.getOrNull()
+        }
+
+        /**
+         * Picks the localized [WhatsNewContent] out of one version's per-locale
+         * map. A Chinese [languageTag] (`zh-*`) maps to the `zh-TW` block;
+         * everything else falls back to `en`. An entry with no usable text is
+         * treated as absent.
+         */
+        private fun select(
+            versionEntry: Map<String, WhatsNewContent>?,
+            languageTag: String,
+        ): WhatsNewContent? {
+            versionEntry ?: return null
             val localeKey = if (languageTag.startsWith("zh", ignoreCase = true)) "zh-TW" else "en"
             val content = versionEntry[localeKey] ?: versionEntry["en"] ?: return null
-
-            // An entry with no usable text is treated as absent.
             if (content.title.isNullOrBlank() || content.highlights.isNullOrEmpty()) return null
             return content
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
@@ -1,0 +1,62 @@
+package org.ntust.app.tigerduck.update
+
+import android.content.Context
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Loads maintainer-authored "What's new" content from `assets/whatsnew.json`.
+ *
+ * The JSON is an object keyed by versionCode string; each version holds a
+ * per-locale map (`zh-TW`, `en`) of [WhatsNewContent].
+ */
+@Singleton
+class WhatsNewRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+) {
+    /**
+     * The [WhatsNewContent] for [versionCode] in the locale implied by
+     * [languageTag], or null if the asset is missing/malformed, has no entry
+     * for the version, or the entry is empty.
+     */
+    fun entryFor(versionCode: Int, languageTag: String): WhatsNewContent? {
+        val json = runCatching {
+            context.assets.open(ASSET_NAME).bufferedReader().use { it.readText() }
+        }.getOrElse {
+            Log.w(TAG, "whatsnew.json not readable", it)
+            return null
+        }
+        return parse(json, versionCode, languageTag)
+    }
+
+    companion object {
+        const val ASSET_NAME = "whatsnew.json"
+        private const val TAG = "WhatsNewRepository"
+        private val gson = Gson()
+
+        /**
+         * Pure parse step — no Android dependencies, unit-testable.
+         *
+         * Locale selection: a Chinese [languageTag] (`zh-*`) maps to the
+         * `zh-TW` block; everything else falls back to `en`.
+         */
+        fun parse(json: String, versionCode: Int, languageTag: String): WhatsNewContent? {
+            val type = object : TypeToken<Map<String, Map<String, WhatsNewContent>>>() {}.type
+            val byVersion: Map<String, Map<String, WhatsNewContent>> = runCatching {
+                gson.fromJson<Map<String, Map<String, WhatsNewContent>>>(json, type)
+            }.getOrNull() ?: return null
+
+            val versionEntry = byVersion[versionCode.toString()] ?: return null
+            val localeKey = if (languageTag.startsWith("zh", ignoreCase = true)) "zh-TW" else "en"
+            val content = versionEntry[localeKey] ?: versionEntry["en"] ?: return null
+
+            // An entry with no usable text is treated as absent.
+            if (content.title.isNullOrBlank() || content.highlights.isNullOrEmpty()) return null
+            return content
+        }
+    }
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">لوحة مفاتيح قياسية</string>
     <string name="action_add">إضافة</string>
     <string name="action_allow">السماح</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">التبويبات المتاحة</string>
     <string name="tab_editor_section_current_tabs">التبويبات الحالية</string>
     <string name="tab_editor_title">محرر التبويبات</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">تعاني بعض الهواتف من محركات اهتزاز منخفضة الجودة قد تتجاهل الاهتزازات الضعيفة جداً أو القصيرة جداً. إذا كنت لا تشعر بالإعداد، حاول رفع قوته أو مدته. يمكنك البدء بتجربة الإعداد المسبق \"متوسط\" أولاً.</string>
     <string name="vibration_settings_revert">إعادة إلى الافتراضي</string>
     <string name="vibration_settings_section_length_ms">المدة (ms)</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">التبويبات المتاحة</string>
     <string name="tab_editor_section_current_tabs">التبويبات الحالية</string>
     <string name="tab_editor_title">محرر التبويبات</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">التحديث جاهز للتثبيت.</string>
+    <string name="update_restart_action">إعادة التشغيل</string>
     <string name="vibration_settings_motor_warning">تعاني بعض الهواتف من محركات اهتزاز منخفضة الجودة قد تتجاهل الاهتزازات الضعيفة جداً أو القصيرة جداً. إذا كنت لا تشعر بالإعداد، حاول رفع قوته أو مدته. يمكنك البدء بتجربة الإعداد المسبق \"متوسط\" أولاً.</string>
     <string name="vibration_settings_revert">إعادة إلى الافتراضي</string>
     <string name="vibration_settings_section_length_ms">المدة (ms)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавиатура</string>
     <string name="action_add">Добави</string>
     <string name="action_allow">Разреши</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Налични табове</string>
     <string name="tab_editor_section_current_tabs">Текущи табове</string>
     <string name="tab_editor_title">Редактор на табове</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Някои телефони имат вибромотори с по-ниско качество, които може да игнорират много слаби или много кратки вибрации. Ако не усещате дадена настройка, опитайте да увеличите нейната сила или продължителност. Можете да започнете с пресет \"Среден\".</string>
     <string name="vibration_settings_revert">Възстановяване по подразбиране</string>
     <string name="vibration_settings_section_length_ms">Продължителност (ms)</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Налични табове</string>
     <string name="tab_editor_section_current_tabs">Текущи табове</string>
     <string name="tab_editor_title">Редактор на табове</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Актуализацията е изтеглена и готова за инсталиране.</string>
+    <string name="update_restart_action">Рестартиране</string>
     <string name="vibration_settings_motor_warning">Някои телефони имат вибромотори с по-ниско качество, които може да игнорират много слаби или много кратки вибрации. Ако не усещате дадена настройка, опитайте да увеличите нейната сила или продължителност. Можете да започнете с пресет \"Среден\".</string>
     <string name="vibration_settings_revert">Възстановяване по подразбиране</string>
     <string name="vibration_settings_section_length_ms">Продължителност (ms)</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">স্ট্যান্ডার্ড কীবোর্ড</string>
     <string name="action_add">যোগ করুন</string>
     <string name="action_allow">অনুমতি দিন</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">উপলব্ধ ট্যাবসমূহ</string>
     <string name="tab_editor_section_current_tabs">বর্তমান ট্যাবসমূহ</string>
     <string name="tab_editor_title">ট্যাব এডিটর</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">কিছু ফোনে নিম্নমানের ভাইব্রেশন মোটর থাকে যা খুব দুর্বল বা খুব ছোট ভাইব্রেশন উপেক্ষা করতে পারে। যদি কোনো সেটিং অনুভব না করেন, তাহলে এর শক্তি বা দৈর্ঘ্য বাড়ানোর চেষ্টা করুন। আপনি প্রথমে \"মাঝারি\" প্রিসেট দিয়ে শুরু করতে পারেন।</string>
     <string name="vibration_settings_revert">ডিফল্টে ফিরুন</string>
     <string name="vibration_settings_section_length_ms">দৈর্ঘ্য (ms)</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">উপলব্ধ ট্যাবসমূহ</string>
     <string name="tab_editor_section_current_tabs">বর্তমান ট্যাবসমূহ</string>
     <string name="tab_editor_title">ট্যাব এডিটর</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">আপডেট ডাউনলোড হয়েছে, ইনস্টল করতে প্রস্তুত।</string>
+    <string name="update_restart_action">পুনরায় চালু করুন</string>
     <string name="vibration_settings_motor_warning">কিছু ফোনে নিম্নমানের ভাইব্রেশন মোটর থাকে যা খুব দুর্বল বা খুব ছোট ভাইব্রেশন উপেক্ষা করতে পারে। যদি কোনো সেটিং অনুভব না করেন, তাহলে এর শক্তি বা দৈর্ঘ্য বাড়ানোর চেষ্টা করুন। আপনি প্রথমে \"মাঝারি\" প্রিসেট দিয়ে শুরু করতে পারেন।</string>
     <string name="vibration_settings_revert">ডিফল্টে ফিরুন</string>
     <string name="vibration_settings_section_length_ms">দৈর্ঘ্য (ms)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclat estàndard</string>
     <string name="action_add">Afegeix</string>
     <string name="action_allow">Permet</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestanyes disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestanyes actuals</string>
     <string name="tab_editor_title">Editor de pestanyes</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Alguns telèfons tenen motors de vibració de menor qualitat que poden ignorar vibracions molt febles o molt curtes. Si no podeu sentir una configuració, proveu d\'augmentar-ne la força o la durada. Podeu començar provant primer el preajust \"Mitjà\".</string>
     <string name="vibration_settings_revert">Restablir per defecte</string>
     <string name="vibration_settings_section_length_ms">Durada (ms)</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestanyes disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestanyes actuals</string>
     <string name="tab_editor_title">Editor de pestanyes</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">L\'actualització s\'ha descarregat i és llesta per instal·lar.</string>
+    <string name="update_restart_action">Reinicia</string>
     <string name="vibration_settings_motor_warning">Alguns telèfons tenen motors de vibració de menor qualitat que poden ignorar vibracions molt febles o molt curtes. Si no podeu sentir una configuració, proveu d\'augmentar-ne la força o la durada. Podeu començar provant primer el preajust \"Mitjà\".</string>
     <string name="vibration_settings_revert">Restablir per defecte</string>
     <string name="vibration_settings_section_length_ms">Durada (ms)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardní klávesnice</string>
     <string name="action_add">Přidat</string>
     <string name="action_allow">Povolit</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupné záložky</string>
     <string name="tab_editor_section_current_tabs">Aktuální záložky</string>
     <string name="tab_editor_title">Editor záložek</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Některé telefony mají vibromotorek nižší kvality, který může ignorovat velmi slabé nebo velmi krátké vibrace. Pokud nastavení necítíte, zkuste zvýšit jeho sílu nebo délku. Můžete začít vyzkoušením předvolby \"Střední\".</string>
     <string name="vibration_settings_revert">Obnovit výchozí</string>
     <string name="vibration_settings_section_length_ms">Délka (ms)</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupné záložky</string>
     <string name="tab_editor_section_current_tabs">Aktuální záložky</string>
     <string name="tab_editor_title">Editor záložek</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Aktualizace je stažena a připravena k instalaci.</string>
+    <string name="update_restart_action">Restartovat</string>
     <string name="vibration_settings_motor_warning">Některé telefony mají vibromotorek nižší kvality, který může ignorovat velmi slabé nebo velmi krátké vibrace. Pokud nastavení necítíte, zkuste zvýšit jeho sílu nebo délku. Můžete začít vyzkoušením předvolby \"Střední\".</string>
     <string name="vibration_settings_revert">Obnovit výchozí</string>
     <string name="vibration_settings_section_length_ms">Délka (ms)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgængelige faneblade</string>
     <string name="tab_editor_section_current_tabs">Aktuelle faneblade</string>
     <string name="tab_editor_title">Fanebladseditor</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Opdateringen er hentet og klar til installation.</string>
+    <string name="update_restart_action">Genstart</string>
     <string name="vibration_settings_motor_warning">Nogle telefoner har vibrationsmotor af lavere kvalitet, som muligvis ignorerer meget svage eller meget korte vibrationer. Hvis du ikke kan mærke en indstilling, kan du prøve at øge dens styrke eller længde. Du kan starte med at prøve \"Middel\"-forudindstillingen.</string>
     <string name="vibration_settings_revert">Gendan standard</string>
     <string name="vibration_settings_section_length_ms">Varighed (ms)</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Tilføj</string>
     <string name="action_allow">Tillad</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgængelige faneblade</string>
     <string name="tab_editor_section_current_tabs">Aktuelle faneblade</string>
     <string name="tab_editor_title">Fanebladseditor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Nogle telefoner har vibrationsmotor af lavere kvalitet, som muligvis ignorerer meget svage eller meget korte vibrationer. Hvis du ikke kan mærke en indstilling, kan du prøve at øge dens styrke eller længde. Du kan starte med at prøve \"Middel\"-forudindstillingen.</string>
     <string name="vibration_settings_revert">Gendan standard</string>
     <string name="vibration_settings_section_length_ms">Varighed (ms)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Hinzufügen</string>
     <string name="action_allow">Erlauben</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Verfügbare Tabs</string>
     <string name="tab_editor_section_current_tabs">Aktuelle Tabs</string>
     <string name="tab_editor_title">Tab-Editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Einige Telefone haben Vibrationsmotoren geringerer Qualität, die sehr schwache oder sehr kurze Vibrationen ignorieren können. Falls Sie eine Einstellung nicht spüren, versuchen Sie, die Stärke oder Länge zu erhöhen. Sie können mit der Voreinstellung \"Mittel\" beginnen.</string>
     <string name="vibration_settings_revert">Standard wiederherstellen</string>
     <string name="vibration_settings_section_length_ms">Dauer (ms)</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Verfügbare Tabs</string>
     <string name="tab_editor_section_current_tabs">Aktuelle Tabs</string>
     <string name="tab_editor_title">Tab-Editor</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Das Update wurde heruntergeladen und ist bereit zur Installation.</string>
+    <string name="update_restart_action">Neu starten</string>
     <string name="vibration_settings_motor_warning">Einige Telefone haben Vibrationsmotoren geringerer Qualität, die sehr schwache oder sehr kurze Vibrationen ignorieren können. Falls Sie eine Einstellung nicht spüren, versuchen Sie, die Stärke oder Länge zu erhöhen. Sie können mit der Voreinstellung \"Mittel\" beginnen.</string>
     <string name="vibration_settings_revert">Standard wiederherstellen</string>
     <string name="vibration_settings_section_length_ms">Dauer (ms)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Τυπικό πληκτρολόγιο</string>
     <string name="action_add">Προσθήκη</string>
     <string name="action_allow">Επιτρέπεται</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Διαθέσιμες καρτέλες</string>
     <string name="tab_editor_section_current_tabs">Τρέχουσες καρτέλες</string>
     <string name="tab_editor_title">Επεξεργαστής καρτελών</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Ορισμένα τηλέφωνα διαθέτουν κινητήρες δόνησης χαμηλότερης ποιότητας που ενδέχεται να αγνοούν πολύ αδύναμες ή πολύ σύντομες δονήσεις. Αν δεν αισθάνεστε μια ρύθμιση, δοκιμάστε να αυξήσετε την ένταση ή τη διάρκειά της. Μπορείτε να ξεκινήσετε δοκιμάζοντας την προεπιλογή \"Μέτριο\".</string>
     <string name="vibration_settings_revert">Επαναφορά προεπιλογής</string>
     <string name="vibration_settings_section_length_ms">Διάρκεια (ms)</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Διαθέσιμες καρτέλες</string>
     <string name="tab_editor_section_current_tabs">Τρέχουσες καρτέλες</string>
     <string name="tab_editor_title">Επεξεργαστής καρτελών</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Η ενημέρωση έχει ληφθεί και είναι έτοιμη για εγκατάσταση.</string>
+    <string name="update_restart_action">Επανεκκίνηση</string>
     <string name="vibration_settings_motor_warning">Ορισμένα τηλέφωνα διαθέτουν κινητήρες δόνησης χαμηλότερης ποιότητας που ενδέχεται να αγνοούν πολύ αδύναμες ή πολύ σύντομες δονήσεις. Αν δεν αισθάνεστε μια ρύθμιση, δοκιμάστε να αυξήσετε την ένταση ή τη διάρκειά της. Μπορείτε να ξεκινήσετε δοκιμάζοντας την προεπιλογή \"Μέτριο\".</string>
     <string name="vibration_settings_revert">Επαναφορά προεπιλογής</string>
     <string name="vibration_settings_section_length_ms">Διάρκεια (ms)</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Available tabs</string>
     <string name="tab_editor_section_current_tabs">Current tabs</string>
     <string name="tab_editor_title">Tab editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Some phones have lower-quality vibration motors that may ignore very weak or very short vibrations. If you can\'t feel a setting, try raising its strength or length. You can start by trying the medium preset first.</string>
     <string name="vibration_settings_revert">Reset to default</string>
     <string name="vibration_settings_section_length_ms">Length (ms)</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Available tabs</string>
     <string name="tab_editor_section_current_tabs">Current tabs</string>
     <string name="tab_editor_title">Tab editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Some phones have lower-quality vibration motors that may ignore very weak or very short vibrations. If you can\'t feel a setting, try raising its strength or length. You can start by trying the medium preset first.</string>
     <string name="vibration_settings_revert">Reset to default</string>
     <string name="vibration_settings_section_length_ms">Length (ms)</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Available tabs</string>
     <string name="tab_editor_section_current_tabs">Current tabs</string>
     <string name="tab_editor_title">Tab editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Some phones have lower-quality vibration motors that may ignore very weak or very short vibrations. If you can\'t feel a setting, try raising its strength or length. You can start by trying the medium preset first.</string>
     <string name="vibration_settings_revert">Reset to default</string>
     <string name="vibration_settings_section_length_ms">Length (ms)</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Available tabs</string>
     <string name="tab_editor_section_current_tabs">Current tabs</string>
     <string name="tab_editor_title">Tab editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Some phones have lower-quality vibration motors that may ignore very weak or very short vibrations. If you can\'t feel a setting, try raising its strength or length. You can start by trying the medium preset first.</string>
     <string name="vibration_settings_revert">Reset to default</string>
     <string name="vibration_settings_section_length_ms">Length (ms)</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestañas disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestañas actuales</string>
     <string name="tab_editor_title">Editor de pestañas</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">La actualización se ha descargado y está lista para instalar.</string>
+    <string name="update_restart_action">Reiniciar</string>
     <string name="vibration_settings_motor_warning">Algunos teléfonos tienen motores de vibración de menor calidad que pueden ignorar vibraciones muy débiles o muy cortas. Si no puedes sentir una configuración, intenta aumentar su intensidad o duración. Puedes empezar probando el ajuste preestablecido \"Medio\".</string>
     <string name="vibration_settings_revert">Restablecer por defecto</string>
     <string name="vibration_settings_section_length_ms">Duración (ms)</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestañas disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestañas actuales</string>
     <string name="tab_editor_title">Editor de pestañas</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Algunos teléfonos tienen motores de vibración de menor calidad que pueden ignorar vibraciones muy débiles o muy cortas. Si no puedes sentir una configuración, intenta aumentar su intensidad o duración. Puedes empezar probando el ajuste preestablecido \"Medio\".</string>
     <string name="vibration_settings_revert">Restablecer por defecto</string>
     <string name="vibration_settings_section_length_ms">Duración (ms)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestañas disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestañas actuales</string>
     <string name="tab_editor_title">Editor de pestañas</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">La actualización se ha descargado y está lista para instalar.</string>
+    <string name="update_restart_action">Reiniciar</string>
     <string name="vibration_settings_motor_warning">Algunos teléfonos tienen motores de vibración de menor calidad que pueden ignorar vibraciones muy débiles o muy cortas. Si no puedes sentir una configuración, intenta aumentar su intensidad o duración. Puedes empezar probando el ajuste preestablecido \"Medio\".</string>
     <string name="vibration_settings_revert">Restablecer por defecto</string>
     <string name="vibration_settings_section_length_ms">Duración (ms)</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclado estándar</string>
     <string name="action_add">Agregar</string>
     <string name="action_allow">Permitir</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pestañas disponibles</string>
     <string name="tab_editor_section_current_tabs">Pestañas actuales</string>
     <string name="tab_editor_title">Editor de pestañas</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Algunos teléfonos tienen motores de vibración de menor calidad que pueden ignorar vibraciones muy débiles o muy cortas. Si no puedes sentir una configuración, intenta aumentar su intensidad o duración. Puedes empezar probando el ajuste preestablecido \"Medio\".</string>
     <string name="vibration_settings_revert">Restablecer por defecto</string>
     <string name="vibration_settings_section_length_ms">Duración (ms)</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardklaviatuur</string>
     <string name="action_add">Lisa</string>
     <string name="action_allow">Luba</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Saadaval olevad vahekaardid</string>
     <string name="tab_editor_section_current_tabs">Praegused vahekaardid</string>
     <string name="tab_editor_title">Vahekaartide redaktor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Mõnel telefonil on madalama kvaliteediga vibraatorimootor, mis võib ignoreerida väga nõrku või väga lühikesi vibratsioone. Kui te seadistust ei tunne, proovige suurendada selle tugevust või pikkust. Võite alustada eelseade \"Keskmine\" proovimisest.</string>
     <string name="vibration_settings_revert">Lähtesta vaikimisi</string>
     <string name="vibration_settings_section_length_ms">Kestus (ms)</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Saadaval olevad vahekaardid</string>
     <string name="tab_editor_section_current_tabs">Praegused vahekaardid</string>
     <string name="tab_editor_title">Vahekaartide redaktor</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Uuendus on alla laaditud ja paigaldamiseks valmis.</string>
+    <string name="update_restart_action">Taaskäivita</string>
     <string name="vibration_settings_motor_warning">Mõnel telefonil on madalama kvaliteediga vibraatorimootor, mis võib ignoreerida väga nõrku või väga lühikesi vibratsioone. Kui te seadistust ei tunne, proovige suurendada selle tugevust või pikkust. Võite alustada eelseade \"Keskmine\" proovimisest.</string>
     <string name="vibration_settings_revert">Lähtesta vaikimisi</string>
     <string name="vibration_settings_section_length_ms">Kestus (ms)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">تب‌های در دسترس</string>
     <string name="tab_editor_section_current_tabs">تب‌های فعلی</string>
     <string name="tab_editor_title">ویرایشگر تب‌ها</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">به‌روزرسانی دانلود شد و آماده نصب است.</string>
+    <string name="update_restart_action">راه‌اندازی مجدد</string>
     <string name="vibration_settings_motor_warning">برخی گوشی‌ها موتورهای لرزش با کیفیت پایین‌تری دارند که ممکن است لرزش‌های بسیار ضعیف یا بسیار کوتاه را نادیده بگیرند. اگر تنظیمی را حس نمی‌کنید، سعی کنید قدرت یا طول آن را افزایش دهید. می‌توانید با امتحان کردن پیش‌تنظیم \"متوسط\" شروع کنید.</string>
     <string name="vibration_settings_revert">بازگشت به پیش‌فرض</string>
     <string name="vibration_settings_section_length_ms">مدت (ms)</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">صفحه‌کلید استاندارد</string>
     <string name="action_add">افزودن</string>
     <string name="action_allow">اجازه دادن</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">تب‌های در دسترس</string>
     <string name="tab_editor_section_current_tabs">تب‌های فعلی</string>
     <string name="tab_editor_title">ویرایشگر تب‌ها</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">برخی گوشی‌ها موتورهای لرزش با کیفیت پایین‌تری دارند که ممکن است لرزش‌های بسیار ضعیف یا بسیار کوتاه را نادیده بگیرند. اگر تنظیمی را حس نمی‌کنید، سعی کنید قدرت یا طول آن را افزایش دهید. می‌توانید با امتحان کردن پیش‌تنظیم \"متوسط\" شروع کنید.</string>
     <string name="vibration_settings_revert">بازگشت به پیش‌فرض</string>
     <string name="vibration_settings_section_length_ms">مدت (ms)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Saatavilla olevat välilehdet</string>
     <string name="tab_editor_section_current_tabs">Nykyiset välilehdet</string>
     <string name="tab_editor_title">Välilehtieditori</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Päivitys on ladattu ja valmis asennettavaksi.</string>
+    <string name="update_restart_action">Käynnistä uudelleen</string>
     <string name="vibration_settings_motor_warning">Joillakin puhelimilla on heikomman laadun värinämoottorit, jotka saattavat jättää huomioimatta hyvin heikot tai hyvin lyhyet värinät. Jos et tunne asetusta, yritä lisätä sen voimakkuutta tai pituutta. Voit aloittaa kokeilemalla esiasetusta \"Keskipitkä\".</string>
     <string name="vibration_settings_revert">Palauta oletukseksi</string>
     <string name="vibration_settings_section_length_ms">Kesto (ms)</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Vakionäppäimistö</string>
     <string name="action_add">Lisää</string>
     <string name="action_allow">Salli</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Saatavilla olevat välilehdet</string>
     <string name="tab_editor_section_current_tabs">Nykyiset välilehdet</string>
     <string name="tab_editor_title">Välilehtieditori</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Joillakin puhelimilla on heikomman laadun värinämoottorit, jotka saattavat jättää huomioimatta hyvin heikot tai hyvin lyhyet värinät. Jos et tunne asetusta, yritä lisätä sen voimakkuutta tai pituutta. Voit aloittaa kokeilemalla esiasetusta \"Keskipitkä\".</string>
     <string name="vibration_settings_revert">Palauta oletukseksi</string>
     <string name="vibration_settings_section_length_ms">Kesto (ms)</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard na keyboard</string>
     <string name="action_add">Idagdag</string>
     <string name="action_allow">Payagan</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Mga available na tab</string>
     <string name="tab_editor_section_current_tabs">Mga kasalukuyang tab</string>
     <string name="tab_editor_title">Editor ng tab</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Ang ilang mga telepono ay may mas mababang kalidad na vibration motor na maaaring hindi mapansin ang napakahina o napakaikling vibration. Kung hindi mo maramdaman ang isang setting, subukang itaas ang lakas o haba nito. Maaari kang magsimula sa pamamagitan ng pagsubok sa \"Katamtaman\" na preset muna.</string>
     <string name="vibration_settings_revert">I-reset sa default</string>
     <string name="vibration_settings_section_length_ms">Haba (ms)</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Mga available na tab</string>
     <string name="tab_editor_section_current_tabs">Mga kasalukuyang tab</string>
     <string name="tab_editor_title">Editor ng tab</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Na-download na ang update at handa nang i-install.</string>
+    <string name="update_restart_action">I-restart</string>
     <string name="vibration_settings_motor_warning">Ang ilang mga telepono ay may mas mababang kalidad na vibration motor na maaaring hindi mapansin ang napakahina o napakaikling vibration. Kung hindi mo maramdaman ang isang setting, subukang itaas ang lakas o haba nito. Maaari kang magsimula sa pamamagitan ng pagsubok sa \"Katamtaman\" na preset muna.</string>
     <string name="vibration_settings_revert">I-reset sa default</string>
     <string name="vibration_settings_section_length_ms">Haba (ms)</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Onglets disponibles</string>
     <string name="tab_editor_section_current_tabs">Onglets actuels</string>
     <string name="tab_editor_title">Éditeur d\'onglets</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">La mise à jour est téléchargée et prête à être installée.</string>
+    <string name="update_restart_action">Redémarrer</string>
     <string name="vibration_settings_motor_warning">Certains téléphones sont équipés de moteurs de vibration de moindre qualité qui peuvent ignorer les vibrations très faibles ou très courtes. Si vous ne ressentez pas un réglage, essayez d\'augmenter son intensité ou sa durée. Vous pouvez commencer par essayer le préréglage \"Moyen\".</string>
     <string name="vibration_settings_revert">Rétablir par défaut</string>
     <string name="vibration_settings_section_length_ms">Durée (ms)</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Onglets disponibles</string>
     <string name="tab_editor_section_current_tabs">Onglets actuels</string>
     <string name="tab_editor_title">Éditeur d\'onglets</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Certains téléphones sont équipés de moteurs de vibration de moindre qualité qui peuvent ignorer les vibrations très faibles ou très courtes. Si vous ne ressentez pas un réglage, essayez d\'augmenter son intensité ou sa durée. Vous pouvez commencer par essayer le préréglage \"Moyen\".</string>
     <string name="vibration_settings_revert">Rétablir par défaut</string>
     <string name="vibration_settings_section_length_ms">Durée (ms)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Onglets disponibles</string>
     <string name="tab_editor_section_current_tabs">Onglets actuels</string>
     <string name="tab_editor_title">Éditeur d\'onglets</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">La mise à jour est téléchargée et prête à être installée.</string>
+    <string name="update_restart_action">Redémarrer</string>
     <string name="vibration_settings_motor_warning">Certains téléphones sont équipés de moteurs de vibration de moindre qualité qui peuvent ignorer les vibrations très faibles ou très courtes. Si vous ne ressentez pas un réglage, essayez d\'augmenter son intensité ou sa durée. Vous pouvez commencer par essayer le préréglage \"Moyen\".</string>
     <string name="vibration_settings_revert">Rétablir par défaut</string>
     <string name="vibration_settings_section_length_ms">Durée (ms)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Clavier standard</string>
     <string name="action_add">Ajouter</string>
     <string name="action_allow">Autoriser</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Onglets disponibles</string>
     <string name="tab_editor_section_current_tabs">Onglets actuels</string>
     <string name="tab_editor_title">Éditeur d\'onglets</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Certains téléphones sont équipés de moteurs de vibration de moindre qualité qui peuvent ignorer les vibrations très faibles ou très courtes. Si vous ne ressentez pas un réglage, essayez d\'augmenter son intensité ou sa durée. Vous pouvez commencer par essayer le préréglage \"Moyen\".</string>
     <string name="vibration_settings_revert">Rétablir par défaut</string>
     <string name="vibration_settings_section_length_ms">Durée (ms)</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">પ્રમાણભૂત કીબોર્ડ</string>
     <string name="action_add">ઉમેરો</string>
     <string name="action_allow">મંજૂરી આપો</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">ઉપલબ્ધ ટૅબ</string>
     <string name="tab_editor_section_current_tabs">વર્તમાન ટૅબ</string>
     <string name="tab_editor_title">ટૅબ એડિટર</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">કેટલા ફોનમાં નીચી ગુણવત્તાના વાઇબ્રેશન મોટર હોય છે જે ખૂબ જ નબળા અથવા ખૂબ ટૂંકા વાઇબ્રેશનને અવગણી શકે છે. જો તમને કોઈ સેટિંગ ન અનુભવાય, તો તેની શક્તિ અથવા લંબાઈ વધારવાનો પ્રયાસ કરો. તમે પહેલા \"મધ્યમ\" પ્રીસેટ અજમાવીને શરૂ કરી શકો છો.</string>
     <string name="vibration_settings_revert">ડિફૉલ્ટ પર રીસેટ</string>
     <string name="vibration_settings_section_length_ms">સમયગાળો (ms)</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">ઉપલબ્ધ ટૅબ</string>
     <string name="tab_editor_section_current_tabs">વર્તમાન ટૅબ</string>
     <string name="tab_editor_title">ટૅબ એડિટર</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">અપડેટ ડાઉનલોડ થઈ ગઈ છે, ઇન્સ્ટોલ કરવા તૈયાર છે.</string>
+    <string name="update_restart_action">પુનઃપ્રારંભ કરો</string>
     <string name="vibration_settings_motor_warning">કેટલા ફોનમાં નીચી ગુણવત્તાના વાઇબ્રેશન મોટર હોય છે જે ખૂબ જ નબળા અથવા ખૂબ ટૂંકા વાઇબ્રેશનને અવગણી શકે છે. જો તમને કોઈ સેટિંગ ન અનુભવાય, તો તેની શક્તિ અથવા લંબાઈ વધારવાનો પ્રયાસ કરો. તમે પહેલા \"મધ્યમ\" પ્રીસેટ અજમાવીને શરૂ કરી શકો છો.</string>
     <string name="vibration_settings_revert">ડિફૉલ્ટ પર રીસેટ</string>
     <string name="vibration_settings_section_length_ms">સમયગાળો (ms)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">उपलब्ध Tabs</string>
     <string name="tab_editor_section_current_tabs">वर्तमान Tabs</string>
     <string name="tab_editor_title">Tab संपादक</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">अपडेट डाउनलोड हो गया है, इंस्टॉल करने के लिए तैयार है।</string>
+    <string name="update_restart_action">पुनः प्रारंभ करें</string>
     <string name="vibration_settings_motor_warning">कुछ फोनों में कम गुणवत्ता वाले वाइब्रेशन मोटर होते हैं जो बहुत कमज़ोर या बहुत छोटे वाइब्रेशन को अनदेखा कर सकते हैं। अगर आप कोई सेटिंग महसूस नहीं कर पाते, तो उसकी ताकत या लंबाई बढ़ाने की कोशिश करें। आप पहले \"मध्यम\" प्रीसेट आज़माकर शुरू कर सकते हैं।</string>
     <string name="vibration_settings_revert">डिफ़ॉल्ट पर रीसेट</string>
     <string name="vibration_settings_section_length_ms">अवधि (ms)</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोड़ें</string>
     <string name="action_allow">अनुमति दें</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">उपलब्ध Tabs</string>
     <string name="tab_editor_section_current_tabs">वर्तमान Tabs</string>
     <string name="tab_editor_title">Tab संपादक</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">कुछ फोनों में कम गुणवत्ता वाले वाइब्रेशन मोटर होते हैं जो बहुत कमज़ोर या बहुत छोटे वाइब्रेशन को अनदेखा कर सकते हैं। अगर आप कोई सेटिंग महसूस नहीं कर पाते, तो उसकी ताकत या लंबाई बढ़ाने की कोशिश करें। आप पहले \"मध्यम\" प्रीसेट आज़माकर शुरू कर सकते हैं।</string>
     <string name="vibration_settings_revert">डिफ़ॉल्ट पर रीसेट</string>
     <string name="vibration_settings_section_length_ms">अवधि (ms)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupne kartice</string>
     <string name="tab_editor_section_current_tabs">Trenutne kartice</string>
     <string name="tab_editor_title">Urednik kartica</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Ažuriranje je preuzeto i spremno za instalaciju.</string>
+    <string name="update_restart_action">Ponovo pokreni</string>
     <string name="vibration_settings_motor_warning">Neki telefoni imaju vibromotore niže kvalitete koji mogu ignorirati vrlo slabe ili vrlo kratke vibracije. Ako ne možete osjetiti postavku, pokušajte povećati njenu snagu ili trajanje. Možete početi isprobavanjem unaprijed postavljene vrijednosti \"Srednje\".</string>
     <string name="vibration_settings_revert">Vrati na zadano</string>
     <string name="vibration_settings_section_length_ms">Trajanje (ms)</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dopusti</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupne kartice</string>
     <string name="tab_editor_section_current_tabs">Trenutne kartice</string>
     <string name="tab_editor_title">Urednik kartica</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Neki telefoni imaju vibromotore niže kvalitete koji mogu ignorirati vrlo slabe ili vrlo kratke vibracije. Ako ne možete osjetiti postavku, pokušajte povećati njenu snagu ili trajanje. Možete početi isprobavanjem unaprijed postavljene vrijednosti \"Srednje\".</string>
     <string name="vibration_settings_revert">Vrati na zadano</string>
     <string name="vibration_settings_section_length_ms">Trajanje (ms)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Normál billentyűzet</string>
     <string name="action_add">Hozzáadás</string>
     <string name="action_allow">Engedélyezés</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Elérhető lapok</string>
     <string name="tab_editor_section_current_tabs">Jelenlegi lapok</string>
     <string name="tab_editor_title">Lap szerkesztő</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Egyes telefonokon alacsonyabb minőségű vibrációs motor van, amely figyelmen kívül hagyhatja a nagyon gyenge vagy nagyon rövid rezgéseket. Ha nem érez egy beállítást, próbálja növelni annak erősségét vagy hosszát. Kezdheti a \"Közepes\" előbeállítás kipróbálásával.</string>
     <string name="vibration_settings_revert">Alapértelmezett visszaállítása</string>
     <string name="vibration_settings_section_length_ms">Időtartam (ms)</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Elérhető lapok</string>
     <string name="tab_editor_section_current_tabs">Jelenlegi lapok</string>
     <string name="tab_editor_title">Lap szerkesztő</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">A frissítés letöltve, telepítésre kész.</string>
+    <string name="update_restart_action">Újraindítás</string>
     <string name="vibration_settings_motor_warning">Egyes telefonokon alacsonyabb minőségű vibrációs motor van, amely figyelmen kívül hagyhatja a nagyon gyenge vagy nagyon rövid rezgéseket. Ha nem érez egy beállítást, próbálja növelni annak erősségét vagy hosszát. Kezdheti a \"Közepes\" előbeállítás kipróbálásával.</string>
     <string name="vibration_settings_revert">Alapértelmezett visszaállítása</string>
     <string name="vibration_settings_section_length_ms">Időtartam (ms)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab yang tersedia</string>
     <string name="tab_editor_section_current_tabs">Tab saat ini</string>
     <string name="tab_editor_title">Editor tab</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Pembaruan telah diunduh dan siap diinstal.</string>
+    <string name="update_restart_action">Mulai ulang</string>
     <string name="vibration_settings_motor_warning">Beberapa ponsel memiliki motor getar berkualitas lebih rendah yang mungkin mengabaikan getaran yang sangat lemah atau sangat pendek. Jika Anda tidak bisa merasakan suatu pengaturan, coba naikkan kekuatan atau panjangnya. Anda bisa mulai dengan mencoba preset \"Sedang\" terlebih dahulu.</string>
     <string name="vibration_settings_revert">Setel ulang ke default</string>
     <string name="vibration_settings_section_length_ms">Durasi (ms)</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Keyboard standar</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Izinkan</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab yang tersedia</string>
     <string name="tab_editor_section_current_tabs">Tab saat ini</string>
     <string name="tab_editor_title">Editor tab</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Beberapa ponsel memiliki motor getar berkualitas lebih rendah yang mungkin mengabaikan getaran yang sangat lemah atau sangat pendek. Jika Anda tidak bisa merasakan suatu pengaturan, coba naikkan kekuatan atau panjangnya. Anda bisa mulai dengan mencoba preset \"Sedang\" terlebih dahulu.</string>
     <string name="vibration_settings_revert">Setel ulang ke default</string>
     <string name="vibration_settings_section_length_ms">Durasi (ms)</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tiltækir flipar</string>
     <string name="tab_editor_section_current_tabs">Núverandi flipar</string>
     <string name="tab_editor_title">Fliparitill</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Uppfærslan hefur verið sótt og er tilbúin til uppsetningar.</string>
+    <string name="update_restart_action">Endurræsa</string>
     <string name="vibration_settings_motor_warning">Sumir símar hafa lægri gæða titringsmótor sem gætu hunsað mjög veika eða mjög stuttar titringshreyfingar. Ef þú finnur ekki fyrir stillingu skaltu reyna að auka styrk hennar eða lengd. Þú getur byrjað á að prófa \"Meðal\" forstillinguna fyrst.</string>
     <string name="vibration_settings_revert">Endurstilla sjálfgefið</string>
     <string name="vibration_settings_section_length_ms">Lengd (ms)</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Staðlað lyklaborð</string>
     <string name="action_add">Bæta við</string>
     <string name="action_allow">Leyfa</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tiltækir flipar</string>
     <string name="tab_editor_section_current_tabs">Núverandi flipar</string>
     <string name="tab_editor_title">Fliparitill</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Sumir símar hafa lægri gæða titringsmótor sem gætu hunsað mjög veika eða mjög stuttar titringshreyfingar. Ef þú finnur ekki fyrir stillingu skaltu reyna að auka styrk hennar eða lengd. Þú getur byrjað á að prófa \"Meðal\" forstillinguna fyrst.</string>
     <string name="vibration_settings_revert">Endurstilla sjálfgefið</string>
     <string name="vibration_settings_section_length_ms">Lengd (ms)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Tastiera standard</string>
     <string name="action_add">Aggiungi</string>
     <string name="action_allow">Consenti</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Schede disponibili</string>
     <string name="tab_editor_section_current_tabs">Schede attuali</string>
     <string name="tab_editor_title">Editor schede</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Alcuni telefoni hanno motori di vibrazione di qualità inferiore che potrebbero ignorare vibrazioni molto deboli o molto brevi. Se non riesci a sentire un\'impostazione, prova ad aumentarne la forza o la durata. Puoi iniziare provando prima il preset \"Medio\".</string>
     <string name="vibration_settings_revert">Ripristina predefinito</string>
     <string name="vibration_settings_section_length_ms">Durata (ms)</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Schede disponibili</string>
     <string name="tab_editor_section_current_tabs">Schede attuali</string>
     <string name="tab_editor_title">Editor schede</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">L\'aggiornamento è stato scaricato ed è pronto per l\'installazione.</string>
+    <string name="update_restart_action">Riavvia</string>
     <string name="vibration_settings_motor_warning">Alcuni telefoni hanno motori di vibrazione di qualità inferiore che potrebbero ignorare vibrazioni molto deboli o molto brevi. Se non riesci a sentire un\'impostazione, prova ad aumentarne la forza o la durata. Puoi iniziare provando prima il preset \"Medio\".</string>
     <string name="vibration_settings_revert">Ripristina predefinito</string>
     <string name="vibration_settings_section_length_ms">Durata (ms)</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">טאבים זמינים</string>
     <string name="tab_editor_section_current_tabs">טאבים נוכחיים</string>
     <string name="tab_editor_title">עורך טאבים</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">העדכון הורד ומוכן להתקנה.</string>
+    <string name="update_restart_action">הפעל מחדש</string>
     <string name="vibration_settings_motor_warning">לחלק מהטלפונים יש מנועי רטט באיכות נמוכה יותר שעלולים להתעלם מרטטים חלשים מאוד או קצרים מאוד. אם אינך מרגיש הגדרה מסוימת, נסה להגביר את עוצמתה או אורכה. תוכל להתחיל בניסוי הקבוע \"בינוני\" תחילה.</string>
     <string name="vibration_settings_revert">אפס לברירת מחדל</string>
     <string name="vibration_settings_section_length_ms">משך (ms)</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">מקלדת רגילה</string>
     <string name="action_add">הוסף</string>
     <string name="action_allow">אפשר</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">טאבים זמינים</string>
     <string name="tab_editor_section_current_tabs">טאבים נוכחיים</string>
     <string name="tab_editor_title">עורך טאבים</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">לחלק מהטלפונים יש מנועי רטט באיכות נמוכה יותר שעלולים להתעלם מרטטים חלשים מאוד או קצרים מאוד. אם אינך מרגיש הגדרה מסוימת, נסה להגביר את עוצמתה או אורכה. תוכל להתחיל בניסוי הקבוע \"בינוני\" תחילה.</string>
     <string name="vibration_settings_revert">אפס לברירת מחדל</string>
     <string name="vibration_settings_section_length_ms">משך (ms)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">標準キーボード</string>
     <string name="action_add">追加</string>
     <string name="action_allow">許可</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">その他の利用可能なタブ</string>
     <string name="tab_editor_section_current_tabs">現在のタブ</string>
     <string name="tab_editor_title">タブエディタ</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">一部のスマートフォンは振動モーターの品質が低く、非常に弱い振動や非常に短い振動を無視することがあります。設定を感じられない場合は、強度や長さを上げてみてください。まず「中間」のプリセットから試してみることをお勧めします。</string>
     <string name="vibration_settings_revert">デフォルトに戻す</string>
     <string name="vibration_settings_section_length_ms">長さ (ms)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">その他の利用可能なタブ</string>
     <string name="tab_editor_section_current_tabs">現在のタブ</string>
     <string name="tab_editor_title">タブエディタ</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">アップデートがダウンロード済みです。インストール準備ができました。</string>
+    <string name="update_restart_action">再起動</string>
     <string name="vibration_settings_motor_warning">一部のスマートフォンは振動モーターの品質が低く、非常に弱い振動や非常に短い振動を無視することがあります。設定を感じられない場合は、強度や長さを上げてみてください。まず「中間」のプリセットから試してみることをお勧めします。</string>
     <string name="vibration_settings_revert">デフォルトに戻す</string>
     <string name="vibration_settings_section_length_ms">長さ (ms)</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Қол жетімді қойындылар</string>
     <string name="tab_editor_section_current_tabs">Ағымдағы қойындылар</string>
     <string name="tab_editor_title">Қойынды редакторы</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Жаңарту жүктеліп алынды және орнатуға дайын.</string>
+    <string name="update_restart_action">Қайта іске қосу</string>
     <string name="vibration_settings_motor_warning">Кейбір телефондарда сапасы төменірек дірілдеткіш моторлары болады, олар өте әлсіз немесе өте қысқа дірілдерді елемеуі мүмкін. Егер параметрді сезбесеңіз, оның күшін немесе ұзақтығын арттырып көріңіз. \"Орташа\" алдын ала орнатымын алдымен сынап бастай аласыз.</string>
     <string name="vibration_settings_revert">Әдепкіге қайтару</string>
     <string name="vibration_settings_section_length_ms">Ұзақтығы (ms)</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Стандартты пернетақта</string>
     <string name="action_add">Қосу</string>
     <string name="action_allow">Рұқсат беру</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Қол жетімді қойындылар</string>
     <string name="tab_editor_section_current_tabs">Ағымдағы қойындылар</string>
     <string name="tab_editor_title">Қойынды редакторы</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Кейбір телефондарда сапасы төменірек дірілдеткіш моторлары болады, олар өте әлсіз немесе өте қысқа дірілдерді елемеуі мүмкін. Егер параметрді сезбесеңіз, оның күшін немесе ұзақтығын арттырып көріңіз. \"Орташа\" алдын ала орнатымын алдымен сынап бастай аласыз.</string>
     <string name="vibration_settings_revert">Әдепкіге қайтару</string>
     <string name="vibration_settings_section_length_ms">Ұзақтығы (ms)</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">ಲಭ್ಯ ಟ್ಯಾಬ್‌ಗಳು</string>
     <string name="tab_editor_section_current_tabs">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್‌ಗಳು</string>
     <string name="tab_editor_title">ಟ್ಯಾಬ್ ಸಂಪಾದಕ</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">ಅಪ್‌ಡೇಟ್ ಡೌನ್‌ಲೋಡ್ ಆಗಿದೆ, ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ಸಿದ್ಧ.</string>
+    <string name="update_restart_action">ಮರುಪ್ರಾರಂಭಿಸಿ</string>
     <string name="vibration_settings_motor_warning">ಕೆಲವು ಫೋನ್‌ಗಳಲ್ಲಿ ಕಡಿಮೆ ಗುಣಮಟ್ಟದ ವೈಬ್ರೇಶನ್ ಮೋಟಾರ್‌ಗಳಿರುತ್ತವೆ, ಅವು ತುಂಬಾ ದುರ್ಬಲ ಅಥವಾ ತುಂಬಾ ಕಡಿಮೆ ಅವಧಿಯ ವೈಬ್ರೇಶನ್‌ಗಳನ್ನು ನಿರ್ಲಕ್ಷಿಸಬಹುದು. ಯಾವುದೇ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಅನುಭವಿಸಲಾಗದಿದ್ದರೆ, ಅದರ ಶಕ್ತಿ ಅಥವಾ ಉದ್ದವನ್ನು ಹೆಚ್ಚಿಸಲು ಪ್ರಯತ್ನಿಸಿ. ಮೊದಲು \"ಮಧ್ಯಮ\" ಪ್ರೀಸೆಟ್ ಅನ್ನು ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="vibration_settings_revert">ಡೀಫಾಲ್ಟ್‌ಗೆ ಮರುಹೊಂದಿಸಿ</string>
     <string name="vibration_settings_section_length_ms">ಅವಧಿ (ms)</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">ಪ್ರಮಾಣಿತ ಕೀಬೋರ್ಡ್</string>
     <string name="action_add">ಸೇರಿಸಿ</string>
     <string name="action_allow">ಅನುಮತಿಸಿ</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">ಲಭ್ಯ ಟ್ಯಾಬ್‌ಗಳು</string>
     <string name="tab_editor_section_current_tabs">ಪ್ರಸ್ತುತ ಟ್ಯಾಬ್‌ಗಳು</string>
     <string name="tab_editor_title">ಟ್ಯಾಬ್ ಸಂಪಾದಕ</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">ಕೆಲವು ಫೋನ್‌ಗಳಲ್ಲಿ ಕಡಿಮೆ ಗುಣಮಟ್ಟದ ವೈಬ್ರೇಶನ್ ಮೋಟಾರ್‌ಗಳಿರುತ್ತವೆ, ಅವು ತುಂಬಾ ದುರ್ಬಲ ಅಥವಾ ತುಂಬಾ ಕಡಿಮೆ ಅವಧಿಯ ವೈಬ್ರೇಶನ್‌ಗಳನ್ನು ನಿರ್ಲಕ್ಷಿಸಬಹುದು. ಯಾವುದೇ ಸೆಟ್ಟಿಂಗ್ ಅನ್ನು ಅನುಭವಿಸಲಾಗದಿದ್ದರೆ, ಅದರ ಶಕ್ತಿ ಅಥವಾ ಉದ್ದವನ್ನು ಹೆಚ್ಚಿಸಲು ಪ್ರಯತ್ನಿಸಿ. ಮೊದಲು \"ಮಧ್ಯಮ\" ಪ್ರೀಸೆಟ್ ಅನ್ನು ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="vibration_settings_revert">ಡೀಫಾಲ್ಟ್‌ಗೆ ಮರುಹೊಂದಿಸಿ</string>
     <string name="vibration_settings_section_length_ms">ಅವಧಿ (ms)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">표준 키보드</string>
     <string name="action_add">추가</string>
     <string name="action_allow">허용</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">사용 가능한 탭</string>
     <string name="tab_editor_section_current_tabs">현재 탭</string>
     <string name="tab_editor_title">탭 편집기</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">일부 스마트폰은 진동 모터 품질이 낮아 매우 약하거나 짧은 진동을 무시할 수 있습니다. 설정이 느껴지지 않으면 강도나 길이를 높여 보세요. 먼저 \"보통\" 프리셋을 시도해 보는 것을 권장합니다.</string>
     <string name="vibration_settings_revert">기본값으로 재설정</string>
     <string name="vibration_settings_section_length_ms">길이 (ms)</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">사용 가능한 탭</string>
     <string name="tab_editor_section_current_tabs">현재 탭</string>
     <string name="tab_editor_title">탭 편집기</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">업데이트가 다운로드되었습니다. 설치 준비가 완료되었습니다.</string>
+    <string name="update_restart_action">다시 시작</string>
     <string name="vibration_settings_motor_warning">일부 스마트폰은 진동 모터 품질이 낮아 매우 약하거나 짧은 진동을 무시할 수 있습니다. 설정이 느껴지지 않으면 강도나 길이를 높여 보세요. 먼저 \"보통\" 프리셋을 시도해 보는 것을 권장합니다.</string>
     <string name="vibration_settings_revert">기본값으로 재설정</string>
     <string name="vibration_settings_section_length_ms">길이 (ms)</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standartinė klaviatūra</string>
     <string name="action_add">Pridėti</string>
     <string name="action_allow">Leisti</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Galimi skirtukai</string>
     <string name="tab_editor_section_current_tabs">Dabartiniai skirtukai</string>
     <string name="tab_editor_title">Skirtukų redaktorius</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Kai kuriuose telefonuose yra žemesnės kokybės vibromotoriai, kurie gali ignoruoti labai silpnas arba labai trumpas vibracijas. Jei negalite pajusti nustatymo, pabandykite padidinti jo stiprumą arba ilgį. Galite pradėti išbandydami \"Vidutinis\" išankstinį nustatymą.</string>
     <string name="vibration_settings_revert">Atkurti numatytuosius</string>
     <string name="vibration_settings_section_length_ms">Trukmė (ms)</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Galimi skirtukai</string>
     <string name="tab_editor_section_current_tabs">Dabartiniai skirtukai</string>
     <string name="tab_editor_title">Skirtukų redaktorius</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Atnaujinimas atsisiųstas ir paruoštas diegti.</string>
+    <string name="update_restart_action">Paleisti iš naujo</string>
     <string name="vibration_settings_motor_warning">Kai kuriuose telefonuose yra žemesnės kokybės vibromotoriai, kurie gali ignoruoti labai silpnas arba labai trumpas vibracijas. Jei negalite pajusti nustatymo, pabandykite padidinti jo stiprumą arba ilgį. Galite pradėti išbandydami \"Vidutinis\" išankstinį nustatymą.</string>
     <string name="vibration_settings_revert">Atkurti numatytuosius</string>
     <string name="vibration_settings_section_length_ms">Trukmė (ms)</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pieejamie cilņi</string>
     <string name="tab_editor_section_current_tabs">Pašreizējie cilņi</string>
     <string name="tab_editor_title">Ciļņu redaktors</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Atjauninājums ir lejupielādēts un gatavs instalēšanai.</string>
+    <string name="update_restart_action">Restartēt</string>
     <string name="vibration_settings_motor_warning">Dažiem telefoniem ir zemākas kvalitātes vibrācijas motori, kas var ignorēt ļoti vājas vai ļoti īsas vibrācijas. Ja nevarat sajust kādu iestatījumu, mēģiniet palielināt tā stiprumu vai ilgumu. Varat sākt, izmēģinot \"Vidējs\" sākotnējo iestatījumu.</string>
     <string name="vibration_settings_revert">Atjaunot noklusējumu</string>
     <string name="vibration_settings_section_length_ms">Ilgums (ms)</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standarta tastatūra</string>
     <string name="action_add">Pievienot</string>
     <string name="action_allow">Atļaut</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Pieejamie cilņi</string>
     <string name="tab_editor_section_current_tabs">Pašreizējie cilņi</string>
     <string name="tab_editor_title">Ciļņu redaktors</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Dažiem telefoniem ir zemākas kvalitātes vibrācijas motori, kas var ignorēt ļoti vājas vai ļoti īsas vibrācijas. Ja nevarat sajust kādu iestatījumu, mēģiniet palielināt tā stiprumu vai ilgumu. Varat sākt, izmēģinot \"Vidējs\" sākotnējo iestatījumu.</string>
     <string name="vibration_settings_revert">Atjaunot noklusējumu</string>
     <string name="vibration_settings_section_length_ms">Ilgums (ms)</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">ലഭ്യമായ ടാബുകൾ</string>
     <string name="tab_editor_section_current_tabs">നിലവിലെ ടാബുകൾ</string>
     <string name="tab_editor_title">ടാബ് എഡിറ്റർ</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">അപ്‌ഡേറ്റ് ഡൗൺലോഡ് ആയി, ഇൻസ്റ്റാൾ ചെയ്യാൻ തയ്യാർ.</string>
+    <string name="update_restart_action">പുനരാരംഭിക്കുക</string>
     <string name="vibration_settings_motor_warning">ചില ഫോണുകളിൽ നിലവാരം കുറഞ്ഞ വൈബ്രേഷൻ മോട്ടോറുകൾ ഉണ്ട്, അവ വളരെ ദുർബലമോ വളരെ ചെറുതോ ആയ വൈബ്രേഷനുകൾ അവഗണിക്കാം. ഒരു ക്രമീകരണം അനുഭവപ്പെടുന്നില്ലെങ്കിൽ, അതിന്റെ ശക്തി അല്ലെങ്കിൽ ദൈർഘ്യം വർദ്ധിപ്പിക്കാൻ ശ്രമിക്കൂ. ആദ്യം \"ഇടത്തരം\" പ്രീസെറ്റ് പരീക്ഷിക്കുന്നതിൽ നിന്ന് ആരംഭിക്കാം.</string>
     <string name="vibration_settings_revert">ഡിഫോൾട്ടിലേക്ക് പുനഃസജ്ജമാക്കുക</string>
     <string name="vibration_settings_section_length_ms">ദൈർഘ്യം (ms)</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">സ്റ്റാൻഡേർഡ് കീബോർഡ്</string>
     <string name="action_add">ചേർക്കുക</string>
     <string name="action_allow">അനുവദിക്കുക</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">ലഭ്യമായ ടാബുകൾ</string>
     <string name="tab_editor_section_current_tabs">നിലവിലെ ടാബുകൾ</string>
     <string name="tab_editor_title">ടാബ് എഡിറ്റർ</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">ചില ഫോണുകളിൽ നിലവാരം കുറഞ്ഞ വൈബ്രേഷൻ മോട്ടോറുകൾ ഉണ്ട്, അവ വളരെ ദുർബലമോ വളരെ ചെറുതോ ആയ വൈബ്രേഷനുകൾ അവഗണിക്കാം. ഒരു ക്രമീകരണം അനുഭവപ്പെടുന്നില്ലെങ്കിൽ, അതിന്റെ ശക്തി അല്ലെങ്കിൽ ദൈർഘ്യം വർദ്ധിപ്പിക്കാൻ ശ്രമിക്കൂ. ആദ്യം \"ഇടത്തരം\" പ്രീസെറ്റ് പരീക്ഷിക്കുന്നതിൽ നിന്ന് ആരംഭിക്കാം.</string>
     <string name="vibration_settings_revert">ഡിഫോൾട്ടിലേക്ക് പുനഃസജ്ജമാക്കുക</string>
     <string name="vibration_settings_section_length_ms">ദൈർഘ്യം (ms)</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">उपलब्ध Tabs</string>
     <string name="tab_editor_section_current_tabs">सध्याचे Tabs</string>
     <string name="tab_editor_title">Tab संपादक</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">अपडेट डाउनलोड झाले आहे, इंस्टॉल करण्यासाठी तयार आहे.</string>
+    <string name="update_restart_action">पुन्हा सुरू करा</string>
     <string name="vibration_settings_motor_warning">काही फोनमध्ये कमी दर्जाचे व्हायब्रेशन मोटर असतात जे खूप कमकुवत किंवा खूप कमी कालावधीचे व्हायब्रेशन दुर्लक्षित करू शकतात. जर एखादी सेटिंग जाणवत नसेल, तर त्याची शक्ती किंवा लांबी वाढवण्याचा प्रयत्न करा. तुम्ही प्रथम \"मध्यम\" प्रीसेट वापरून पाहू शकता।</string>
     <string name="vibration_settings_revert">डीफॉल्टवर रीसेट करा</string>
     <string name="vibration_settings_section_length_ms">कालावधी (ms)</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">मानक कीबोर्ड</string>
     <string name="action_add">जोडा</string>
     <string name="action_allow">परवानगी द्या</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">उपलब्ध Tabs</string>
     <string name="tab_editor_section_current_tabs">सध्याचे Tabs</string>
     <string name="tab_editor_title">Tab संपादक</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">काही फोनमध्ये कमी दर्जाचे व्हायब्रेशन मोटर असतात जे खूप कमकुवत किंवा खूप कमी कालावधीचे व्हायब्रेशन दुर्लक्षित करू शकतात. जर एखादी सेटिंग जाणवत नसेल, तर त्याची शक्ती किंवा लांबी वाढवण्याचा प्रयत्न करा. तुम्ही प्रथम \"मध्यम\" प्रीसेट वापरून पाहू शकता।</string>
     <string name="vibration_settings_revert">डीफॉल्टवर रीसेट करा</string>
     <string name="vibration_settings_section_length_ms">कालावधी (ms)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Papan kekunci standard</string>
     <string name="action_add">Tambah</string>
     <string name="action_allow">Benarkan</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab tersedia</string>
     <string name="tab_editor_section_current_tabs">Tab semasa</string>
     <string name="tab_editor_title">Editor tab</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Sesetengah telefon mempunyai motor getaran berkualiti lebih rendah yang mungkin mengabaikan getaran yang sangat lemah atau sangat pendek. Jika anda tidak dapat merasai sesuatu tetapan, cuba naikkan kekuatan atau panjangnya. Anda boleh mula dengan mencuba pratetap \"Sederhana\" terlebih dahulu.</string>
     <string name="vibration_settings_revert">Tetapkan semula ke lalai</string>
     <string name="vibration_settings_section_length_ms">Tempoh (ms)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab tersedia</string>
     <string name="tab_editor_section_current_tabs">Tab semasa</string>
     <string name="tab_editor_title">Editor tab</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Kemas kini telah dimuat turun dan sedia untuk dipasang.</string>
+    <string name="update_restart_action">Mulakan semula</string>
     <string name="vibration_settings_motor_warning">Sesetengah telefon mempunyai motor getaran berkualiti lebih rendah yang mungkin mengabaikan getaran yang sangat lemah atau sangat pendek. Jika anda tidak dapat merasai sesuatu tetapan, cuba naikkan kekuatan atau panjangnya. Anda boleh mula dengan mencuba pratetap \"Sederhana\" terlebih dahulu.</string>
     <string name="vibration_settings_revert">Tetapkan semula ke lalai</string>
     <string name="vibration_settings_section_length_ms">Tempoh (ms)</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgjengelige faner</string>
     <string name="tab_editor_section_current_tabs">Gjeldende faner</string>
     <string name="tab_editor_title">Faneredaktør</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Oppdateringen er lastet ned og klar til installering.</string>
+    <string name="update_restart_action">Start på nytt</string>
     <string name="vibration_settings_motor_warning">Noen telefoner har vibrasjonsmotorer av lavere kvalitet som kan ignorere veldig svake eller veldig korte vibrasjoner. Hvis du ikke kan kjenne en innstilling, prøv å øke styrken eller lengden. Du kan begynne med å prøve \"Middels\" forhåndsinnstillingen.</string>
     <string name="vibration_settings_revert">Gjenopprett standard</string>
     <string name="vibration_settings_section_length_ms">Varighet (ms)</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgjengelige faner</string>
     <string name="tab_editor_section_current_tabs">Gjeldende faner</string>
     <string name="tab_editor_title">Faneredaktør</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Noen telefoner har vibrasjonsmotorer av lavere kvalitet som kan ignorere veldig svake eller veldig korte vibrasjoner. Hvis du ikke kan kjenne en innstilling, prøv å øke styrken eller lengden. Du kan begynne med å prøve \"Middels\" forhåndsinnstillingen.</string>
     <string name="vibration_settings_revert">Gjenopprett standard</string>
     <string name="vibration_settings_section_length_ms">Varighet (ms)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Beschikbare tabbladen</string>
     <string name="tab_editor_section_current_tabs">Huidige tabbladen</string>
     <string name="tab_editor_title">Tabbladeditor</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">De update is gedownload en klaar om te installeren.</string>
+    <string name="update_restart_action">Opnieuw starten</string>
     <string name="vibration_settings_motor_warning">Sommige telefoons hebben vibratieomoren van lagere kwaliteit die zeer zwakke of zeer korte trillingen kunnen negeren. Als u een instelling niet voelt, probeer dan de sterkte of lengte te verhogen. U kunt beginnen met het uitproberen van de voorinstelling \"Gemiddeld\".</string>
     <string name="vibration_settings_revert">Standaard herstellen</string>
     <string name="vibration_settings_section_length_ms">Duur (ms)</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standaardtoetsenbord</string>
     <string name="action_add">Toevoegen</string>
     <string name="action_allow">Toestaan</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Beschikbare tabbladen</string>
     <string name="tab_editor_section_current_tabs">Huidige tabbladen</string>
     <string name="tab_editor_title">Tabbladeditor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Sommige telefoons hebben vibratieomoren van lagere kwaliteit die zeer zwakke of zeer korte trillingen kunnen negeren. Als u een instelling niet voelt, probeer dan de sterkte of lengte te verhogen. U kunt beginnen met het uitproberen van de voorinstelling \"Gemiddeld\".</string>
     <string name="vibration_settings_revert">Standaard herstellen</string>
     <string name="vibration_settings_section_length_ms">Duur (ms)</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgjengelige faner</string>
     <string name="tab_editor_section_current_tabs">Gjeldende faner</string>
     <string name="tab_editor_title">Faneredaktør</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Oppdateringen er lastet ned og klar til installering.</string>
+    <string name="update_restart_action">Start på nytt</string>
     <string name="vibration_settings_motor_warning">Noen telefoner har vibrasjonsmotorer av lavere kvalitet som kan ignorere veldig svake eller veldig korte vibrasjoner. Hvis du ikke kan kjenne en innstilling, prøv å øke styrken eller lengden. Du kan begynne med å prøve \"Middels\" forhåndsinnstillingen.</string>
     <string name="vibration_settings_revert">Gjenopprett standard</string>
     <string name="vibration_settings_section_length_ms">Varighet (ms)</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardtastatur</string>
     <string name="action_add">Legg til</string>
     <string name="action_allow">Tillat</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tilgjengelige faner</string>
     <string name="tab_editor_section_current_tabs">Gjeldende faner</string>
     <string name="tab_editor_title">Faneredaktør</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Noen telefoner har vibrasjonsmotorer av lavere kvalitet som kan ignorere veldig svake eller veldig korte vibrasjoner. Hvis du ikke kan kjenne en innstilling, prøv å øke styrken eller lengden. Du kan begynne med å prøve \"Middels\" forhåndsinnstillingen.</string>
     <string name="vibration_settings_revert">Gjenopprett standard</string>
     <string name="vibration_settings_section_length_ms">Varighet (ms)</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">ਸਟੈਂਡਰਡ ਕੀਬੋਰਡ</string>
     <string name="action_add">ਜੋੜੋ</string>
     <string name="action_allow">ਆਗਿਆ ਦਿਓ</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">ਉਪਲਬਧ ਟੈਬ</string>
     <string name="tab_editor_section_current_tabs">ਮੌਜੂਦਾ ਟੈਬ</string>
     <string name="tab_editor_title">ਟੈਬ ਸੰਪਾਦਕ</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">ਕੁਝ ਫੋਨਾਂ ਵਿੱਚ ਘੱਟ ਗੁਣਵੱਤਾ ਵਾਲੇ ਵਾਈਬ੍ਰੇਸ਼ਨ ਮੋਟਰ ਹੁੰਦੇ ਹਨ ਜੋ ਬਹੁਤ ਕਮਜ਼ੋਰ ਜਾਂ ਬਹੁਤ ਛੋਟੇ ਵਾਈਬ੍ਰੇਸ਼ਨ ਨੂੰ ਨਜ਼ਰਅੰਦਾਜ਼ ਕਰ ਸਕਦੇ ਹਨ। ਜੇ ਤੁਸੀਂ ਕੋਈ ਸੈਟਿੰਗ ਮਹਿਸੂਸ ਨਹੀਂ ਕਰ ਸਕਦੇ, ਤਾਂ ਇਸਦੀ ਤਾਕਤ ਜਾਂ ਲੰਬਾਈ ਵਧਾਉਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ। ਤੁਸੀਂ ਪਹਿਲਾਂ \"ਦਰਮਿਆਨਾ\" ਪ੍ਰੀਸੈੱਟ ਅਜ਼ਮਾ ਕੇ ਸ਼ੁਰੂ ਕਰ ਸਕਦੇ ਹੋ।</string>
     <string name="vibration_settings_revert">ਡਿਫੌਲਟ \'ਤੇ ਰੀਸੈੱਟ</string>
     <string name="vibration_settings_section_length_ms">ਅਵਧੀ (ms)</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">ਉਪਲਬਧ ਟੈਬ</string>
     <string name="tab_editor_section_current_tabs">ਮੌਜੂਦਾ ਟੈਬ</string>
     <string name="tab_editor_title">ਟੈਬ ਸੰਪਾਦਕ</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">ਅੱਪਡੇਟ ਡਾਊਨਲੋਡ ਹੋ ਗਿਆ ਹੈ, ਇੰਸਟਾਲ ਕਰਨ ਲਈ ਤਿਆਰ ਹੈ।</string>
+    <string name="update_restart_action">ਮੁੜ ਚਾਲੂ ਕਰੋ</string>
     <string name="vibration_settings_motor_warning">ਕੁਝ ਫੋਨਾਂ ਵਿੱਚ ਘੱਟ ਗੁਣਵੱਤਾ ਵਾਲੇ ਵਾਈਬ੍ਰੇਸ਼ਨ ਮੋਟਰ ਹੁੰਦੇ ਹਨ ਜੋ ਬਹੁਤ ਕਮਜ਼ੋਰ ਜਾਂ ਬਹੁਤ ਛੋਟੇ ਵਾਈਬ੍ਰੇਸ਼ਨ ਨੂੰ ਨਜ਼ਰਅੰਦਾਜ਼ ਕਰ ਸਕਦੇ ਹਨ। ਜੇ ਤੁਸੀਂ ਕੋਈ ਸੈਟਿੰਗ ਮਹਿਸੂਸ ਨਹੀਂ ਕਰ ਸਕਦੇ, ਤਾਂ ਇਸਦੀ ਤਾਕਤ ਜਾਂ ਲੰਬਾਈ ਵਧਾਉਣ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ। ਤੁਸੀਂ ਪਹਿਲਾਂ \"ਦਰਮਿਆਨਾ\" ਪ੍ਰੀਸੈੱਟ ਅਜ਼ਮਾ ਕੇ ਸ਼ੁਰੂ ਕਰ ਸਕਦੇ ਹੋ।</string>
     <string name="vibration_settings_revert">ਡਿਫੌਲਟ \'ਤੇ ਰੀਸੈੱਟ</string>
     <string name="vibration_settings_section_length_ms">ਅਵਧੀ (ms)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostępne zakładki</string>
     <string name="tab_editor_section_current_tabs">Bieżące zakładki</string>
     <string name="tab_editor_title">Edytor zakładek</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Aktualizacja została pobrana i jest gotowa do zainstalowania.</string>
+    <string name="update_restart_action">Uruchom ponownie</string>
     <string name="vibration_settings_motor_warning">Niektóre telefony mają silniki wibracji niższej jakości, które mogą ignorować bardzo słabe lub bardzo krótkie wibracje. Jeśli nie czujesz ustawienia, spróbuj zwiększyć jego siłę lub długość. Możesz zacząć od wypróbowania ustawienia wstępnego \"Średni\".</string>
     <string name="vibration_settings_revert">Przywróć domyślne</string>
     <string name="vibration_settings_section_length_ms">Czas trwania (ms)</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardowa klawiatura</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Zezwól</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostępne zakładki</string>
     <string name="tab_editor_section_current_tabs">Bieżące zakładki</string>
     <string name="tab_editor_title">Edytor zakładek</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Niektóre telefony mają silniki wibracji niższej jakości, które mogą ignorować bardzo słabe lub bardzo krótkie wibracje. Jeśli nie czujesz ustawienia, spróbuj zwiększyć jego siłę lub długość. Możesz zacząć od wypróbowania ustawienia wstępnego \"Średni\".</string>
     <string name="vibration_settings_revert">Przywróć domyślne</string>
     <string name="vibration_settings_section_length_ms">Czas trwania (ms)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Abas disponíveis</string>
     <string name="tab_editor_section_current_tabs">Abas atuais</string>
     <string name="tab_editor_title">Editor de abas</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Alguns celulares têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se você não conseguir sentir uma configuração, tente aumentar sua intensidade ou duração. Você pode começar experimentando a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Restaurar padrão</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Abas disponíveis</string>
     <string name="tab_editor_section_current_tabs">Abas atuais</string>
     <string name="tab_editor_title">Editor de abas</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">A atualização foi baixada e está pronta para instalar.</string>
+    <string name="update_restart_action">Reiniciar</string>
     <string name="vibration_settings_motor_warning">Alguns celulares têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se você não conseguir sentir uma configuração, tente aumentar sua intensidade ou duração. Você pode começar experimentando a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Restaurar padrão</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Separadores disponíveis</string>
     <string name="tab_editor_section_current_tabs">Separadores atuais</string>
     <string name="tab_editor_title">Editor de separadores</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">A atualização foi transferida e está pronta para instalar.</string>
+    <string name="update_restart_action">Reiniciar</string>
     <string name="vibration_settings_motor_warning">Alguns telemóveis têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se não conseguir sentir uma definição, tente aumentar a sua intensidade ou duração. Pode começar por experimentar a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Repor predefinição</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Separadores disponíveis</string>
     <string name="tab_editor_section_current_tabs">Separadores atuais</string>
     <string name="tab_editor_title">Editor de separadores</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Alguns telemóveis têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se não conseguir sentir uma definição, tente aumentar a sua intensidade ou duração. Pode começar por experimentar a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Repor predefinição</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Separadores disponíveis</string>
     <string name="tab_editor_section_current_tabs">Separadores atuais</string>
     <string name="tab_editor_title">Editor de separadores</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">A atualização foi transferida e está pronta para instalar.</string>
+    <string name="update_restart_action">Reiniciar</string>
     <string name="vibration_settings_motor_warning">Alguns telemóveis têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se não conseguir sentir uma definição, tente aumentar a sua intensidade ou duração. Pode começar por experimentar a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Repor predefinição</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Teclado padrão</string>
     <string name="action_add">Adicionar</string>
     <string name="action_allow">Permitir</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Separadores disponíveis</string>
     <string name="tab_editor_section_current_tabs">Separadores atuais</string>
     <string name="tab_editor_title">Editor de separadores</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Alguns telemóveis têm motores de vibração de menor qualidade que podem ignorar vibrações muito fracas ou muito curtas. Se não conseguir sentir uma definição, tente aumentar a sua intensidade ou duração. Pode começar por experimentar a predefinição \"Médio\" primeiro.</string>
     <string name="vibration_settings_revert">Repor predefinição</string>
     <string name="vibration_settings_section_length_ms">Duração (ms)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">File disponibile</string>
     <string name="tab_editor_section_current_tabs">File curente</string>
     <string name="tab_editor_title">Editor file</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Actualizarea a fost descărcată și este gata de instalare.</string>
+    <string name="update_restart_action">Repornire</string>
     <string name="vibration_settings_motor_warning">Unele telefoane au motoare de vibrație de calitate mai scăzută care pot ignora vibrațiile foarte slabe sau foarte scurte. Dacă nu simțiți o setare, încercați să îi creșteți intensitatea sau durata. Puteți începe încercând mai întâi presetul \"Mediu\".</string>
     <string name="vibration_settings_revert">Restabilire implicită</string>
     <string name="vibration_settings_section_length_ms">Durată (ms)</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Tastatură standard</string>
     <string name="action_add">Adaugă</string>
     <string name="action_allow">Permite</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">File disponibile</string>
     <string name="tab_editor_section_current_tabs">File curente</string>
     <string name="tab_editor_title">Editor file</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Unele telefoane au motoare de vibrație de calitate mai scăzută care pot ignora vibrațiile foarte slabe sau foarte scurte. Dacă nu simțiți o setare, încercați să îi creșteți intensitatea sau durata. Puteți începe încercând mai întâi presetul \"Mediu\".</string>
     <string name="vibration_settings_revert">Restabilire implicită</string>
     <string name="vibration_settings_section_length_ms">Durată (ms)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступные вкладки</string>
     <string name="tab_editor_section_current_tabs">Текущие вкладки</string>
     <string name="tab_editor_title">Редактор вкладок</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Обновление загружено и готово к установке.</string>
+    <string name="update_restart_action">Перезапустить</string>
     <string name="vibration_settings_motor_warning">На некоторых телефонах установлены вибромоторы более низкого качества, которые могут игнорировать очень слабые или очень короткие вибрации. Если вы не ощущаете настройку, попробуйте увеличить её силу или длину. Для начала рекомендуем попробовать предустановку «Средняя».</string>
     <string name="vibration_settings_revert">Сбросить к умолчанию</string>
     <string name="vibration_settings_section_length_ms">Длительность (ms)</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Стандартная клавиатура</string>
     <string name="action_add">Добавить</string>
     <string name="action_allow">Разрешить</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступные вкладки</string>
     <string name="tab_editor_section_current_tabs">Текущие вкладки</string>
     <string name="tab_editor_title">Редактор вкладок</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">На некоторых телефонах установлены вибромоторы более низкого качества, которые могут игнорировать очень слабые или очень короткие вибрации. Если вы не ощущаете настройку, попробуйте увеличить её силу или длину. Для начала рекомендуем попробовать предустановку «Средняя».</string>
     <string name="vibration_settings_revert">Сбросить к умолчанию</string>
     <string name="vibration_settings_section_length_ms">Длительность (ms)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupné karty</string>
     <string name="tab_editor_section_current_tabs">Aktuálne karty</string>
     <string name="tab_editor_title">Editor kariet</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Aktualizácia je stiahnutá a pripravená na inštaláciu.</string>
+    <string name="update_restart_action">Reštartovať</string>
     <string name="vibration_settings_motor_warning">Niektoré telefóny majú vibračné motory nižšej kvality, ktoré môžu ignorovať veľmi slabé alebo veľmi krátke vibrácie. Ak neviete pocítiť nastavenie, skúste zvýšiť jeho silu alebo dĺžku. Môžete začať vyskúšaním predvoľby \"Stredný\".</string>
     <string name="vibration_settings_revert">Obnoviť predvolené</string>
     <string name="vibration_settings_section_length_ms">Trvanie (ms)</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Štandardná klávesnica</string>
     <string name="action_add">Pridať</string>
     <string name="action_allow">Povoliť</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Dostupné karty</string>
     <string name="tab_editor_section_current_tabs">Aktuálne karty</string>
     <string name="tab_editor_title">Editor kariet</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Niektoré telefóny majú vibračné motory nižšej kvality, ktoré môžu ignorovať veľmi slabé alebo veľmi krátke vibrácie. Ak neviete pocítiť nastavenie, skúste zvýšiť jeho silu alebo dĺžku. Môžete začať vyskúšaním predvoľby \"Stredný\".</string>
     <string name="vibration_settings_revert">Obnoviť predvolené</string>
     <string name="vibration_settings_section_length_ms">Trvanie (ms)</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Razpoložljivi zavihki</string>
     <string name="tab_editor_section_current_tabs">Trenutni zavihki</string>
     <string name="tab_editor_title">Urejevalnik zavihkov</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Posodobitev je prenesena in pripravljena za namestitev.</string>
+    <string name="update_restart_action">Znova zaženi</string>
     <string name="vibration_settings_motor_warning">Nekateri telefoni imajo vibromotorje nižje kakovosti, ki lahko ignorirajo zelo šibke ali zelo kratke vibracije. Če ne čutite nastavitve, poskusite povečati njeno moč ali dolžino. Začnete lahko s preizkusom prednastavitve \"Srednje\".</string>
     <string name="vibration_settings_revert">Ponastavi privzeto</string>
     <string name="vibration_settings_section_length_ms">Trajanje (ms)</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardna tipkovnica</string>
     <string name="action_add">Dodaj</string>
     <string name="action_allow">Dovoli</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Razpoložljivi zavihki</string>
     <string name="tab_editor_section_current_tabs">Trenutni zavihki</string>
     <string name="tab_editor_title">Urejevalnik zavihkov</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Nekateri telefoni imajo vibromotorje nižje kakovosti, ki lahko ignorirajo zelo šibke ali zelo kratke vibracije. Če ne čutite nastavitve, poskusite povečati njeno moč ali dolžino. Začnete lahko s preizkusom prednastavitve \"Srednje\".</string>
     <string name="vibration_settings_revert">Ponastavi privzeto</string>
     <string name="vibration_settings_section_length_ms">Trajanje (ms)</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступне картице</string>
     <string name="tab_editor_section_current_tabs">Тренутне картице</string>
     <string name="tab_editor_title">Уређивач картица</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Ажурирање је преузето и спремно за инсталацију.</string>
+    <string name="update_restart_action">Поново покрени</string>
     <string name="vibration_settings_motor_warning">Неки телефони имају вибромоторе нижег квалитета koji могу игнорисати врло слабе или врло кратке вибрације. Ако не можете да осетите подешавање, покушајте да повећате његову јачину или дужину. Можете почети испробавањем предпоставке \"Средње\".</string>
     <string name="vibration_settings_revert">Врати на подразумевано</string>
     <string name="vibration_settings_section_length_ms">Трајање (ms)</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Стандардна тастатура</string>
     <string name="action_add">Додај</string>
     <string name="action_allow">Дозволи</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступне картице</string>
     <string name="tab_editor_section_current_tabs">Тренутне картице</string>
     <string name="tab_editor_title">Уређивач картица</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Неки телефони имају вибромоторе нижег квалитета koji могу игнорисати врло слабе или врло кратке вибрације. Ако не можете да осетите подешавање, покушајте да повећате његову јачину или дужину. Можете почети испробавањем предпоставке \"Средње\".</string>
     <string name="vibration_settings_revert">Врати на подразумевано</string>
     <string name="vibration_settings_section_length_ms">Трајање (ms)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standardtangentbord</string>
     <string name="action_add">Lägg till</string>
     <string name="action_allow">Tillåt</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tillgängliga flikar</string>
     <string name="tab_editor_section_current_tabs">Nuvarande flikar</string>
     <string name="tab_editor_title">Flikredigerare</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Vissa telefoner har vibrationsmotorer av lägre kvalitet som kan ignorera mycket svaga eller mycket korta vibrationer. Om du inte kan känna en inställning, prova att öka dess styrka eller längd. Du kan börja med att prova förinställningen \"Medel\".</string>
     <string name="vibration_settings_revert">Återställ standard</string>
     <string name="vibration_settings_section_length_ms">Varaktighet (ms)</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tillgängliga flikar</string>
     <string name="tab_editor_section_current_tabs">Nuvarande flikar</string>
     <string name="tab_editor_title">Flikredigerare</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Uppdateringen är nedladdad och redo att installeras.</string>
+    <string name="update_restart_action">Starta om</string>
     <string name="vibration_settings_motor_warning">Vissa telefoner har vibrationsmotorer av lägre kvalitet som kan ignorera mycket svaga eller mycket korta vibrationer. Om du inte kan känna en inställning, prova att öka dess styrka eller längd. Du kan börja med att prova förinställningen \"Medel\".</string>
     <string name="vibration_settings_revert">Återställ standard</string>
     <string name="vibration_settings_section_length_ms">Varaktighet (ms)</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">கிடைக்கக்கூடிய Tab-கள்</string>
     <string name="tab_editor_section_current_tabs">தற்போதைய Tab-கள்</string>
     <string name="tab_editor_title">Tab திருத்தி</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">புதுப்பிப்பு பதிவிறக்கப்பட்டது, நிறுவ தயாராக உள்ளது.</string>
+    <string name="update_restart_action">மீண்டும் தொடங்கு</string>
     <string name="vibration_settings_motor_warning">சில தொலைபேசிகளில் குறைந்த தரமான அதிர்வு மோட்டார்கள் உள்ளன, அவை மிகவும் பலவீனமான அல்லது மிகவும் குறுகிய அதிர்வுகளை புறக்கணிக்கக்கூடும். ஒரு அமைப்பை உணர முடியாவிட்டால், அதன் வலிமை அல்லது நீளத்தை அதிகரிக்க முயற்சிக்கவும். முதலில் \"நடுத்தர\" முன்னமைவை முயற்சிப்பதில் இருந்து தொடங்கலாம்.</string>
     <string name="vibration_settings_revert">இயல்புநிலைக்கு மீட்டமை</string>
     <string name="vibration_settings_section_length_ms">கால அளவு (ms)</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">நிலையான விசைப்பலகை</string>
     <string name="action_add">சேர்</string>
     <string name="action_allow">அனுமதி</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">கிடைக்கக்கூடிய Tab-கள்</string>
     <string name="tab_editor_section_current_tabs">தற்போதைய Tab-கள்</string>
     <string name="tab_editor_title">Tab திருத்தி</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">சில தொலைபேசிகளில் குறைந்த தரமான அதிர்வு மோட்டார்கள் உள்ளன, அவை மிகவும் பலவீனமான அல்லது மிகவும் குறுகிய அதிர்வுகளை புறக்கணிக்கக்கூடும். ஒரு அமைப்பை உணர முடியாவிட்டால், அதன் வலிமை அல்லது நீளத்தை அதிகரிக்க முயற்சிக்கவும். முதலில் \"நடுத்தர\" முன்னமைவை முயற்சிப்பதில் இருந்து தொடங்கலாம்.</string>
     <string name="vibration_settings_revert">இயல்புநிலைக்கு மீட்டமை</string>
     <string name="vibration_settings_section_length_ms">கால அளவு (ms)</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">ప్రామాణిక కీబోర్డ్</string>
     <string name="action_add">జోడించు</string>
     <string name="action_allow">అనుమతించు</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">అందుబాటులో ఉన్న ట్యాబ్‌లు</string>
     <string name="tab_editor_section_current_tabs">ప్రస్తుత ట్యాబ్‌లు</string>
     <string name="tab_editor_title">ట్యాబ్ ఎడిటర్</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">కొన్ని ఫోన్లలో తక్కువ నాణ్యమైన వైబ్రేషన్ మోటార్లు ఉంటాయి, అవి చాలా బలహీనమైన లేదా చాలా తక్కువ వ్యవధిగల వైబ్రేషన్లను విస్మరించవచ్చు. మీకు ఏదైనా సెట్టింగ్ అనుభవం కాకపోతే, దాని బలం లేదా పొడవును పెంచడానికి ప్రయత్నించండి. ముందుగా \"మధ్యమ\" ప్రీసెట్‌ను ప్రయత్నించడం ద్వారా ప్రారంభించవచ్చు.</string>
     <string name="vibration_settings_revert">డిఫాల్ట్‌కు రీసెట్ చేయండి</string>
     <string name="vibration_settings_section_length_ms">వ్యవధి (ms)</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">అందుబాటులో ఉన్న ట్యాబ్‌లు</string>
     <string name="tab_editor_section_current_tabs">ప్రస్తుత ట్యాబ్‌లు</string>
     <string name="tab_editor_title">ట్యాబ్ ఎడిటర్</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">అప్‌డేట్ డౌన్‌లోడ్ అయింది, ఇన్‌స్టాల్ చేయడానికి సిద్ధంగా ఉంది.</string>
+    <string name="update_restart_action">పునఃప్రారంభించు</string>
     <string name="vibration_settings_motor_warning">కొన్ని ఫోన్లలో తక్కువ నాణ్యమైన వైబ్రేషన్ మోటార్లు ఉంటాయి, అవి చాలా బలహీనమైన లేదా చాలా తక్కువ వ్యవధిగల వైబ్రేషన్లను విస్మరించవచ్చు. మీకు ఏదైనా సెట్టింగ్ అనుభవం కాకపోతే, దాని బలం లేదా పొడవును పెంచడానికి ప్రయత్నించండి. ముందుగా \"మధ్యమ\" ప్రీసెట్‌ను ప్రయత్నించడం ద్వారా ప్రారంభించవచ్చు.</string>
     <string name="vibration_settings_revert">డిఫాల్ట్‌కు రీసెట్ చేయండి</string>
     <string name="vibration_settings_section_length_ms">వ్యవధి (ms)</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">แท็บที่ใช้ได้</string>
     <string name="tab_editor_section_current_tabs">แท็บปัจจุบัน</string>
     <string name="tab_editor_title">ตัวแก้ไขแท็บ</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">อัปเดตดาวน์โหลดเสร็จแล้ว พร้อมติดตั้ง</string>
+    <string name="update_restart_action">รีสตาร์ท</string>
     <string name="vibration_settings_motor_warning">โทรศัพท์บางรุ่นมีมอเตอร์สั่นคุณภาพต่ำที่อาจไม่ตอบสนองต่อการสั่นที่อ่อนมากหรือสั้นมาก หากคุณรู้สึกไม่ได้ถึงการตั้งค่า ให้ลองเพิ่มความแรงหรือความยาว คุณสามารถเริ่มต้นด้วยการลองใช้ค่าตั้งต้น \"ปานกลาง\" ก่อน</string>
     <string name="vibration_settings_revert">รีเซ็ตเป็นค่าเริ่มต้น</string>
     <string name="vibration_settings_section_length_ms">ระยะเวลา (ms)</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">แป้นพิมพ์มาตรฐาน</string>
     <string name="action_add">เพิ่ม</string>
     <string name="action_allow">อนุญาต</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">แท็บที่ใช้ได้</string>
     <string name="tab_editor_section_current_tabs">แท็บปัจจุบัน</string>
     <string name="tab_editor_title">ตัวแก้ไขแท็บ</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">โทรศัพท์บางรุ่นมีมอเตอร์สั่นคุณภาพต่ำที่อาจไม่ตอบสนองต่อการสั่นที่อ่อนมากหรือสั้นมาก หากคุณรู้สึกไม่ได้ถึงการตั้งค่า ให้ลองเพิ่มความแรงหรือความยาว คุณสามารถเริ่มต้นด้วยการลองใช้ค่าตั้งต้น \"ปานกลาง\" ก่อน</string>
     <string name="vibration_settings_revert">รีเซ็ตเป็นค่าเริ่มต้น</string>
     <string name="vibration_settings_section_length_ms">ระยะเวลา (ms)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Kullanılabilir sekmeler</string>
     <string name="tab_editor_section_current_tabs">Mevcut sekmeler</string>
     <string name="tab_editor_title">Sekme düzenleyici</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Güncelleme indirildi ve yüklenmeye hazır.</string>
+    <string name="update_restart_action">Yeniden başlat</string>
     <string name="vibration_settings_motor_warning">Bazı telefonlarda çok zayıf veya çok kısa titreşimleri görmezden gelebilecek daha düşük kaliteli titreşim motorları bulunur. Bir ayarı hissedemiyorsanız gücünü veya uzunluğunu artırmayı deneyin. \"Orta\" ön ayarını deneyerek başlayabilirsiniz.</string>
     <string name="vibration_settings_revert">Varsayılana sıfırla</string>
     <string name="vibration_settings_section_length_ms">Süre (ms)</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standart klavye</string>
     <string name="action_add">Ekle</string>
     <string name="action_allow">İzin ver</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Kullanılabilir sekmeler</string>
     <string name="tab_editor_section_current_tabs">Mevcut sekmeler</string>
     <string name="tab_editor_title">Sekme düzenleyici</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Bazı telefonlarda çok zayıf veya çok kısa titreşimleri görmezden gelebilecek daha düşük kaliteli titreşim motorları bulunur. Bir ayarı hissedemiyorsanız gücünü veya uzunluğunu artırmayı deneyin. \"Orta\" ön ayarını deneyerek başlayabilirsiniz.</string>
     <string name="vibration_settings_revert">Varsayılana sıfırla</string>
     <string name="vibration_settings_section_length_ms">Süre (ms)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступні вкладки</string>
     <string name="tab_editor_section_current_tabs">Поточні вкладки</string>
     <string name="tab_editor_title">Редактор вкладок</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Оновлення завантажено та готове до встановлення.</string>
+    <string name="update_restart_action">Перезапустити</string>
     <string name="vibration_settings_motor_warning">Деякі телефони мають вібромотори нижчої якості, які можуть ігнорувати дуже слабкі або дуже короткі вібрації. Якщо ви не відчуваєте певне налаштування, спробуйте збільшити його силу або тривалість. Ви можете почати з випробування попереднього налаштування «Середня».</string>
     <string name="vibration_settings_revert">Скинути до стандартних</string>
     <string name="vibration_settings_section_length_ms">Тривалість (ms)</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Стандартна клавіатура</string>
     <string name="action_add">Додати</string>
     <string name="action_allow">Дозволити</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Доступні вкладки</string>
     <string name="tab_editor_section_current_tabs">Поточні вкладки</string>
     <string name="tab_editor_title">Редактор вкладок</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Деякі телефони мають вібромотори нижчої якості, які можуть ігнорувати дуже слабкі або дуже короткі вібрації. Якщо ви не відчуваєте певне налаштування, спробуйте збільшити його силу або тривалість. Ви можете почати з випробування попереднього налаштування «Середня».</string>
     <string name="vibration_settings_revert">Скинути до стандартних</string>
     <string name="vibration_settings_section_length_ms">Тривалість (ms)</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">دستیاب ٹیبز</string>
     <string name="tab_editor_section_current_tabs">موجودہ ٹیبز</string>
     <string name="tab_editor_title">ٹیب ایڈیٹر</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">اپڈیٹ ڈاؤن لوڈ ہو گئی ہے، انسٹال کرنے کے لیے تیار ہے۔</string>
+    <string name="update_restart_action">دوبارہ شروع کریں</string>
     <string name="vibration_settings_motor_warning">کچھ فونوں میں کم معیار کے وائبریشن موٹر ہوتے ہیں جو بہت کمزور یا بہت مختصر وائبریشن کو نظرانداز کر سکتے ہیں۔ اگر آپ کوئی ترتیب محسوس نہیں کر سکتے، تو اس کی طاقت یا لمبائی بڑھانے کی کوشش کریں۔ آپ پہلے \"درمیانہ\" پری سیٹ آزما کر شروع کر سکتے ہیں۔</string>
     <string name="vibration_settings_revert">ڈیفالٹ پر ری سیٹ</string>
     <string name="vibration_settings_section_length_ms">مدت (ms)</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">معیاری کی بورڈ</string>
     <string name="action_add">شامل کریں</string>
     <string name="action_allow">اجازت دیں</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">دستیاب ٹیبز</string>
     <string name="tab_editor_section_current_tabs">موجودہ ٹیبز</string>
     <string name="tab_editor_title">ٹیب ایڈیٹر</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">کچھ فونوں میں کم معیار کے وائبریشن موٹر ہوتے ہیں جو بہت کمزور یا بہت مختصر وائبریشن کو نظرانداز کر سکتے ہیں۔ اگر آپ کوئی ترتیب محسوس نہیں کر سکتے، تو اس کی طاقت یا لمبائی بڑھانے کی کوشش کریں۔ آپ پہلے \"درمیانہ\" پری سیٹ آزما کر شروع کر سکتے ہیں۔</string>
     <string name="vibration_settings_revert">ڈیفالٹ پر ری سیٹ</string>
     <string name="vibration_settings_section_length_ms">مدت (ms)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab có sẵn</string>
     <string name="tab_editor_section_current_tabs">Tab hiện tại</string>
     <string name="tab_editor_title">Trình chỉnh sửa Tab</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">Bản cập nhật đã tải xong, sẵn sàng cài đặt.</string>
+    <string name="update_restart_action">Khởi động lại</string>
     <string name="vibration_settings_motor_warning">Một số điện thoại có động cơ rung chất lượng thấp hơn có thể bỏ qua những rung động rất yếu hoặc rất ngắn. Nếu bạn không cảm nhận được một cài đặt, hãy thử tăng cường độ hoặc độ dài của nó. Bạn có thể bắt đầu bằng cách thử cài đặt trước \"Vừa\" trước.</string>
     <string name="vibration_settings_revert">Đặt lại mặc định</string>
     <string name="vibration_settings_section_length_ms">Thời lượng (ms)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Bàn phím tiêu chuẩn</string>
     <string name="action_add">Thêm</string>
     <string name="action_allow">Cho phép</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Tab có sẵn</string>
     <string name="tab_editor_section_current_tabs">Tab hiện tại</string>
     <string name="tab_editor_title">Trình chỉnh sửa Tab</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Một số điện thoại có động cơ rung chất lượng thấp hơn có thể bỏ qua những rung động rất yếu hoặc rất ngắn. Nếu bạn không cảm nhận được một cài đặt, hãy thử tăng cường độ hoặc độ dài của nó. Bạn có thể bắt đầu bằng cách thử cài đặt trước \"Vừa\" trước.</string>
     <string name="vibration_settings_revert">Đặt lại mặc định</string>
     <string name="vibration_settings_section_length_ms">Thời lượng (ms)</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">更新已下載完成，準備安裝。</string>
+    <string name="update_restart_action">重新啟動</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
     <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 编辑器</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">更新已下载完成，准备安装。</string>
+    <string name="update_restart_action">重新启动</string>
     <string name="vibration_settings_motor_warning">部分手机的震动马达品质较差，过弱或过短的震动可能完全感受不到。若感受不到震动，请试着调高强度或时长。建议先从「中」预设开始试试。</string>
     <string name="vibration_settings_revert">恢复默认</string>
     <string name="vibration_settings_section_length_ms">时长 (ms)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
     <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 编辑器</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">部分手机的震动马达品质较差，过弱或过短的震动可能完全感受不到。若感受不到震动，请试着调高强度或时长。建议先从「中」预设开始试试。</string>
     <string name="vibration_settings_revert">恢复默认</string>
     <string name="vibration_settings_section_length_ms">时长 (ms)</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">更新已下載完成，準備安裝。</string>
+    <string name="update_restart_action">重新啟動</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
     <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">更新已下載完成，準備安裝。</string>
+    <string name="update_restart_action">重新啟動</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">有功課</string>
     <string name="a11y_class_table_conflict_prefix">撞堂</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">㩒兩下揀第個選項</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右掃可以調整時間</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">部分手機嘅震動馬達質素較差，過弱或過短嘅震動可能完全感受唔到。若感受唔到震動，請試吓調高強度或時長。建議先試試「中」預設。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度 (ms)</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -613,8 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 编辑器</string>
-    <string name="update_ready_message">An update is ready to install.</string>
-    <string name="update_restart_action">Restart</string>
+    <string name="update_ready_message">更新已下载完成，准备安装。</string>
+    <string name="update_restart_action">重新启动</string>
     <string name="vibration_settings_motor_warning">部分手机的震动马达品质较差，过弱或过短的震动可能完全感受不到。若感受不到震动，请试着调高强度或时长。建议先从「中」预设开始试试。</string>
     <string name="vibration_settings_revert">恢复默认</string>
     <string name="vibration_settings_section_length_ms">时长 (ms)</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">有作业</string>
     <string name="a11y_class_table_conflict_prefix">冲堂</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">点击两下以选择其他选项</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右滑动可调整时间</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">标准键盘</string>
     <string name="action_add">添加</string>
     <string name="action_allow">允许</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">其他可用的 Tab</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 编辑器</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">部分手机的震动马达品质较差，过弱或过短的震动可能完全感受不到。若感受不到震动，请试着调高强度或时长。建议先从「中」预设开始试试。</string>
     <string name="vibration_settings_revert">恢复默认</string>
     <string name="vibration_settings_section_length_ms">时长 (ms)</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">點擊兩下以在 Moodle 中開啟作業</string>
+    <string name="a11y_calendar_day">%1$@，共 %2$lld 個事件</string>
+    <string name="a11y_calendar_nav_next">下個月</string>
+    <string name="a11y_calendar_nav_prev">上個月</string>
     <string name="a11y_class_table_cell_assignment_indicator">有作業</string>
     <string name="a11y_class_table_conflict_prefix">衝堂</string>
+    <string name="a11y_course_card_open_details_hint">點兩下查看詳情</string>
+    <string name="a11y_course_detail_open_moodle">在 Moodle 中開啟</string>
     <string name="a11y_dropdown_action_hint">點擊兩下以選擇其他選項</string>
+    <string name="a11y_rankings_trend_chart">學期 GPA 趨勢</string>
+    <string name="a11y_rankings_trend_no_selection">未選擇學期</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">左右滑動可調整時間</string>
+    <string name="a11y_timetable_cell">週%1$@ 第%2$@節：%3$@</string>
     <string name="account_id_use_standard_keyboard">標準鍵盤</string>
     <string name="action_add">新增</string>
     <string name="action_allow">允許</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">可新增的分頁</string>
     <string name="tab_editor_section_current_tabs">目前的 Tab</string>
     <string name="tab_editor_title">Tab 編輯器</string>
+    <string name="update_ready_message">更新已下載完成，準備安裝。</string>
+    <string name="update_restart_action">重新啟動</string>
     <string name="vibration_settings_motor_warning">部分手機的震動馬達品質較差，過弱或過短的震動可能完全感受不到。若感受不到震動，請試著調高強度或時長。建議先從「中」預設開始試試。</string>
     <string name="vibration_settings_revert">還原預設</string>
     <string name="vibration_settings_section_length_ms">長度（毫秒）</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Generated from localization/source/*.json. Do not edit directly. -->
+    <string name="a11y_assignment_open_moodle_hint">Double tap to open the assignment in Moodle</string>
+    <string name="a11y_calendar_day">%1$@, %2$lld events</string>
+    <string name="a11y_calendar_nav_next">Next month</string>
+    <string name="a11y_calendar_nav_prev">Previous month</string>
     <string name="a11y_class_table_cell_assignment_indicator">Has assignment</string>
     <string name="a11y_class_table_conflict_prefix">Class conflict</string>
+    <string name="a11y_course_card_open_details_hint">Double tap for details</string>
+    <string name="a11y_course_detail_open_moodle">Open in Moodle</string>
     <string name="a11y_dropdown_action_hint">Double tap to choose another option</string>
+    <string name="a11y_rankings_trend_chart">GPA trend by semester</string>
+    <string name="a11y_rankings_trend_no_selection">No semester selected</string>
+    <string name="a11y_rankings_trend_point">%1$@ GPA %2$@</string>
     <string name="a11y_time_slider_swipe_hint">Swipe left or right to change the time</string>
+    <string name="a11y_timetable_cell">%1$@ period %2$@: %3$@</string>
     <string name="account_id_use_standard_keyboard">Standard keyboard</string>
     <string name="action_add">Add</string>
     <string name="action_allow">Allow</string>
@@ -603,6 +613,8 @@
     <string name="tab_editor_section_available_tabs">Available tabs</string>
     <string name="tab_editor_section_current_tabs">Current tabs</string>
     <string name="tab_editor_title">Tab editor</string>
+    <string name="update_ready_message">An update is ready to install.</string>
+    <string name="update_restart_action">Restart</string>
     <string name="vibration_settings_motor_warning">Some phones have lower-quality vibration motors that may ignore very weak or very short vibrations. If you can\'t feel a setting, try raising its strength or length. You can start by trying the medium preset first.</string>
     <string name="vibration_settings_revert">Reset to default</string>
     <string name="vibration_settings_section_length_ms">Length (ms)</string>

--- a/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -3,6 +3,8 @@ package org.ntust.app.tigerduck.update
 import android.app.Activity
 import android.content.Context
 import android.util.Log
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.InstallStateUpdatedListener
@@ -56,8 +58,13 @@ class UpdateChecker @Inject constructor(
         }
     }
 
-    /** Query Play and start the FLEXIBLE flow if eligible and not rate-limited. */
-    fun maybePromptForUpdate(activity: Activity) {
+    /**
+     * Query Play and start the FLEXIBLE flow if eligible and not rate-limited.
+     * [launcher] receives the confirmation-UI result; the caller must route it
+     * back through [onUpdateFlowResult] so the install listener is attached
+     * only for a flow the user actually accepted.
+     */
+    fun maybePromptForUpdate(launcher: ActivityResultLauncher<IntentSenderRequest>) {
         manager.appUpdateInfo
             .addOnSuccessListener { info ->
                 runCatching {
@@ -72,34 +79,41 @@ class UpdateChecker @Inject constructor(
                     )
                     if (!allowed) return@runCatching
 
-                    // Drop any listener a previously abandoned flexible flow
-                    // left attached, so this singleton can't accumulate
-                    // registrations across repeated eligible prompts.
-                    manager.unregisterListener(installListener)
-                    manager.registerListener(installListener)
-
+                    // No listener is registered here: registration is deferred
+                    // to onUpdateFlowResult so a throw on this line, a launch
+                    // that returns false, or a user cancellation can never
+                    // leave this singleton holding a stale registration.
                     val launched = manager.startUpdateFlowForResult(
                         info,
-                        activity,
+                        launcher,
                         AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
-                        UPDATE_REQUEST_CODE,
                     )
                     if (launched) {
                         // Record the prompt only once the flow actually
                         // launched — the cooldown must not suppress a prompt
-                        // the user never saw. If startUpdateFlowForResult
-                        // throws, the runCatching below swallows it and nothing
-                        // is recorded either.
+                        // the user never saw.
                         appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
                         appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
-                    } else {
-                        // Play declined to launch (another flow already active,
-                        // etc.) — there is nothing for the listener to observe.
-                        manager.unregisterListener(installListener)
                     }
                 }.onFailure { Log.w(TAG, "update prompt failed", it) }
             }
             .addOnFailureListener { Log.w(TAG, "appUpdateInfo query failed", it) }
+    }
+
+    /**
+     * Handle the result of Play's update confirmation UI. The install listener
+     * is registered here, and only on acceptance: a cancelled or failed flow
+     * starts no download, so there is nothing for the listener to observe and
+     * it must not be attached to this singleton.
+     */
+    fun onUpdateFlowResult(resultCode: Int) {
+        if (resultCode != Activity.RESULT_OK) return
+        runCatching {
+            // Re-register defensively: an earlier accepted flow's listener may
+            // still be attached, and registerListener alone could stack it.
+            manager.unregisterListener(installListener)
+            manager.registerListener(installListener)
+        }.onFailure { Log.w(TAG, "update flow result handling failed", it) }
     }
 
     /** Re-check on return to foreground: surface an update that finished downloading while away. */
@@ -123,6 +137,5 @@ class UpdateChecker @Inject constructor(
 
     companion object {
         private const val TAG = "UpdateChecker"
-        private const val UPDATE_REQUEST_CODE = 17_390
     }
 }

--- a/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -40,9 +40,19 @@ class UpdateChecker @Inject constructor(
     /** True once a FLEXIBLE update has finished downloading and can be installed. */
     val installReady: StateFlow<Boolean> = _installReady.asStateFlow()
 
-    private val installListener = InstallStateUpdatedListener { state ->
-        if (state.installStatus() == InstallStatus.DOWNLOADED) {
-            _installReady.value = true
+    // Explicit type: the lambda references installListener itself (to
+    // self-unregister), which would otherwise make type inference recursive.
+    private val installListener: InstallStateUpdatedListener = InstallStateUpdatedListener { state ->
+        when (state.installStatus()) {
+            InstallStatus.DOWNLOADED -> _installReady.value = true
+            // Terminal states: the flexible flow is over. Drop the listener so
+            // a cancelled or failed download can't leave this singleton holding
+            // a stale registration (and live callback) until process death.
+            InstallStatus.INSTALLED,
+            InstallStatus.FAILED,
+            InstallStatus.CANCELED ->
+                runCatching { manager.unregisterListener(installListener) }
+            else -> Unit
         }
     }
 
@@ -62,19 +72,31 @@ class UpdateChecker @Inject constructor(
                     )
                     if (!allowed) return@runCatching
 
+                    // Drop any listener a previously abandoned flexible flow
+                    // left attached, so this singleton can't accumulate
+                    // registrations across repeated eligible prompts.
+                    manager.unregisterListener(installListener)
                     manager.registerListener(installListener)
-                    manager.startUpdateFlowForResult(
+
+                    val launched = manager.startUpdateFlowForResult(
                         info,
                         activity,
                         AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
                         UPDATE_REQUEST_CODE,
                     )
-                    // Record the prompt only after the flow actually launched.
-                    // If startUpdateFlowForResult throws, the runCatching below
-                    // swallows it — the cooldown must not then suppress a
-                    // prompt the user never saw.
-                    appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
-                    appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
+                    if (launched) {
+                        // Record the prompt only once the flow actually
+                        // launched — the cooldown must not suppress a prompt
+                        // the user never saw. If startUpdateFlowForResult
+                        // throws, the runCatching below swallows it and nothing
+                        // is recorded either.
+                        appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
+                        appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
+                    } else {
+                        // Play declined to launch (another flow already active,
+                        // etc.) — there is nothing for the listener to observe.
+                        manager.unregisterListener(installListener)
+                    }
                 }.onFailure { Log.w(TAG, "update prompt failed", it) }
             }
             .addOnFailureListener { Log.w(TAG, "appUpdateInfo query failed", it) }

--- a/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -1,0 +1,102 @@
+package org.ntust.app.tigerduck.update
+
+import android.app.Activity
+import android.content.Context
+import android.util.Log
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.InstallStateUpdatedListener
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.InstallStatus
+import com.google.android.play.core.install.model.UpdateAvailability
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Play-flavor in-app update checker (issue #89). Wraps Play's
+ * `AppUpdateManager`, runs the FLEXIBLE flow (background download, prompt to
+ * restart), and gates re-prompting via [UpdatePromptGate].
+ *
+ * The fdroid flavor ships a no-op stub at the same FQN so `MainActivity` in
+ * `main/` can inject and call this regardless of flavor — same pattern as
+ * `FcmBootstrap`.
+ *
+ * Every Play call is wrapped: a failed update check is a silent no-op and
+ * never surfaces UI (issue #89 requirement).
+ */
+@Singleton
+class UpdateChecker @Inject constructor(
+    @param:ApplicationContext context: Context,
+    private val appPreferences: AppPreferences,
+) {
+    private val manager = AppUpdateManagerFactory.create(context)
+
+    private val _installReady = MutableStateFlow(false)
+    /** True once a FLEXIBLE update has finished downloading and can be installed. */
+    val installReady: StateFlow<Boolean> = _installReady.asStateFlow()
+
+    private val installListener = InstallStateUpdatedListener { state ->
+        if (state.installStatus() == InstallStatus.DOWNLOADED) {
+            _installReady.value = true
+        }
+    }
+
+    /** Query Play and start the FLEXIBLE flow if eligible and not rate-limited. */
+    fun maybePromptForUpdate(activity: Activity) {
+        manager.appUpdateInfo
+            .addOnSuccessListener { info ->
+                runCatching {
+                    if (info.updateAvailability() != UpdateAvailability.UPDATE_AVAILABLE) return@runCatching
+                    if (!info.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) return@runCatching
+                    val allowed = UpdatePromptGate.shouldStartFlow(
+                        stalenessDays = info.clientVersionStalenessDays(),
+                        availableVersionCode = info.availableVersionCode(),
+                        lastPromptVersionCode = appPreferences.lastUpdatePromptVersionCode,
+                        lastPromptEpoch = appPreferences.lastUpdatePromptEpoch,
+                        now = System.currentTimeMillis(),
+                    )
+                    if (!allowed) return@runCatching
+
+                    appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
+                    appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
+                    manager.registerListener(installListener)
+                    manager.startUpdateFlowForResult(
+                        info,
+                        activity,
+                        AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
+                        UPDATE_REQUEST_CODE,
+                    )
+                }.onFailure { Log.w(TAG, "update prompt failed", it) }
+            }
+            .addOnFailureListener { Log.w(TAG, "appUpdateInfo query failed", it) }
+    }
+
+    /** Re-check on return to foreground: surface an update that finished downloading while away. */
+    fun resume(activity: Activity) {
+        manager.appUpdateInfo
+            .addOnSuccessListener { info ->
+                if (info.installStatus() == InstallStatus.DOWNLOADED) {
+                    _installReady.value = true
+                }
+            }
+            .addOnFailureListener { Log.w(TAG, "appUpdateInfo resume query failed", it) }
+    }
+
+    /** Install a downloaded update (triggered by the snackbar "Restart" action). */
+    fun completeUpdate() {
+        runCatching {
+            manager.completeUpdate()
+            manager.unregisterListener(installListener)
+        }.onFailure { Log.w(TAG, "completeUpdate failed", it) }
+    }
+
+    companion object {
+        private const val TAG = "UpdateChecker"
+        private const val UPDATE_REQUEST_CODE = 17_390
+    }
+}

--- a/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -62,8 +62,6 @@ class UpdateChecker @Inject constructor(
                     )
                     if (!allowed) return@runCatching
 
-                    appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
-                    appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
                     manager.registerListener(installListener)
                     manager.startUpdateFlowForResult(
                         info,
@@ -71,6 +69,12 @@ class UpdateChecker @Inject constructor(
                         AppUpdateOptions.newBuilder(AppUpdateType.FLEXIBLE).build(),
                         UPDATE_REQUEST_CODE,
                     )
+                    // Record the prompt only after the flow actually launched.
+                    // If startUpdateFlowForResult throws, the runCatching below
+                    // swallows it — the cooldown must not then suppress a
+                    // prompt the user never saw.
+                    appPreferences.lastUpdatePromptVersionCode = info.availableVersionCode()
+                    appPreferences.lastUpdatePromptEpoch = System.currentTimeMillis()
                 }.onFailure { Log.w(TAG, "update prompt failed", it) }
             }
             .addOnFailureListener { Log.w(TAG, "appUpdateInfo query failed", it) }

--- a/app/src/test/java/org/ntust/app/tigerduck/update/UpdatePromptGateTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/update/UpdatePromptGateTest.kt
@@ -1,0 +1,89 @@
+package org.ntust.app.tigerduck.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.TimeUnit
+
+class UpdatePromptGateTest {
+
+    private val now = 1_700_000_000_000L
+
+    @Test
+    fun `does not prompt when update is not stale enough`() {
+        assertFalse(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = 2,
+                availableVersionCode = 21,
+                lastPromptVersionCode = -1,
+                lastPromptEpoch = 0L,
+                now = now,
+            )
+        )
+    }
+
+    @Test
+    fun `does not prompt when staleness is unknown`() {
+        assertFalse(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = null,
+                availableVersionCode = 21,
+                lastPromptVersionCode = -1,
+                lastPromptEpoch = 0L,
+                now = now,
+            )
+        )
+    }
+
+    @Test
+    fun `prompts when staleness meets the threshold and no prior prompt`() {
+        assertTrue(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = 3,
+                availableVersionCode = 21,
+                lastPromptVersionCode = -1,
+                lastPromptEpoch = 0L,
+                now = now,
+            )
+        )
+    }
+
+    @Test
+    fun `does not prompt within cooldown for the same version`() {
+        assertFalse(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = 10,
+                availableVersionCode = 21,
+                lastPromptVersionCode = 21,
+                lastPromptEpoch = now - TimeUnit.DAYS.toMillis(6),
+                now = now,
+            )
+        )
+    }
+
+    @Test
+    fun `prompts again after cooldown elapses for the same version`() {
+        assertTrue(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = 10,
+                availableVersionCode = 21,
+                lastPromptVersionCode = 21,
+                lastPromptEpoch = now - TimeUnit.DAYS.toMillis(8),
+                now = now,
+            )
+        )
+    }
+
+    @Test
+    fun `prompts immediately for a newer version even within cooldown window`() {
+        assertTrue(
+            UpdatePromptGate.shouldStartFlow(
+                stalenessDays = 10,
+                availableVersionCode = 22,
+                lastPromptVersionCode = 21,
+                lastPromptEpoch = now - TimeUnit.DAYS.toMillis(1),
+                now = now,
+            )
+        )
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/update/UpdatePromptGateTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/update/UpdatePromptGateTest.kt
@@ -23,8 +23,10 @@ class UpdatePromptGateTest {
     }
 
     @Test
-    fun `does not prompt when staleness is unknown`() {
-        assertFalse(
+    fun `prompts when staleness is unknown`() {
+        // Play has already reported the update as available; missing staleness
+        // data must not suppress the prompt (issue #89 review).
+        assertTrue(
             UpdatePromptGate.shouldStartFlow(
                 stalenessDays = null,
                 availableVersionCode = 21,

--- a/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewGateTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewGateTest.kt
@@ -1,0 +1,34 @@
+package org.ntust.app.tigerduck.update
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ntust.app.tigerduck.data.preferences.AppPreferences
+
+class WhatsNewGateTest {
+
+    @Test
+    fun `does not show on a fresh install`() {
+        assertFalse(
+            WhatsNewGate.shouldShow(
+                lastSeenVersionCode = AppPreferences.WHATS_NEW_UNSET,
+                currentVersionCode = 21,
+            )
+        )
+    }
+
+    @Test
+    fun `shows after an upgrade`() {
+        assertTrue(WhatsNewGate.shouldShow(lastSeenVersionCode = 20, currentVersionCode = 21))
+    }
+
+    @Test
+    fun `does not show when already on the current version`() {
+        assertFalse(WhatsNewGate.shouldShow(lastSeenVersionCode = 21, currentVersionCode = 21))
+    }
+
+    @Test
+    fun `does not show when last seen is somehow newer`() {
+        assertFalse(WhatsNewGate.shouldShow(lastSeenVersionCode = 22, currentVersionCode = 21))
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewRepositoryTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewRepositoryTest.kt
@@ -1,0 +1,54 @@
+package org.ntust.app.tigerduck.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class WhatsNewRepositoryTest {
+
+    private val json = """
+        {
+          "21": {
+            "zh-TW": { "title": "1.5.0 新功能", "highlights": ["一", "二"] },
+            "en":    { "title": "What's new in 1.5.0", "highlights": ["One", "Two"] }
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `returns the english entry for an english language tag`() {
+        val content = WhatsNewRepository.parse(json, versionCode = 21, languageTag = "en-US")
+        assertEquals("What's new in 1.5.0", content?.title)
+        assertEquals(listOf("One", "Two"), content?.highlights)
+    }
+
+    @Test
+    fun `returns the zh-TW entry for a chinese language tag`() {
+        val content = WhatsNewRepository.parse(json, versionCode = 21, languageTag = "zh-Hant-TW")
+        assertEquals(listOf("一", "二"), content?.highlights)
+    }
+
+    @Test
+    fun `falls back to english for a non-chinese non-english language tag`() {
+        val content = WhatsNewRepository.parse(json, versionCode = 21, languageTag = "ja-JP")
+        assertEquals("What's new in 1.5.0", content?.title)
+    }
+
+    @Test
+    fun `returns null when no entry exists for the version`() {
+        assertNull(WhatsNewRepository.parse(json, versionCode = 99, languageTag = "en-US"))
+    }
+
+    @Test
+    fun `returns null for malformed json`() {
+        assertNull(WhatsNewRepository.parse("{ not json", versionCode = 21, languageTag = "en-US"))
+    }
+
+    @Test
+    fun `returns null when an entry has blank title or empty highlights`() {
+        val blank = """
+            { "21": { "en": { "title": "", "highlights": [] } } }
+        """.trimIndent()
+        assertNull(WhatsNewRepository.parse(blank, versionCode = 21, languageTag = "en-US"))
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewRepositoryTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/update/WhatsNewRepositoryTest.kt
@@ -51,4 +51,39 @@ class WhatsNewRepositoryTest {
         """.trimIndent()
         assertNull(WhatsNewRepository.parse(blank, versionCode = 21, languageTag = "en-US"))
     }
+
+    @Test
+    fun `parseLatest returns the entry for the only version present`() {
+        val content = WhatsNewRepository.parseLatest(json, languageTag = "en-US")
+        assertEquals("What's new in 1.5.0", content?.title)
+    }
+
+    @Test
+    fun `parseLatest picks the highest version by numeric value, not lexically`() {
+        // Lexically "9" > "10"; numerically 10 wins.
+        val multi = """
+            {
+              "9":  { "en": { "title": "Old", "highlights": ["a"] } },
+              "10": { "en": { "title": "New", "highlights": ["b"] } }
+            }
+        """.trimIndent()
+        val content = WhatsNewRepository.parseLatest(multi, languageTag = "en-US")
+        assertEquals("New", content?.title)
+    }
+
+    @Test
+    fun `parseLatest respects locale selection`() {
+        val content = WhatsNewRepository.parseLatest(json, languageTag = "zh-Hant-TW")
+        assertEquals(listOf("一", "二"), content?.highlights)
+    }
+
+    @Test
+    fun `parseLatest returns null for malformed json`() {
+        assertNull(WhatsNewRepository.parseLatest("{ not json", languageTag = "en-US"))
+    }
+
+    @Test
+    fun `parseLatest returns null when no version entry exists`() {
+        assertNull(WhatsNewRepository.parseLatest("{}", languageTag = "en-US"))
+    }
 }

--- a/debug/_lib.sh
+++ b/debug/_lib.sh
@@ -25,6 +25,34 @@ require() {
   }
 }
 
+# Run "$@", killing it after <secs> seconds. Returns the command's own exit
+# status, or 124 if it had to be killed for overrunning. Prefers GNU
+# `timeout` / `gtimeout`; falls back to a background-process watchdog because
+# macOS ships no `timeout`.
+run_with_timeout() {
+  local secs="$1"; shift
+  local tool
+  if tool="$(command -v timeout || command -v gtimeout || true)" && [[ -n "$tool" ]]; then
+    "$tool" "$secs" "$@"
+    return $?
+  fi
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null ) &
+  local watch_pid=$!
+  local rc=0
+  wait "$cmd_pid" 2>/dev/null || rc=$?
+  if kill -0 "$watch_pid" 2>/dev/null; then
+    # Command finished on its own — cancel the watchdog.
+    kill -TERM "$watch_pid" 2>/dev/null || true
+    wait "$watch_pid" 2>/dev/null || true
+  else
+    # Watchdog already exited → it fired and killed the command.
+    rc=124
+  fi
+  return "$rc"
+}
+
 # Print a serial for an interactive device pick. Lists every connected adb
 # device (phones, watches, emulators) and lets the user choose. If exactly
 # one is connected, returns it without prompting. Optional first arg is a
@@ -49,10 +77,20 @@ pick_device() {
     # device.
     [[ "$line" =~ ^(.+)[[:space:]]+device([[:space:]].*)?$ ]] || continue
     local serial="${BASH_REMATCH[1]}"
-    local chars model tag=""
-    chars="$(adb -s "$serial" shell getprop ro.build.characteristics </dev/null 2>/dev/null | tr -d '\r' || true)"
-    model="$(adb -s "$serial" shell getprop ro.product.model </dev/null 2>/dev/null | tr -d '\r' || true)"
-    [[ "$chars" == *watch* ]] && tag=" [watch]"
+    # Probe model + form factor in one timed `adb shell` round-trip. A stale
+    # transport (e.g. a dropped wireless connection still listed as `device`)
+    # makes `adb shell` hang forever, which would freeze the whole picker — so
+    # cap it and tag the device [unresponsive] instead of blocking.
+    local chars="" model="" tag="" probe
+    if probe="$(run_with_timeout 5 adb -s "$serial" shell \
+        'getprop ro.build.characteristics; getprop ro.product.model' \
+        </dev/null 2>/dev/null)"; then
+      probe="${probe//$'\r'/}"
+      { IFS= read -r chars; IFS= read -r model; } <<< "$probe" || true
+    else
+      tag=" [unresponsive]"
+    fi
+    [[ "$chars" == *watch* ]] && tag="$tag [watch]"
     [[ "$serial" == emulator-* ]] && tag="$tag [emulator]"
     serials+=("$serial")
     labels+=("$serial  ${model:-?}$tag")

--- a/debug/_lib.sh
+++ b/debug/_lib.sh
@@ -40,7 +40,14 @@ pick_device() {
   # (adb shell inherits stdin and would consume the remaining lines, leaving
   # us with only the first device — and a silent auto-pick).
   while IFS= read -r line <&3; do
-    [[ "$line" =~ ^([^[:space:]]+)[[:space:]]+device([[:space:]].*)?$ ]] || continue
+    # The state column ("device") is always the last whitespace-separated
+    # field; the serial is everything before it. A greedy (.+) is required
+    # because mDNS-discovered wireless devices report a serial that itself
+    # contains a space — e.g. "adb-SERIAL (2)._adb-tls-connect._tcp", where
+    # " (2)" is Bonjour's duplicate-name disambiguator. A [^space]+ token
+    # would split on that space and fail to match, silently dropping the
+    # device.
+    [[ "$line" =~ ^(.+)[[:space:]]+device([[:space:]].*)?$ ]] || continue
     local serial="${BASH_REMATCH[1]}"
     local chars model tag=""
     chars="$(adb -s "$serial" shell getprop ro.build.characteristics </dev/null 2>/dev/null | tr -d '\r' || true)"
@@ -115,7 +122,10 @@ print(int(dt.timestamp() * 1000))
   saved="$(python3 -c 'import time; print(int(time.time()*1000))')"
 
   local tmp
-  tmp="$(mktemp -t debug_clock.XXXXXX.xml)"
+  # Pass a full template path rather than `mktemp -t PREFIX`: GNU and BSD
+  # (macOS) mktemp interpret `-t` differently, but both accept a template
+  # operand ending in XXXXXX.
+  tmp="$(mktemp "${TMPDIR:-/tmp}/debug_clock.XXXXXX")"
   cat >"$tmp" <<XML
 <?xml version="1.0" encoding="utf-8" standalone="yes" ?>
 <map>

--- a/debug/_lib.sh
+++ b/debug/_lib.sh
@@ -36,20 +36,25 @@ run_with_timeout() {
     "$tool" "$secs" "$@"
     return $?
   fi
+  # The watchdog records that it fired (non-empty marker) before killing the
+  # command. A timeout is then detected from that fact — not inferred from the
+  # watchdog no longer being alive, which cannot tell "I killed it" apart from
+  # "I expired just as the command finished on its own".
+  local marker
+  marker="$(mktemp "${TMPDIR:-/tmp}/rwt.XXXXXX")"
   "$@" &
   local cmd_pid=$!
-  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null ) &
+  ( sleep "$secs"; printf fired >"$marker"; kill -TERM "$cmd_pid" 2>/dev/null ) &
   local watch_pid=$!
   local rc=0
   wait "$cmd_pid" 2>/dev/null || rc=$?
-  if kill -0 "$watch_pid" 2>/dev/null; then
-    # Command finished on its own — cancel the watchdog.
-    kill -TERM "$watch_pid" 2>/dev/null || true
-    wait "$watch_pid" 2>/dev/null || true
-  else
-    # Watchdog already exited → it fired and killed the command.
-    rc=124
-  fi
+  # Stop the watchdog the instant the command is done: if it was still
+  # sleeping it never fires and the marker stays empty; if it already fired
+  # the marker is non-empty and this kill is a harmless no-op.
+  kill -TERM "$watch_pid" 2>/dev/null || true
+  wait "$watch_pid" 2>/dev/null || true
+  [[ -s "$marker" ]] && rc=124
+  rm -f "$marker"
   return "$rc"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ lifecycleRuntimeKtx = "2.10.0"
 activityCompose = "1.13.0"
 composeBom = "2026.04.01"
 navigationCompose = "2.9.8"
+playAppUpdate = "2.1.0"
 hilt = "2.59.2"
 hiltNavigationCompose = "1.3.0"
 ksp = "2.3.7"
@@ -86,6 +87,7 @@ androidx-wear-watchface-complications-data-source = { group = "androidx.wear.wat
 androidx-wear-watchface-complications-data-source-ktx = { group = "androidx.wear.watchface", name = "watchface-complications-data-source-ktx", version.ref = "wearComplications" }
 androidx-wear-remote-interactions = { group = "androidx.wear", name = "wear-remote-interactions", version.ref = "wearRemoteInteractions" }
 play-services-wearable = { group = "com.google.android.gms", name = "play-services-wearable", version.ref = "playServicesWearable" }
+play-app-update-ktx = { group = "com.google.android.play", name = "app-update-ktx", version.ref = "playAppUpdate" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore", version.ref = "datastore" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 


### PR DESCRIPTION
## Summary

Adds the in-app update prompt and "What's New" dialog feature (#89), plus follow-up fixes from code review and debug-tooling improvements.

- **Update checker**: play-flavor `UpdateChecker` with the Play FLEXIBLE in-app update flow; fdroid gets a no-op stub. Wired into `MainActivity` with an `UpdateInstallSnackbar`.
- **What's New dialog**: `WhatsNewRepository` parses `whatsnew.json`; `WhatsNewGate` detects upgrades and `WhatsNewDialog` shows the notes. `UpdatePromptGate` adds staleness + cooldown gating.
- **Persistence**: new update-prompt and what's-new preferences.
- **i18n**: localized update strings; `WhatsNewDialog` uses the framework OK string.
- **Debug tooling**: control to replay "What's New" on next launch (works on any versionCode); install scripts handle wireless adb and macOS; `pick_device` no longer hangs on a stale adb transport.

## Test plan

- [ ] Play flavor: trigger an available update, confirm FLEXIBLE flow + install snackbar
- [ ] fdroid flavor: confirm no-op stub, no GMS imports
- [ ] Fresh upgrade shows the What's New dialog once, then respects cooldown
- [ ] Debug "Replay What's new" re-shows the dialog