### PR TITLE
feat: flip-to-show library QR

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -225,6 +225,10 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
         get() = prefs.getBoolean("libraryFeatureEnabled", false)
         set(value) = prefs.edit().putBoolean("libraryFeatureEnabled", value).apply()
 
+    var flipToLibraryEnabled: Boolean
+        get() = prefs.getBoolean("flipToLibraryEnabled", false)
+        set(value) = prefs.edit().putBoolean("flipToLibraryEnabled", value).apply()
+
     var notifyAssignments: Boolean
         get() = prefs.getBoolean("notifyAssignments", true)
         set(value) = prefs.edit().putBoolean("notifyAssignments", value).apply()

--- a/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
@@ -2,6 +2,8 @@ package org.ntust.app.tigerduck.sensor
 
 import android.content.Context
 import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 
 /**
@@ -18,16 +20,49 @@ import android.hardware.SensorManager
  * Phone-only: do not instantiate from `:wear`.
  */
 class FlipDetector(
-    private val context: Context,
+    context: Context,
     private val onFaceDown: () -> Unit,
 ) {
 
-    fun register() {
-        // Filled in by Task 4.
+    private val sensorManager: SensorManager? =
+        context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+    private val sensor: Sensor? =
+        sensorManager?.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR)
+
+    private var registered = false
+    private var state = DetectorState.initial()
+
+    private val listener = object : SensorEventListener {
+        override fun onSensorChanged(event: SensorEvent) {
+            if (event.sensor.type != Sensor.TYPE_ROTATION_VECTOR) return
+            val faceDown = isFaceDown(event.values)
+            state = nextState(state, faceDown, event.timestamp)
+            if (state.fired) onFaceDown()
+        }
+
+        override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
     }
 
+    /**
+     * Idempotent. No-op if already registered or no rotation-vector sensor
+     * exists on this device.
+     */
+    fun register() {
+        if (registered) return
+        val sm = sensorManager ?: return
+        val s = sensor ?: return
+        // Reset the state machine each time we (re-)register so a sensor
+        // event from a previous session can't leak into the new debounce window.
+        state = DetectorState.initial()
+        sm.registerListener(listener, s, SensorManager.SENSOR_DELAY_UI)
+        registered = true
+    }
+
+    /** Idempotent. */
     fun unregister() {
-        // Filled in by Task 4.
+        if (!registered) return
+        sensorManager?.unregisterListener(listener)
+        registered = false
     }
 
     companion object {

--- a/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
@@ -1,0 +1,88 @@
+package org.ntust.app.tigerduck.sensor
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorManager
+
+/**
+ * Detects a sustained "phone face-down" gesture using the rotation-vector
+ * sensor. The two pure helpers ([isFaceDown] and [nextState]) carry all the
+ * logic and are unit-tested in isolation; this class is just the
+ * [SensorManager] glue around them.
+ *
+ * The detector emits exactly one [onFaceDown] callback per Upright -> FaceDown
+ * transition; flickers under the debounce window are filtered out. A cold-
+ * start [DetectorState.Unknown] state ensures opening the app while the phone
+ * is already face-down does NOT auto-fire.
+ *
+ * Phone-only: do not instantiate from `:wear`.
+ */
+class FlipDetector(
+    private val context: Context,
+    private val onFaceDown: () -> Unit,
+) {
+
+    fun register() {
+        // Filled in by Task 4.
+    }
+
+    fun unregister() {
+        // Filled in by Task 4.
+    }
+
+    companion object {
+
+        /**
+         * `true` iff the device has a rotation-vector sensor we can register
+         * against. Settings reads this to decide whether the toggle is
+         * interactive or greyed out.
+         */
+        fun isSupported(context: Context): Boolean {
+            val sm = context.getSystemService(Context.SENSOR_SERVICE) as? SensorManager
+                ?: return false
+            return sm.getDefaultSensor(Sensor.TYPE_ROTATION_VECTOR) != null
+        }
+
+        /**
+         * `R[8] <= FACE_DOWN_R8_THRESHOLD` captures both "screen facing the
+         * ground" and "within ~32 degrees of flat" in one comparison. Tighter
+         * (more negative) = fewer false positives but harder to trigger.
+         */
+        internal const val FACE_DOWN_R8_THRESHOLD = -0.85f
+
+        /**
+         * Re-arm threshold for the inverse transition (FaceDown -> Upright).
+         * Looser so a momentary jiggle while reading the QR doesn't trip the
+         * detector back to Upright and immediately re-fire.
+         */
+        internal const val UPRIGHT_R8_THRESHOLD = -0.5f
+
+        /**
+         * Returns `true` when the rotation vector indicates the device is
+         * roughly face-down (within ~32 degrees of perfectly inverted).
+         *
+         * Pure — no Android SDK call at runtime. We compute R[8] directly
+         * from the quaternion. Given unit quaternion (qx, qy, qz, qw), the
+         * rotation matrix element at row 2, col 2 is:
+         *
+         *   R[8] = 1 - 2*(qx² + qy²)
+         *
+         * This is the world-frame Z-component of the device's screen-normal
+         * axis. R[8] ≈ +1 means screen faces up; R[8] ≈ -1 means face-down.
+         *
+         * The input [rotationVector] follows Android's sensor convention:
+         *   [qx*sin(θ/2), qy*sin(θ/2), qz*sin(θ/2), cos(θ/2)].
+         * A 3-element vector (w omitted) is also handled: w is recovered as
+         * sqrt(max(0, 1 - qx² - qy² - qz²)) to stay consistent with how
+         * [android.hardware.SensorManager.getRotationMatrixFromVector] behaves
+         * when the sensor omits the scalar component.
+         */
+        internal fun isFaceDown(rotationVector: FloatArray): Boolean {
+            val qx = rotationVector[0]
+            val qy = rotationVector[1]
+            // R[8] = 1 - 2*(qx² + qy²) — independent of qz and qw.
+            val r8 = 1f - 2f * (qx * qx + qy * qy)
+            return r8 <= FACE_DOWN_R8_THRESHOLD
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
@@ -84,5 +84,79 @@ class FlipDetector(
             val r8 = 1f - 2f * (qx * qx + qy * qy)
             return r8 <= FACE_DOWN_R8_THRESHOLD
         }
+
+        /** Debounce window — must be sustained before a transition is committed. */
+        internal const val DEBOUNCE_NANOS: Long = 400_000_000L  // 400 ms
+
+        /**
+         * Sentinel stored in [DetectorState.windowStartNanos] before the first
+         * sensor event is received. Guaranteed to be distinct from any real
+         * nanosecond timestamp the sensor delivers.
+         */
+        private const val WINDOW_UNSET = Long.MIN_VALUE
+
+        /**
+         * Advance the debounce machine by one sensor event.
+         *
+         * The committed [Phase] transitions only when the predicate has held
+         * for at least [DEBOUNCE_NANOS]. `fired` is `true` only on the
+         * specific transition Upright -> FaceDown; all other transitions
+         * (including the cold-start Unknown -> FaceDown) leave `fired = false`.
+         */
+        internal fun nextState(
+            current: DetectorState,
+            isFaceDown: Boolean,
+            timestampNanos: Long,
+        ): DetectorState {
+            // Start the window on the very first event, or whenever the
+            // observed predicate changes direction.
+            if (current.windowStartNanos == WINDOW_UNSET || isFaceDown != current.pendingFaceDown) {
+                return current.copy(
+                    pendingFaceDown = isFaceDown,
+                    windowStartNanos = timestampNanos,
+                    fired = false,
+                )
+            }
+            val elapsed = timestampNanos - current.windowStartNanos
+            if (elapsed < DEBOUNCE_NANOS) {
+                // Window still open — phase unchanged, callback not fired.
+                return current.copy(fired = false)
+            }
+            // Window satisfied. Decide whether to commit the new phase.
+            val targetPhase = if (isFaceDown) Phase.FaceDown else Phase.Upright
+            if (targetPhase == current.phase) {
+                return current.copy(fired = false)
+            }
+            val didFire = current.phase == Phase.Upright && targetPhase == Phase.FaceDown
+            return current.copy(phase = targetPhase, fired = didFire)
+        }
+    }
+
+    /** Tri-state for the debounce machine. */
+    enum class Phase { Unknown, Upright, FaceDown }
+
+    /**
+     * Immutable state for the debounce machine.
+     *
+     * @property phase the committed phase (only changes after the window elapses)
+     * @property pendingFaceDown the predicate value observed during the current window
+     * @property windowStartNanos timestamp of the first event in the current window
+     * @property fired `true` iff this transition fired the onFaceDown callback;
+     *                 callers consume and reset this on each step.
+     */
+    data class DetectorState(
+        val phase: Phase,
+        val pendingFaceDown: Boolean,
+        val windowStartNanos: Long,
+        val fired: Boolean,
+    ) {
+        companion object {
+            fun initial(): DetectorState = DetectorState(
+                phase = Phase.Unknown,
+                pendingFaceDown = false,
+                windowStartNanos = Long.MIN_VALUE,
+                fired = false,
+            )
+        }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/sensor/FlipDetector.kt
@@ -86,13 +86,6 @@ class FlipDetector(
         internal const val FACE_DOWN_R8_THRESHOLD = -0.85f
 
         /**
-         * Re-arm threshold for the inverse transition (FaceDown -> Upright).
-         * Looser so a momentary jiggle while reading the QR doesn't trip the
-         * detector back to Upright and immediately re-fire.
-         */
-        internal const val UPRIGHT_R8_THRESHOLD = -0.5f
-
-        /**
          * Returns `true` when the rotation vector indicates the device is
          * roughly face-down (within ~32 degrees of perfectly inverted).
          *

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
@@ -249,6 +249,16 @@ class AppState @Inject constructor(
             prefs.libraryFeatureEnabled = value
         }
 
+    private var flipToLibraryEnabledState by mutableStateOf(prefs.flipToLibraryEnabled)
+
+    var flipToLibraryEnabled: Boolean
+        get() = flipToLibraryEnabledState
+        set(value) {
+            if (flipToLibraryEnabledState == value) return
+            flipToLibraryEnabledState = value
+            prefs.flipToLibraryEnabled = value
+        }
+
     // Transient signal from the library-shortcut widget: when the user taps
     // the widget while the library feature is disabled, we navigate to
     // Settings and flip this so SettingsScreen surfaces an "enable first"
@@ -352,6 +362,7 @@ class AppState @Inject constructor(
             rotationModeState = prefs.rotationMode
             notifyAssignmentsState = prefs.notifyAssignments
             libraryFeatureEnabledState = prefs.libraryFeatureEnabled
+            flipToLibraryEnabledState = prefs.flipToLibraryEnabled
             configuredTabsState = prefs.configuredTabs
             HapticScenario.tunable.forEach { scenario ->
                 hapticStrengthStates[scenario] = prefs.hapticStrength(scenario)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/haptics/HapticScenario.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/haptics/HapticScenario.kt
@@ -46,6 +46,13 @@ enum class HapticScenario(
         userTunable = true,
         labelRes = R.string.haptic_scenario_class_table_long_press,
     ),
+    FlipToLibrary(
+        prefKey = "flipToLibrary",
+        defaultStrengthPct = 60,
+        defaultDurationMs = 20,
+        userTunable = true,
+        labelRes = R.string.haptic_scenario_flip_to_library,
+    ),
     LibraryWarning(
         prefKey = "libraryWarning",
         defaultStrengthPct = 100,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
@@ -133,6 +133,7 @@ fun MainNavigation(
     onStartRouteConsumed: () -> Unit = {},
 ) {
     val navController = rememberNavController()
+    FlipToLibraryEffect(navController = navController, appState = appState)
     LaunchedEffect(widgetStartRoute) {
         widgetStartRoute ?: return@LaunchedEffect
         // The library-shortcut widget emits a sentinel instead of a direct

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
@@ -19,6 +19,9 @@ import org.ntust.app.tigerduck.ui.haptics.Haptics
  * The detector is registered only while:
  *   - the device has a rotation-vector sensor, AND
  *   - the user has opted in via `appState.flipToLibraryEnabled`, AND
+ *   - the parent Library feature itself is on (`appState.libraryFeatureEnabled`),
+ *     so disabling Library actually stops the sensor instead of leaving it
+ *     running while every callback bails at a fire-time guard, AND
  *   - the host activity is at least STARTED.
  *
  * The library-session check ([AppState.isLibraryLoggedIn]) runs at fire time
@@ -40,18 +43,25 @@ fun FlipToLibraryEffect(
     val supported = remember(context) { FlipDetector.isSupported(context) }
     if (!supported) return
 
-    // Reading the Compose-state-backed property here makes the enclosing
+    // Reading the Compose-state-backed properties here makes the enclosing
     // composition observe changes, so the DisposableEffect below restarts
-    // when the user toggles the setting.
-    val enabled = appState.flipToLibraryEnabled
+    // when the user toggles either setting.
+    val enabled = appState.flipToLibraryEnabled && appState.libraryFeatureEnabled
 
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val detector = remember(navController, appState) {
         FlipDetector(context) {
-            // Fire-time guards. Both checks are synchronous and main-thread —
+            // Fire-time guards. All checks are synchronous and main-thread —
             // sensor callbacks deliver on the main thread by default.
             if (!appState.libraryFeatureEnabled) return@FlipDetector
             if (!appState.isLibraryLoggedIn) return@FlipDetector
+            // Cold-start race: MainNavigation installs this effect before
+            // the NavHost declares its graph, so a flip during initial
+            // composition can navigate() with no destinations registered.
+            // currentBackStackEntry stays null until startDestination is
+            // routed; drop early flips rather than queueing — the gesture
+            // is opportunistic and the user can just flip again.
+            if (navController.currentBackStackEntry == null) return@FlipDetector
             val currentRoute = navController.currentDestination?.route
             if (currentRoute == Screen.Library.route) return@FlipDetector
             navController.navigate(Screen.Library.route) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
@@ -10,6 +10,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
 import org.ntust.app.tigerduck.sensor.FlipDetector
 import org.ntust.app.tigerduck.ui.AppState
+import org.ntust.app.tigerduck.ui.haptics.HapticScenario
+import org.ntust.app.tigerduck.ui.haptics.Haptics
 
 /**
  * Side-effect composable that wires [FlipDetector] into the nav controller.
@@ -55,6 +57,7 @@ fun FlipToLibraryEffect(
             navController.navigate(Screen.Library.route) {
                 launchSingleTop = true
             }
+            Haptics.perform(context, HapticScenario.FlipToLibrary)
         }
     }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
@@ -1,0 +1,77 @@
+package org.ntust.app.tigerduck.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.navigation.NavController
+import org.ntust.app.tigerduck.sensor.FlipDetector
+import org.ntust.app.tigerduck.ui.AppState
+
+/**
+ * Side-effect composable that wires [FlipDetector] into the nav controller.
+ *
+ * The detector is registered only while:
+ *   - the device has a rotation-vector sensor, AND
+ *   - the user has opted in via `appState.flipToLibraryEnabled`, AND
+ *   - the host activity is at least STARTED.
+ *
+ * The library-session check ([AppState.isLibraryLoggedIn]) runs at fire time
+ * inside the callback, not as a registration gate, because
+ * [org.ntust.app.tigerduck.data.preferences.CredentialManager] only exposes
+ * synchronous accessors — adding a flow purely for this gate is more plumbing
+ * than the feature warrants.
+ *
+ * Net effect: when the user flips the phone face-down with a valid library
+ * session, the nav controller jumps to [Screen.Library]; flips with no session
+ * or already-on-Library are silently no-op.
+ */
+@Composable
+fun FlipToLibraryEffect(
+    navController: NavController,
+    appState: AppState,
+) {
+    val context = LocalContext.current
+    val supported = remember(context) { FlipDetector.isSupported(context) }
+    if (!supported) return
+
+    // Reading the Compose-state-backed property here makes the enclosing
+    // composition observe changes, so the DisposableEffect below restarts
+    // when the user toggles the setting.
+    val enabled = appState.flipToLibraryEnabled
+
+    val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val detector = remember(navController, appState) {
+        FlipDetector(context) {
+            // Fire-time guards. Both checks are synchronous and main-thread —
+            // sensor callbacks deliver on the main thread by default.
+            if (!appState.isLibraryLoggedIn) return@FlipDetector
+            val currentRoute = navController.currentDestination?.route
+            if (currentRoute == Screen.Library.route) return@FlipDetector
+            navController.navigate(Screen.Library.route) {
+                launchSingleTop = true
+            }
+        }
+    }
+
+    DisposableEffect(enabled, lifecycle) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> if (enabled) detector.register()
+                Lifecycle.Event.ON_STOP -> detector.unregister()
+                else -> Unit
+            }
+        }
+        lifecycle.addObserver(observer)
+        if (enabled && lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            detector.register()
+        }
+        onDispose {
+            lifecycle.removeObserver(observer)
+            detector.unregister()
+        }
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
@@ -1,13 +1,21 @@
 package org.ntust.app.tigerduck.ui.navigation
 
+import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.navigation.NavController
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import org.ntust.app.tigerduck.sensor.FlipDetector
 import org.ntust.app.tigerduck.ui.AppState
 import org.ntust.app.tigerduck.ui.haptics.HapticScenario
@@ -48,6 +56,15 @@ fun FlipToLibraryEffect(
     // when the user toggles either setting.
     val enabled = appState.flipToLibraryEnabled && appState.libraryFeatureEnabled
 
+    // Cold-start race: MainNavigation installs this effect before NavHost
+    // declares its graph, so a flip during initial composition lands before
+    // navigate() has any destinations to route to. Dropping the callback
+    // would also strand the detector in FaceDown (it only fires once per
+    // Upright -> FaceDown transition), forcing the user to re-arm with a
+    // full upright -> face-down cycle before the next try would register.
+    // Queue the pending flip and consume it once the back stack appears.
+    var pendingFlip by remember(navController, appState) { mutableStateOf(false) }
+
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val detector = remember(navController, appState) {
         FlipDetector(context) {
@@ -55,19 +72,28 @@ fun FlipToLibraryEffect(
             // sensor callbacks deliver on the main thread by default.
             if (!appState.libraryFeatureEnabled) return@FlipDetector
             if (!appState.isLibraryLoggedIn) return@FlipDetector
-            // Cold-start race: MainNavigation installs this effect before
-            // the NavHost declares its graph, so a flip during initial
-            // composition can navigate() with no destinations registered.
-            // currentBackStackEntry stays null until startDestination is
-            // routed; drop early flips rather than queueing — the gesture
-            // is opportunistic and the user can just flip again.
-            if (navController.currentBackStackEntry == null) return@FlipDetector
-            val currentRoute = navController.currentDestination?.route
-            if (currentRoute == Screen.Library.route) return@FlipDetector
-            navController.navigate(Screen.Library.route) {
-                launchSingleTop = true
+            if (navController.currentBackStackEntry == null) {
+                pendingFlip = true
+                return@FlipDetector
             }
-            Haptics.perform(context, HapticScenario.FlipToLibrary)
+            navigateToLibrary(navController, context)
+        }
+    }
+
+    if (pendingFlip) {
+        LaunchedEffect(Unit) {
+            snapshotFlow { navController.currentBackStackEntry }
+                .filterNotNull()
+                .first()
+            // Re-check gates at consume time — `enabled` and the session
+            // can change while the back stack is being built.
+            if (appState.flipToLibraryEnabled &&
+                appState.libraryFeatureEnabled &&
+                appState.isLibraryLoggedIn
+            ) {
+                navigateToLibrary(navController, context)
+            }
+            pendingFlip = false
         }
     }
 
@@ -88,4 +114,13 @@ fun FlipToLibraryEffect(
             detector.unregister()
         }
     }
+}
+
+private fun navigateToLibrary(navController: NavController, context: Context) {
+    val currentRoute = navController.currentDestination?.route
+    if (currentRoute == Screen.Library.route) return
+    navController.navigate(Screen.Library.route) {
+        launchSingleTop = true
+    }
+    Haptics.perform(context, HapticScenario.FlipToLibrary)
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/FlipToLibrary.kt
@@ -48,6 +48,7 @@ fun FlipToLibraryEffect(
         FlipDetector(context) {
             // Fire-time guards. Both checks are synchronous and main-thread —
             // sensor callbacks deliver on the main thread by default.
+            if (!appState.libraryFeatureEnabled) return@FlipDetector
             if (!appState.isLibraryLoggedIn) return@FlipDetector
             val currentRoute = navController.currentDestination?.route
             if (currentRoute == Screen.Library.route) return@FlipDetector

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -632,19 +632,39 @@ private fun SettingsRow(label: String, value: String) {
 internal fun SettingsToggleRow(
     label: String,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
+    enabled: Boolean = true,
+    subtitle: String? = null,
+    onCheckedChange: (Boolean) -> Unit,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(SettingRowHeight)
-            .padding(horizontal = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .heightIn(min = SettingRowHeight)
+            .padding(horizontal = 16.dp, vertical = if (subtitle != null) 8.dp else 0.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(
+                    alpha = if (enabled) 1f else ContentAlpha.DISABLED,
+                ),
+            )
+            if (subtitle != null) {
+                Text(
+                    subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(
+                        alpha = if (enabled) ContentAlpha.SECONDARY else ContentAlpha.DISABLED,
+                    ),
+                )
+            }
+        }
         Switch(
             checked = checked,
             onCheckedChange = onCheckedChange,
+            enabled = enabled,
             colors = tigerDuckSwitchColors(),
         )
     }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -39,6 +39,7 @@ import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.AppFeature
 import org.ntust.app.tigerduck.data.preferences.AppLanguageManager
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.sensor.FlipDetector
 import org.ntust.app.tigerduck.ui.component.ContentCard
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SectionHeader
@@ -367,6 +368,9 @@ fun SettingsScreen(
             // MARK: Other settings
             item { SectionHeader(stringResource(R.string.settings_section_other_settings)) }
             item {
+                val flipSensorSupported = remember(context) {
+                    FlipDetector.isSupported(context)
+                }
                 ContentCard {
                     Column {
                         SettingsToggleRow(
@@ -380,6 +384,20 @@ fun SettingsScreen(
                                 viewModel.appState.configuredTabs =
                                     viewModel.appState.configuredTabs.filter { !it.isLibraryRelated }
                             }
+                        }
+                        if (libraryEnabled) {
+                            HorizontalDivider()
+                            SettingsToggleRow(
+                                label = stringResource(R.string.settings_flip_to_library_title),
+                                checked = viewModel.appState.flipToLibraryEnabled && flipSensorSupported,
+                                enabled = flipSensorSupported,
+                                subtitle = if (flipSensorSupported) {
+                                    stringResource(R.string.settings_flip_to_library_summary)
+                                } else {
+                                    stringResource(R.string.settings_flip_to_library_unsupported)
+                                },
+                                onCheckedChange = { viewModel.appState.flipToLibraryEnabled = it },
+                            )
                         }
                         HorizontalDivider()
                         SettingsLinkRow(stringResource(R.string.settings_section_other_settings)) { onNavigateToOtherSettings() }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">عرض الترجمة</string>
     <string name="settings_color_theme">نسق الألوان</string>
     <string name="settings_feedback_bug_report">ملاحظات / الإبلاغ عن مشكلة</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">عكس اتجاه شريط التمرير</string>
     <string name="settings_language">(Language) اللغة</string>
     <string name="settings_language_english">الإنجليزية</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">قوي</string>
     <string name="haptic_preset_subtle">خفيف</string>
     <string name="haptic_scenario_class_table_long_press">ضغط مطول على جدول الدروس</string>
+    <string name="haptic_scenario_flip_to_library">اقلب لفتح المكتبة</string>
     <string name="haptic_scenario_library_warning">حوار تحذير المكتبة</string>
     <string name="haptic_scenario_pull_to_refresh">السحب للتحديث</string>
     <string name="haptic_scenario_tab_reorder">إعادة ترتيب التبويبات</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">عرض الترجمة</string>
     <string name="settings_color_theme">نسق الألوان</string>
     <string name="settings_feedback_bug_report">ملاحظات / الإبلاغ عن مشكلة</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">اقلب هاتفك بحيث يكون الشاشة لأسفل لفتح رمز QR للمكتبة.</string>
+    <string name="settings_flip_to_library_title">اقلب لعرض رمز QR للمكتبة</string>
+    <string name="settings_flip_to_library_unsupported">جهازك لا يحتوي على المستشعر المطلوب.</string>
     <string name="settings_invert_slider_direction">عكس اتجاه شريط التمرير</string>
     <string name="settings_language">(Language) اللغة</string>
     <string name="settings_language_english">الإنجليزية</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показване на превод</string>
     <string name="settings_color_theme">Цветова тема</string>
     <string name="settings_feedback_bug_report">Обратна връзка / Докладване на проблем</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Обръщане на посоката на плъзгача</string>
     <string name="settings_language">Език (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Силен</string>
     <string name="haptic_preset_subtle">Нежен</string>
     <string name="haptic_scenario_class_table_long_press">Дълго натискане в разписанието</string>
+    <string name="haptic_scenario_flip_to_library">Обърни, за да отвориш библиотеката</string>
     <string name="haptic_scenario_library_warning">Диалог с предупреждение за библиотека</string>
     <string name="haptic_scenario_pull_to_refresh">Издърпване за опресняване</string>
     <string name="haptic_scenario_tab_reorder">Пренареждане на раздели</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показване на превод</string>
     <string name="settings_color_theme">Цветова тема</string>
     <string name="settings_feedback_bug_report">Обратна връзка / Докладване на проблем</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Обърни телефона с екрана надолу, за да отвориш QR на библиотеката.</string>
+    <string name="settings_flip_to_library_title">Обърни за показване на QR на библиотеката</string>
+    <string name="settings_flip_to_library_unsupported">Устройството ти няма необходимия сензор.</string>
     <string name="settings_invert_slider_direction">Обръщане на посоката на плъзгача</string>
     <string name="settings_language">Език (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">অনুবাদ প্রদর্শন করুন</string>
     <string name="settings_color_theme">রং থিম</string>
     <string name="settings_feedback_bug_report">মতামত / সমস্যা রিপোর্ট করুন</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">স্লাইডারের দিক উল্টান</string>
     <string name="settings_language">ভাষা (Language)</string>
     <string name="settings_language_english">ইংরেজি</string>

--- a/app/src/main/res/values-bn/strings.xml
+++ b/app/src/main/res/values-bn/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">শক্তিশালী</string>
     <string name="haptic_preset_subtle">মৃদু</string>
     <string name="haptic_scenario_class_table_long_press">ক্লাস টেবিলে দীর্ঘ চাপ</string>
+    <string name="haptic_scenario_flip_to_library">লাইব্রেরি খুলতে উল্টান</string>
     <string name="haptic_scenario_library_warning">লাইব্রেরি সতর্কতা ডায়ালগ</string>
     <string name="haptic_scenario_pull_to_refresh">রিফ্রেশের জন্য টানুন</string>
     <string name="haptic_scenario_tab_reorder">ট্যাব পুনরায় সাজানো</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">অনুবাদ প্রদর্শন করুন</string>
     <string name="settings_color_theme">রং থিম</string>
     <string name="settings_feedback_bug_report">মতামত / সমস্যা রিপোর্ট করুন</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">লাইব্রেরি QR খুলতে ফোনটি স্ক্রিন নিচু করে উল্টান।</string>
+    <string name="settings_flip_to_library_title">লাইব্রেরি QR দেখাতে উল্টান</string>
+    <string name="settings_flip_to_library_unsupported">আপনার ডিভাইসে প্রয়োজনীয় সেন্সর নেই।</string>
     <string name="settings_invert_slider_direction">স্লাইডারের দিক উল্টান</string>
     <string name="settings_language">ভাষা (Language)</string>
     <string name="settings_language_english">ইংরেজি</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostra traducció</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentaris / Informeu d\'un problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverteix la direcció del control lliscant</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Anglès</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Fort</string>
     <string name="haptic_preset_subtle">Suau</string>
     <string name="haptic_scenario_class_table_long_press">Pulsació llarga a l\'horari</string>
+    <string name="haptic_scenario_flip_to_library">Gira per obrir la biblioteca</string>
     <string name="haptic_scenario_library_warning">Diàleg d\'advertència de la biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Estirar per actualitzar</string>
     <string name="haptic_scenario_tab_reorder">Reordenació de pestanyes</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostra traducció</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentaris / Informeu d\'un problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Gira el telèfon amb la pantalla cap avall per obrir el QR de la biblioteca.</string>
+    <string name="settings_flip_to_library_title">Gira per mostrar el QR de la biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">El teu dispositiu no té el sensor necessari.</string>
     <string name="settings_invert_slider_direction">Inverteix la direcció del control lliscant</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Anglès</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Zobrazit překlad</string>
     <string name="settings_color_theme">Barevný motiv</string>
     <string name="settings_feedback_bug_report">Zpětná vazba / Nahlásit problém</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Obrátit směr posuvníku</string>
     <string name="settings_language">Jazyk (Language)</string>
     <string name="settings_language_english">Angličtina</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Silný</string>
     <string name="haptic_preset_subtle">Jemný</string>
     <string name="haptic_scenario_class_table_long_press">Dlouhý stisk v rozvrhu</string>
+    <string name="haptic_scenario_flip_to_library">Otočit a otevřít knihovnu</string>
     <string name="haptic_scenario_library_warning">Varování knihovny</string>
     <string name="haptic_scenario_pull_to_refresh">Potáhnutím obnovit</string>
     <string name="haptic_scenario_tab_reorder">Přeuspořádání záložek</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Zobrazit překlad</string>
     <string name="settings_color_theme">Barevný motiv</string>
     <string name="settings_feedback_bug_report">Zpětná vazba / Nahlásit problém</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Otočte telefon obrazovkou dolů pro zobrazení QR kódu knihovny.</string>
+    <string name="settings_flip_to_library_title">Otočit pro zobrazení QR kódu knihovny</string>
+    <string name="settings_flip_to_library_unsupported">Vaše zařízení nemá potřebný senzor.</string>
     <string name="settings_invert_slider_direction">Obrátit směr posuvníku</string>
     <string name="settings_language">Jazyk (Language)</string>
     <string name="settings_language_english">Angličtina</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Stærk</string>
     <string name="haptic_preset_subtle">Blid</string>
     <string name="haptic_scenario_class_table_long_press">Langt tryk i skemaet</string>
+    <string name="haptic_scenario_flip_to_library">Vend om for at åbne biblioteket</string>
     <string name="haptic_scenario_library_warning">Biblioteksadvarsel</string>
     <string name="haptic_scenario_pull_to_refresh">Træk for at opdatere</string>
     <string name="haptic_scenario_tab_reorder">Omarranger faner</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversættelse</string>
     <string name="settings_color_theme">Farvetema</string>
     <string name="settings_feedback_bug_report">Feedback / Rapportér problem</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Vend telefonen med skærmen nedad for at åbne bibliotekets QR.</string>
+    <string name="settings_flip_to_library_title">Vend om for at vise bibliotekets QR</string>
+    <string name="settings_flip_to_library_unsupported">Din enhed mangler den nødvendige sensor.</string>
     <string name="settings_invert_slider_direction">Inverter skyderretning</string>
     <string name="settings_language">Sprog (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversættelse</string>
     <string name="settings_color_theme">Farvetema</string>
     <string name="settings_feedback_bug_report">Feedback / Rapportér problem</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter skyderretning</string>
     <string name="settings_language">Sprog (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Stark</string>
     <string name="haptic_preset_subtle">Sanft</string>
     <string name="haptic_scenario_class_table_long_press">Stundenplan langer Druck</string>
+    <string name="haptic_scenario_flip_to_library">Umdrehen zum Öffnen der Bibliothek</string>
     <string name="haptic_scenario_library_warning">Bibliothek-Warnhinweis</string>
     <string name="haptic_scenario_pull_to_refresh">Zum Aktualisieren ziehen</string>
     <string name="haptic_scenario_tab_reorder">Tab-Editor neu anordnen</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Übersetzung anzeigen</string>
     <string name="settings_color_theme">Farbschema</string>
     <string name="settings_feedback_bug_report">Feedback / Fehler melden</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Lege das Handy mit dem Display nach unten, um den Bibliotheks-QR zu öffnen.</string>
+    <string name="settings_flip_to_library_title">Bibliotheks-QR per Umdrehen anzeigen</string>
+    <string name="settings_flip_to_library_unsupported">Dieses Gerät verfügt nicht über den erforderlichen Sensor.</string>
     <string name="settings_invert_slider_direction">Schieberichtung umkehren</string>
     <string name="settings_language">Sprache (Language)</string>
     <string name="settings_language_english">Englisch</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Übersetzung anzeigen</string>
     <string name="settings_color_theme">Farbschema</string>
     <string name="settings_feedback_bug_report">Feedback / Fehler melden</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Schieberichtung umkehren</string>
     <string name="settings_language">Sprache (Language)</string>
     <string name="settings_language_english">Englisch</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Εμφάνιση μετάφρασης</string>
     <string name="settings_color_theme">Θέμα χρωμάτων</string>
     <string name="settings_feedback_bug_report">Σχόλια / Αναφορά προβλήματος</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Αντιστροφή κατεύθυνσης ρυθμιστικού</string>
     <string name="settings_language">Γλώσσα (Language)</string>
     <string name="settings_language_english">Αγγλικά</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Δυνατό</string>
     <string name="haptic_preset_subtle">Απαλό</string>
     <string name="haptic_scenario_class_table_long_press">Παρατεταμένο πάτημα στο πρόγραμμα</string>
+    <string name="haptic_scenario_flip_to_library">Αναποδογύρισε για να ανοίξεις τη βιβλιοθήκη</string>
     <string name="haptic_scenario_library_warning">Προειδοποίηση βιβλιοθήκης</string>
     <string name="haptic_scenario_pull_to_refresh">Σύρσιμο για ανανέωση</string>
     <string name="haptic_scenario_tab_reorder">Αναδιάταξη καρτελών</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Εμφάνιση μετάφρασης</string>
     <string name="settings_color_theme">Θέμα χρωμάτων</string>
     <string name="settings_feedback_bug_report">Σχόλια / Αναφορά προβλήματος</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Αναποδογύρισε το τηλέφωνο με την οθόνη προς τα κάτω για να ανοίξεις τον QR της βιβλιοθήκης.</string>
+    <string name="settings_flip_to_library_title">Αναποδογύρισε για να δεις τον QR της βιβλιοθήκης</string>
+    <string name="settings_flip_to_library_unsupported">Η συσκευή σου δεν διαθέτει τον απαιτούμενο αισθητήρα.</string>
     <string name="settings_invert_slider_direction">Αντιστροφή κατεύθυνσης ρυθμιστικού</string>
     <string name="settings_language">Γλώσσα (Language)</string>
     <string name="settings_language_english">Αγγλικά</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Strong</string>
     <string name="haptic_preset_subtle">Subtle</string>
     <string name="haptic_scenario_class_table_long_press">Class table long-press</string>
+    <string name="haptic_scenario_flip_to_library">Flip to open library</string>
     <string name="haptic_scenario_library_warning">Library warning dialog</string>
     <string name="haptic_scenario_pull_to_refresh">Pull to refresh</string>
     <string name="haptic_scenario_tab_reorder">Tab editor reorder</string>

--- a/app/src/main/res/values-en-rAU/strings.xml
+++ b/app/src/main/res/values-en-rAU/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">Colour theme</string>
     <string name="settings_feedback_bug_report">Feedback / Report issue</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invert slider direction</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Strong</string>
     <string name="haptic_preset_subtle">Subtle</string>
     <string name="haptic_scenario_class_table_long_press">Class table long-press</string>
+    <string name="haptic_scenario_flip_to_library">Flip to open library</string>
     <string name="haptic_scenario_library_warning">Library warning dialog</string>
     <string name="haptic_scenario_pull_to_refresh">Pull to refresh</string>
     <string name="haptic_scenario_tab_reorder">Tab editor reorder</string>

--- a/app/src/main/res/values-en-rCA/strings.xml
+++ b/app/src/main/res/values-en-rCA/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">Color theme</string>
     <string name="settings_feedback_bug_report">Feedback / Report issue</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invert slider direction</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Strong</string>
     <string name="haptic_preset_subtle">Subtle</string>
     <string name="haptic_scenario_class_table_long_press">Class table long-press</string>
+    <string name="haptic_scenario_flip_to_library">Flip to open library</string>
     <string name="haptic_scenario_library_warning">Library warning dialog</string>
     <string name="haptic_scenario_pull_to_refresh">Pull to refresh</string>
     <string name="haptic_scenario_tab_reorder">Tab editor reorder</string>

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">Colour theme</string>
     <string name="settings_feedback_bug_report">Feedback / Report issue</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invert slider direction</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Strong</string>
     <string name="haptic_preset_subtle">Subtle</string>
     <string name="haptic_scenario_class_table_long_press">Class table long-press</string>
+    <string name="haptic_scenario_flip_to_library">Flip to open library</string>
     <string name="haptic_scenario_library_warning">Library warning dialog</string>
     <string name="haptic_scenario_pull_to_refresh">Pull to refresh</string>
     <string name="haptic_scenario_tab_reorder">Tab editor reorder</string>

--- a/app/src/main/res/values-en-rIN/strings.xml
+++ b/app/src/main/res/values-en-rIN/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">Color theme</string>
     <string name="settings_feedback_bug_report">Feedback / Report issue</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invert slider direction</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar traducción</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentarios / Reportar problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invertir dirección del control deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglés</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Fuerte</string>
     <string name="haptic_preset_subtle">Suave</string>
     <string name="haptic_scenario_class_table_long_press">Pulsación larga en el horario</string>
+    <string name="haptic_scenario_flip_to_library">Voltear para abrir la biblioteca</string>
     <string name="haptic_scenario_library_warning">Aviso de biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Deslizar para actualizar</string>
     <string name="haptic_scenario_tab_reorder">Reordenar pestañas</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar traducción</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentarios / Reportar problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Voltea el teléfono boca abajo para abrir el QR de la biblioteca.</string>
+    <string name="settings_flip_to_library_title">Voltear para mostrar el QR de la biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">Tu dispositivo no tiene el sensor requerido.</string>
     <string name="settings_invert_slider_direction">Invertir dirección del control deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglés</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar traducción</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentarios / Reportar problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invertir dirección del control deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglés</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Fuerte</string>
     <string name="haptic_preset_subtle">Suave</string>
     <string name="haptic_scenario_class_table_long_press">Pulsación larga en el horario</string>
+    <string name="haptic_scenario_flip_to_library">Voltear para abrir la biblioteca</string>
     <string name="haptic_scenario_library_warning">Aviso de biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Deslizar para actualizar</string>
     <string name="haptic_scenario_tab_reorder">Reordenar pestañas</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar traducción</string>
     <string name="settings_color_theme">Tema de color</string>
     <string name="settings_feedback_bug_report">Comentarios / Reportar problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Voltea el teléfono boca abajo para abrir el QR de la biblioteca.</string>
+    <string name="settings_flip_to_library_title">Voltear para mostrar el QR de la biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">Tu dispositivo no tiene el sensor requerido.</string>
     <string name="settings_invert_slider_direction">Invertir dirección del control deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglés</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Tugev</string>
     <string name="haptic_preset_subtle">Õrn</string>
     <string name="haptic_scenario_class_table_long_press">Tunniplaanil pikk vajutus</string>
+    <string name="haptic_scenario_flip_to_library">Pööra raamatukogu avamiseks</string>
     <string name="haptic_scenario_library_warning">Raamatukogu hoiatusdialoog</string>
     <string name="haptic_scenario_pull_to_refresh">Tõmba värskendamiseks</string>
     <string name="haptic_scenario_tab_reorder">Vahekaartide ümberjärjestamine</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Kuva tõlge</string>
     <string name="settings_color_theme">Värvi teema</string>
     <string name="settings_feedback_bug_report">Tagasiside / Vea aruanne</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Pööra telefon ekraaniga allapoole, et avada raamatukogu QR.</string>
+    <string name="settings_flip_to_library_title">Pööra raamatukogu QR-i näitamiseks</string>
+    <string name="settings_flip_to_library_unsupported">Seadmel puudub vajalik andur.</string>
     <string name="settings_invert_slider_direction">Pööra liuguri suund ümber</string>
     <string name="settings_language">Keel (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Kuva tõlge</string>
     <string name="settings_color_theme">Värvi teema</string>
     <string name="settings_feedback_bug_report">Tagasiside / Vea aruanne</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Pööra liuguri suund ümber</string>
     <string name="settings_language">Keel (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">نمایش ترجمه شده</string>
     <string name="settings_color_theme">تم رنگ</string>
     <string name="settings_feedback_bug_report">بازخورد / گزارش مشکل</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">معکوس کردن جهت لغزنده</string>
     <string name="settings_language">(Language) زبان</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">قوی</string>
     <string name="haptic_preset_subtle">ملایم</string>
     <string name="haptic_scenario_class_table_long_press">فشار طولانی روی جدول کلاس</string>
+    <string name="haptic_scenario_flip_to_library">برگردانیدن برای باز کردن کتابخانه</string>
     <string name="haptic_scenario_library_warning">دیالوگ هشدار کتابخانه</string>
     <string name="haptic_scenario_pull_to_refresh">کشیدن برای بروزرسانی</string>
     <string name="haptic_scenario_tab_reorder">مرتب‌سازی مجدد برگه‌ها</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">نمایش ترجمه شده</string>
     <string name="settings_color_theme">تم رنگ</string>
     <string name="settings_feedback_bug_report">بازخورد / گزارش مشکل</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">گوشی را صفحه‌رو به پایین برگردانید تا QR کتابخانه باز شود.</string>
+    <string name="settings_flip_to_library_title">برگرداندن برای نمایش QR کتابخانه</string>
+    <string name="settings_flip_to_library_unsupported">دستگاه شما حسگر مورد نیاز را ندارد.</string>
     <string name="settings_invert_slider_direction">معکوس کردن جهت لغزنده</string>
     <string name="settings_language">(Language) زبان</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Näytä käännös</string>
     <string name="settings_color_theme">Väriteema</string>
     <string name="settings_feedback_bug_report">Palaute / Ilmoita ongelma</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Käännä liukusäätimen suunta</string>
     <string name="settings_language">Kieli (Language)</string>
     <string name="settings_language_english">Englanti</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Voimakas</string>
     <string name="haptic_preset_subtle">Kevyt</string>
     <string name="haptic_scenario_class_table_long_press">Pitkä painallus lukujärjestyksessä</string>
+    <string name="haptic_scenario_flip_to_library">Käännä kirjaston avaamiseksi</string>
     <string name="haptic_scenario_library_warning">Kirjaston varoitusikkuna</string>
     <string name="haptic_scenario_pull_to_refresh">Päivitä vetämällä</string>
     <string name="haptic_scenario_tab_reorder">Välilehtien uudelleenjärjestely</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Näytä käännös</string>
     <string name="settings_color_theme">Väriteema</string>
     <string name="settings_feedback_bug_report">Palaute / Ilmoita ongelma</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Käännä puhelin näyttö alaspäin avataksesi kirjaston QR-koodin.</string>
+    <string name="settings_flip_to_library_title">Käännä kirjaston QR-koodin näyttämiseksi</string>
+    <string name="settings_flip_to_library_unsupported">Laitteesta puuttuu tarvittava anturi.</string>
     <string name="settings_invert_slider_direction">Käännä liukusäätimen suunta</string>
     <string name="settings_language">Kieli (Language)</string>
     <string name="settings_language_english">Englanti</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Ipakita ang salin</string>
     <string name="settings_color_theme">Kulay na tema</string>
     <string name="settings_feedback_bug_report">Feedback / Mag-ulat ng isyu</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">I-invert ang direksyon ng slider</string>
     <string name="settings_language">Wika (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Malakas</string>
     <string name="haptic_preset_subtle">Mahinahon</string>
     <string name="haptic_scenario_class_table_long_press">Matagal na pindot sa class table</string>
+    <string name="haptic_scenario_flip_to_library">I-flip para buksan ang library</string>
     <string name="haptic_scenario_library_warning">Dialog ng babala sa library</string>
     <string name="haptic_scenario_pull_to_refresh">I-pull para i-refresh</string>
     <string name="haptic_scenario_tab_reorder">Muling pag-aayos ng mga tab</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Ipakita ang salin</string>
     <string name="settings_color_theme">Kulay na tema</string>
     <string name="settings_feedback_bug_report">Feedback / Mag-ulat ng isyu</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">I-flip ang telepono naka-mukha ang screen pababa para buksan ang library QR.</string>
+    <string name="settings_flip_to_library_title">I-flip para ipakita ang library QR</string>
+    <string name="settings_flip_to_library_unsupported">Wala sa iyong device ang kinakailangang sensor.</string>
     <string name="settings_invert_slider_direction">I-invert ang direksyon ng slider</string>
     <string name="settings_language">Wika (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Fort</string>
     <string name="haptic_preset_subtle">Subtil</string>
     <string name="haptic_scenario_class_table_long_press">Appui long sur l\'emploi du temps</string>
+    <string name="haptic_scenario_flip_to_library">Retourner pour ouvrir la bibliothèque</string>
     <string name="haptic_scenario_library_warning">Dialogue d\'avertissement de la bibliothèque</string>
     <string name="haptic_scenario_pull_to_refresh">Tirer pour actualiser</string>
     <string name="haptic_scenario_tab_reorder">Réorganisation des onglets</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afficher la traduction</string>
     <string name="settings_color_theme">Thème de couleur</string>
     <string name="settings_feedback_bug_report">Commentaires / Signaler un problème</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Retournez votre téléphone écran vers le bas pour afficher le QR de la bibliothèque.</string>
+    <string name="settings_flip_to_library_title">Retourner pour afficher le QR de la bibliothèque</string>
+    <string name="settings_flip_to_library_unsupported">Votre appareil ne dispose pas du capteur requis.</string>
     <string name="settings_invert_slider_direction">Inverser le sens du curseur</string>
     <string name="settings_language">Langue (Language)</string>
     <string name="settings_language_english">Anglais</string>

--- a/app/src/main/res/values-fr-rCA/strings.xml
+++ b/app/src/main/res/values-fr-rCA/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afficher la traduction</string>
     <string name="settings_color_theme">Thème de couleur</string>
     <string name="settings_feedback_bug_report">Commentaires / Signaler un problème</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverser le sens du curseur</string>
     <string name="settings_language">Langue (Language)</string>
     <string name="settings_language_english">Anglais</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Fort</string>
     <string name="haptic_preset_subtle">Subtil</string>
     <string name="haptic_scenario_class_table_long_press">Appui long sur l\'emploi du temps</string>
+    <string name="haptic_scenario_flip_to_library">Retourner pour ouvrir la bibliothèque</string>
     <string name="haptic_scenario_library_warning">Dialogue d\'avertissement de la bibliothèque</string>
     <string name="haptic_scenario_pull_to_refresh">Tirer pour actualiser</string>
     <string name="haptic_scenario_tab_reorder">Réorganisation des onglets</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afficher la traduction</string>
     <string name="settings_color_theme">Thème de couleur</string>
     <string name="settings_feedback_bug_report">Commentaires / Signaler un problème</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Retournez votre téléphone écran vers le bas pour afficher le QR de la bibliothèque.</string>
+    <string name="settings_flip_to_library_title">Retourner pour afficher le QR de la bibliothèque</string>
+    <string name="settings_flip_to_library_unsupported">Votre appareil ne dispose pas du capteur requis.</string>
     <string name="settings_invert_slider_direction">Inverser le sens du curseur</string>
     <string name="settings_language">Langue (Language)</string>
     <string name="settings_language_english">Anglais</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afficher la traduction</string>
     <string name="settings_color_theme">Thème de couleur</string>
     <string name="settings_feedback_bug_report">Commentaires / Signaler un problème</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverser le sens du curseur</string>
     <string name="settings_language">Langue (Language)</string>
     <string name="settings_language_english">Anglais</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">મજબૂત</string>
     <string name="haptic_preset_subtle">હળવો</string>
     <string name="haptic_scenario_class_table_long_press">ક્લાસ ટેબલ પર લાંબો ટેપ</string>
+    <string name="haptic_scenario_flip_to_library">લાઇબ્રેરી ખોલવા ફ્લિપ કરો</string>
     <string name="haptic_scenario_library_warning">લાઇબ્રેરી ચેતવણી સંવાદ</string>
     <string name="haptic_scenario_pull_to_refresh">રિફ્રેશ માટે ખેંચો</string>
     <string name="haptic_scenario_tab_reorder">ટેબ ફરીથી ગોઠવો</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">અનુવાદ બતાવો</string>
     <string name="settings_color_theme">કલર થીમ</string>
     <string name="settings_feedback_bug_report">ફીડબૅક / સમસ્યા જણાવો</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">લાઇબ્રેરી QR ખોલવા ફોનને સ્ક્રીન નીચે રાખી ફ્લિપ કરો.</string>
+    <string name="settings_flip_to_library_title">લાઇબ્રેરી QR બતાવવા ફ્લિપ કરો</string>
+    <string name="settings_flip_to_library_unsupported">તમારા ઉપકરણમાં જરૂરી સેન્સર નથી.</string>
     <string name="settings_invert_slider_direction">સ્લાઇડર દિશા ઊંધી કરો</string>
     <string name="settings_language">ભાષા (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-gu/strings.xml
+++ b/app/src/main/res/values-gu/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">અનુવાદ બતાવો</string>
     <string name="settings_color_theme">કલર થીમ</string>
     <string name="settings_feedback_bug_report">ફીડબૅક / સમસ્યા જણાવો</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">સ્લાઇડર દિશા ઊંધી કરો</string>
     <string name="settings_language">ભાષા (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">अनुवाद दिखाएँ</string>
     <string name="settings_color_theme">रंग थीम</string>
     <string name="settings_feedback_bug_report">फीडबैक / समस्या रिपोर्ट करें</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">स्लाइडर दिशा उलटें</string>
     <string name="settings_language">भाषा (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">तेज़</string>
     <string name="haptic_preset_subtle">हल्का</string>
     <string name="haptic_scenario_class_table_long_press">क्लास टेबल पर लंबा दबाव</string>
+    <string name="haptic_scenario_flip_to_library">लाइब्रेरी खोलने के लिए पलटें</string>
     <string name="haptic_scenario_library_warning">लाइब्रेरी चेतावनी डायलॉग</string>
     <string name="haptic_scenario_pull_to_refresh">रिफ्रेश के लिए खींचें</string>
     <string name="haptic_scenario_tab_reorder">टैब पुनर्व्यवस्थित करें</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">अनुवाद दिखाएँ</string>
     <string name="settings_color_theme">रंग थीम</string>
     <string name="settings_feedback_bug_report">फीडबैक / समस्या रिपोर्ट करें</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">लाइब्रेरी QR खोलने के लिए फ़ोन को स्क्रीन नीचे करके पलटें।</string>
+    <string name="settings_flip_to_library_title">लाइब्रेरी QR दिखाने के लिए पलटें</string>
+    <string name="settings_flip_to_library_unsupported">आपके डिवाइस में आवश्यक सेंसर नहीं है।</string>
     <string name="settings_invert_slider_direction">स्लाइडर दिशा उलटें</string>
     <string name="settings_language">भाषा (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Jako</string>
     <string name="haptic_preset_subtle">Nježno</string>
     <string name="haptic_scenario_class_table_long_press">Dugi pritisak u rasporedu</string>
+    <string name="haptic_scenario_flip_to_library">Preokreni za otvaranje knjižnice</string>
     <string name="haptic_scenario_library_warning">Upozorenje knjižnice</string>
     <string name="haptic_scenario_pull_to_refresh">Povuci za osvježavanje</string>
     <string name="haptic_scenario_tab_reorder">Preuređivanje kartica</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Prikaži prijevod</string>
     <string name="settings_color_theme">Tema boja</string>
     <string name="settings_feedback_bug_report">Povratne informacije / Prijava problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Preokrenite telefon zaslonom prema dolje da otvorite QR knjižnice.</string>
+    <string name="settings_flip_to_library_title">Preokreni za prikaz QR-a knjižnice</string>
+    <string name="settings_flip_to_library_unsupported">Uređaj nema potrebni senzor.</string>
     <string name="settings_invert_slider_direction">Obrni smjer klizača</string>
     <string name="settings_language">Jezik (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Prikaži prijevod</string>
     <string name="settings_color_theme">Tema boja</string>
     <string name="settings_feedback_bug_report">Povratne informacije / Prijava problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Obrni smjer klizača</string>
     <string name="settings_language">Jezik (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Erős</string>
     <string name="haptic_preset_subtle">Enyhe</string>
     <string name="haptic_scenario_class_table_long_press">Hosszú érintés az órarendben</string>
+    <string name="haptic_scenario_flip_to_library">Fordítsd meg a könyvtár megnyitásához</string>
     <string name="haptic_scenario_library_warning">Könyvtár figyelmeztetés</string>
     <string name="haptic_scenario_pull_to_refresh">Húzás a frissítéshez</string>
     <string name="haptic_scenario_tab_reorder">Lapok átrendezése</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Fordítás megjelenítése</string>
     <string name="settings_color_theme">Színtéma</string>
     <string name="settings_feedback_bug_report">Visszajelzés / Hibabejelentés</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Fordítsd az okostelefont képernyővel lefelé a könyvtári QR-kód megnyitásához.</string>
+    <string name="settings_flip_to_library_title">Fordítsd meg a könyvtári QR-kód megjelenítéséhez</string>
+    <string name="settings_flip_to_library_unsupported">Az eszközödnek nincs meg a szükséges érzékelője.</string>
     <string name="settings_invert_slider_direction">Csúszka irányának megfordítása</string>
     <string name="settings_language">Nyelv (Language)</string>
     <string name="settings_language_english">Angol</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Fordítás megjelenítése</string>
     <string name="settings_color_theme">Színtéma</string>
     <string name="settings_feedback_bug_report">Visszajelzés / Hibabejelentés</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Csúszka irányának megfordítása</string>
     <string name="settings_language">Nyelv (Language)</string>
     <string name="settings_language_english">Angol</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Kuat</string>
     <string name="haptic_preset_subtle">Halus</string>
     <string name="haptic_scenario_class_table_long_press">Tekan lama di jadwal kelas</string>
+    <string name="haptic_scenario_flip_to_library">Balik untuk membuka perpustakaan</string>
     <string name="haptic_scenario_library_warning">Dialog peringatan perpustakaan</string>
     <string name="haptic_scenario_pull_to_refresh">Tarik untuk muat ulang</string>
     <string name="haptic_scenario_tab_reorder">Susun ulang tab</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Tampilkan terjemahan</string>
     <string name="settings_color_theme">Tema warna</string>
     <string name="settings_feedback_bug_report">Umpan balik / Laporkan masalah</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Balik ponsel dengan layar menghadap bawah untuk membuka QR perpustakaan.</string>
+    <string name="settings_flip_to_library_title">Balik untuk menampilkan QR perpustakaan</string>
+    <string name="settings_flip_to_library_unsupported">Perangkat Anda tidak memiliki sensor yang diperlukan.</string>
     <string name="settings_invert_slider_direction">Balik arah slider</string>
     <string name="settings_language">Bahasa (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Tampilkan terjemahan</string>
     <string name="settings_color_theme">Tema warna</string>
     <string name="settings_feedback_bug_report">Umpan balik / Laporkan masalah</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Balik arah slider</string>
     <string name="settings_language">Bahasa (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Sterkur</string>
     <string name="haptic_preset_subtle">Mildur</string>
     <string name="haptic_scenario_class_table_long_press">Langt ýt á stundatöflu</string>
+    <string name="haptic_scenario_flip_to_library">Snúa til að opna bókasafnið</string>
     <string name="haptic_scenario_library_warning">Bókasafnsviðvörun</string>
     <string name="haptic_scenario_pull_to_refresh">Draga til að uppfæra</string>
     <string name="haptic_scenario_tab_reorder">Endurraða flipum</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Sýna þýðingu</string>
     <string name="settings_color_theme">Litaþema</string>
     <string name="settings_feedback_bug_report">Endurgjöf / Tilkynna villu</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Snúðu símann með skjánum niður til að opna QR kóða bókasafnsins.</string>
+    <string name="settings_flip_to_library_title">Snúa til að sýna QR kóða bókasafnsins</string>
+    <string name="settings_flip_to_library_unsupported">Tækið er ekki með nauðsynlegan skynjara.</string>
     <string name="settings_invert_slider_direction">Snúa sleðastefnu við</string>
     <string name="settings_language">Tungumál (Language)</string>
     <string name="settings_language_english">Enska</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Sýna þýðingu</string>
     <string name="settings_color_theme">Litaþema</string>
     <string name="settings_feedback_bug_report">Endurgjöf / Tilkynna villu</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Snúa sleðastefnu við</string>
     <string name="settings_language">Tungumál (Language)</string>
     <string name="settings_language_english">Enska</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Forte</string>
     <string name="haptic_preset_subtle">Leggero</string>
     <string name="haptic_scenario_class_table_long_press">Pressione prolungata sull\'orario</string>
+    <string name="haptic_scenario_flip_to_library">Capovolgi per aprire la biblioteca</string>
     <string name="haptic_scenario_library_warning">Avviso della biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Trascina per aggiornare</string>
     <string name="haptic_scenario_tab_reorder">Riordinamento delle schede</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostra tradotto</string>
     <string name="settings_color_theme">Tema colore</string>
     <string name="settings_feedback_bug_report">Feedback / Segnala un problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Capovolgi il telefono con lo schermo verso il basso per aprire il QR della biblioteca.</string>
+    <string name="settings_flip_to_library_title">Capovolgi per mostrare il QR della biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">Il dispositivo non dispone del sensore richiesto.</string>
     <string name="settings_invert_slider_direction">Inverti la direzione del cursore</string>
     <string name="settings_language">Lingua (Language)</string>
     <string name="settings_language_english">Inglese</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostra tradotto</string>
     <string name="settings_color_theme">Tema colore</string>
     <string name="settings_feedback_bug_report">Feedback / Segnala un problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverti la direzione del cursore</string>
     <string name="settings_language">Lingua (Language)</string>
     <string name="settings_language_english">Inglese</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">חזק</string>
     <string name="haptic_preset_subtle">עדין</string>
     <string name="haptic_scenario_class_table_long_press">לחיצה ארוכה על לוח הזמנים</string>
+    <string name="haptic_scenario_flip_to_library">הפוך לפתיחת הספרייה</string>
     <string name="haptic_scenario_library_warning">תיבת דו-שיח של אזהרת ספרייה</string>
     <string name="haptic_scenario_pull_to_refresh">משוך לרענון</string>
     <string name="haptic_scenario_tab_reorder">סידור מחדש של לשוניות</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">הצג תרגום</string>
     <string name="settings_color_theme">ערכת צבעים</string>
     <string name="settings_feedback_bug_report">משוב / דיווח על בעיה</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">הפוך את הטלפון עם המסך כלפי מטה כדי לפתוח את ה-QR של הספרייה.</string>
+    <string name="settings_flip_to_library_title">הפוך להצגת ה-QR של הספרייה</string>
+    <string name="settings_flip_to_library_unsupported">המכשיר שלך לא כולל את החיישן הנדרש.</string>
     <string name="settings_invert_slider_direction">הפוך כיוון מחוון</string>
     <string name="settings_language">(Language) שפה</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">הצג תרגום</string>
     <string name="settings_color_theme">ערכת צבעים</string>
     <string name="settings_feedback_bug_report">משוב / דיווח על בעיה</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">הפוך כיוון מחוון</string>
     <string name="settings_language">(Language) שפה</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">訳語を表示</string>
     <string name="settings_color_theme">カラーテーマ</string>
     <string name="settings_feedback_bug_report">フィードバック / 不具合報告</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">スライダーの方向を反転</string>
     <string name="settings_language">言語 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">強い</string>
     <string name="haptic_preset_subtle">弱い</string>
     <string name="haptic_scenario_class_table_long_press">時間割の長押し</string>
+    <string name="haptic_scenario_flip_to_library">裏返して図書館を開く</string>
     <string name="haptic_scenario_library_warning">図書館警告ダイアログ</string>
     <string name="haptic_scenario_pull_to_refresh">引っ張って更新</string>
     <string name="haptic_scenario_tab_reorder">タブの並び替え</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">訳語を表示</string>
     <string name="settings_color_theme">カラーテーマ</string>
     <string name="settings_feedback_bug_report">フィードバック / 不具合報告</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">スマホを画面下向きに裏返すと図書館QRを開きます。</string>
+    <string name="settings_flip_to_library_title">裏返して図書館QRを表示</string>
+    <string name="settings_flip_to_library_unsupported">このデバイスには必要なセンサーがありません。</string>
     <string name="settings_invert_slider_direction">スライダーの方向を反転</string>
     <string name="settings_language">言語 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Аударманы көрсету</string>
     <string name="settings_color_theme">Түс тақырыбы</string>
     <string name="settings_feedback_bug_report">Пікір / Мәселені хабарлау</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Жүгірткі бағытын кері айналдыру</string>
     <string name="settings_language">Тіл (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-kk/strings.xml
+++ b/app/src/main/res/values-kk/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Күшті</string>
     <string name="haptic_preset_subtle">Жеңіл</string>
     <string name="haptic_scenario_class_table_long_press">Сабақ кестесін ұзақ басу</string>
+    <string name="haptic_scenario_flip_to_library">Кітапхананы ашу үшін аудар</string>
     <string name="haptic_scenario_library_warning">Кітапхана ескертуі</string>
     <string name="haptic_scenario_pull_to_refresh">Жаңарту үшін тартыңыз</string>
     <string name="haptic_scenario_tab_reorder">Қойындыларды қайта реттеу</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Аударманы көрсету</string>
     <string name="settings_color_theme">Түс тақырыбы</string>
     <string name="settings_feedback_bug_report">Пікір / Мәселені хабарлау</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Кітапхана QR-ын ашу үшін телефонды экраны төмен қаратып аудар.</string>
+    <string name="settings_flip_to_library_title">Кітапхана QR-ын көрсету үшін аудар</string>
+    <string name="settings_flip_to_library_unsupported">Құрылғыңызда қажетті датчик жоқ.</string>
     <string name="settings_invert_slider_direction">Жүгірткі бағытын кері айналдыру</string>
     <string name="settings_language">Тіл (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">ಅನುವಾದ ತೋರಿಸು</string>
     <string name="settings_color_theme">ಬಣ್ಣ ಥೀಮ್</string>
     <string name="settings_feedback_bug_report">ಪ್ರತಿಕ್ರಿಯೆ / ಸಮಸ್ಯೆ ವರದಿ</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">ಸ್ಲೈಡರ್ ದಿಕ್ಕು ತಿರುಗಿಸಿ</string>
     <string name="settings_language">ಭಾಷೆ (Language)</string>
     <string name="settings_language_english">ಇಂಗ್ಲಿಷ್</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">ಬಲವಾದ</string>
     <string name="haptic_preset_subtle">ಮೃದು</string>
     <string name="haptic_scenario_class_table_long_press">ತರಗತಿ ಟೇಬಲ್ ಮೇಲೆ ದೀರ್ಘ ಒತ್ತುವಿಕೆ</string>
+    <string name="haptic_scenario_flip_to_library">ಲೈಬ್ರರಿ ತೆರೆಯಲು ಫ್ಲಿಪ್ ಮಾಡಿ</string>
     <string name="haptic_scenario_library_warning">ಲೈಬ್ರರಿ ಎಚ್ಚರಿಕೆ ಡೈಲಾಗ್</string>
     <string name="haptic_scenario_pull_to_refresh">ರಿಫ್ರೆಶ್‌ಗಾಗಿ ಎಳೆಯಿರಿ</string>
     <string name="haptic_scenario_tab_reorder">ಟ್ಯಾಬ್ ಮರು-ಅನುಕ್ರಮ</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">ಅನುವಾದ ತೋರಿಸು</string>
     <string name="settings_color_theme">ಬಣ್ಣ ಥೀಮ್</string>
     <string name="settings_feedback_bug_report">ಪ್ರತಿಕ್ರಿಯೆ / ಸಮಸ್ಯೆ ವರದಿ</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">ಲೈಬ್ರರಿ QR ತೆರೆಯಲು ಫೋನ್ ಅನ್ನು ಸ್ಕ್ರೀನ್ ಕೆಳಕ್ಕೆ ಮಾಡಿ ಫ್ಲಿಪ್ ಮಾಡಿ.</string>
+    <string name="settings_flip_to_library_title">ಲೈಬ್ರರಿ QR ತೋರಿಸಲು ಫ್ಲಿಪ್ ಮಾಡಿ</string>
+    <string name="settings_flip_to_library_unsupported">ನಿಮ್ಮ ಸಾಧನದಲ್ಲಿ ಅಗತ್ಯ ಸೆನ್ಸರ್ ಇಲ್ಲ.</string>
     <string name="settings_invert_slider_direction">ಸ್ಲೈಡರ್ ದಿಕ್ಕು ತಿರುಗಿಸಿ</string>
     <string name="settings_language">ಭಾಷೆ (Language)</string>
     <string name="settings_language_english">ಇಂಗ್ಲಿಷ್</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">강하게</string>
     <string name="haptic_preset_subtle">약하게</string>
     <string name="haptic_scenario_class_table_long_press">수업표 길게 누르기</string>
+    <string name="haptic_scenario_flip_to_library">뒤집어서 도서관 열기</string>
     <string name="haptic_scenario_library_warning">도서관 경고 다이얼로그</string>
     <string name="haptic_scenario_pull_to_refresh">당겨서 새로고침</string>
     <string name="haptic_scenario_tab_reorder">탭 순서 변경</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">번역 표시</string>
     <string name="settings_color_theme">색상 테마</string>
     <string name="settings_feedback_bug_report">피드백 / 문제 신고</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">화면을 아래로 뒤집으면 도서관 QR이 열립니다.</string>
+    <string name="settings_flip_to_library_title">뒤집어서 도서관 QR 표시</string>
+    <string name="settings_flip_to_library_unsupported">이 기기에는 필요한 센서가 없습니다.</string>
     <string name="settings_invert_slider_direction">슬라이더 방향 반전</string>
     <string name="settings_language">언어 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">번역 표시</string>
     <string name="settings_color_theme">색상 테마</string>
     <string name="settings_feedback_bug_report">피드백 / 문제 신고</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">슬라이더 방향 반전</string>
     <string name="settings_language">언어 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Stiprus</string>
     <string name="haptic_preset_subtle">Švelnus</string>
     <string name="haptic_scenario_class_table_long_press">Ilgas paspaudimas tvarkaraštyje</string>
+    <string name="haptic_scenario_flip_to_library">Apversti ir atidaryti biblioteką</string>
     <string name="haptic_scenario_library_warning">Bibliotekos įspėjimas</string>
     <string name="haptic_scenario_pull_to_refresh">Traukti atnaujinti</string>
     <string name="haptic_scenario_tab_reorder">Skirtukų pertvarkymas</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Rodyti vertimą</string>
     <string name="settings_color_theme">Spalvų tema</string>
     <string name="settings_feedback_bug_report">Atsiliepimai / Pranešti apie klaidą</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Apverskite telefoną ekranu žemyn, kad atidarytumėte bibliotekos QR.</string>
+    <string name="settings_flip_to_library_title">Apversti, kad rodytų bibliotekos QR</string>
+    <string name="settings_flip_to_library_unsupported">Jūsų įrenginyje nėra reikiamo jutiklio.</string>
     <string name="settings_invert_slider_direction">Apversti slankiklio kryptį</string>
     <string name="settings_language">Kalba (Language)</string>
     <string name="settings_language_english">Anglų</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Rodyti vertimą</string>
     <string name="settings_color_theme">Spalvų tema</string>
     <string name="settings_feedback_bug_report">Atsiliepimai / Pranešti apie klaidą</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Apversti slankiklio kryptį</string>
     <string name="settings_language">Kalba (Language)</string>
     <string name="settings_language_english">Anglų</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Rādīt tulkojumu</string>
     <string name="settings_color_theme">Krāsu tēma</string>
     <string name="settings_feedback_bug_report">Atsauksme / Ziņot par problēmu</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invertēt slīdņa virzienu</string>
     <string name="settings_language">Valoda (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Spēcīgs</string>
     <string name="haptic_preset_subtle">Viegls</string>
     <string name="haptic_scenario_class_table_long_press">Ilgs pieskāriens stundu sarakstā</string>
+    <string name="haptic_scenario_flip_to_library">Apvērst, lai atvērtu bibliotēku</string>
     <string name="haptic_scenario_library_warning">Bibliotēkas brīdinājums</string>
     <string name="haptic_scenario_pull_to_refresh">Velkt, lai atsvaidzinātu</string>
     <string name="haptic_scenario_tab_reorder">Ciļņu pārkārtošana</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Rādīt tulkojumu</string>
     <string name="settings_color_theme">Krāsu tēma</string>
     <string name="settings_feedback_bug_report">Atsauksme / Ziņot par problēmu</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Apvērs tālruni ar ekrānu uz leju, lai atvērtu bibliotēkas QR.</string>
+    <string name="settings_flip_to_library_title">Apvērst, lai parādītu bibliotēkas QR</string>
+    <string name="settings_flip_to_library_unsupported">Ierīcei nav nepieciešamā sensora.</string>
     <string name="settings_invert_slider_direction">Invertēt slīdņa virzienu</string>
     <string name="settings_language">Valoda (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">ശക്തമായ</string>
     <string name="haptic_preset_subtle">മൃദുവായ</string>
     <string name="haptic_scenario_class_table_long_press">ക്ലാസ് ടേബിളിൽ നീണ്ട അമർത്തൽ</string>
+    <string name="haptic_scenario_flip_to_library">ലൈബ്രറി തുറക്കാൻ മറിക്കുക</string>
     <string name="haptic_scenario_library_warning">ലൈബ്രറി മുന്നറിയിപ്പ് ഡയലോഗ്</string>
     <string name="haptic_scenario_pull_to_refresh">റിഫ്രഷ് ചെയ്യാൻ വലിക്കുക</string>
     <string name="haptic_scenario_tab_reorder">ടാബ് പുനഃക്രമീകരിക്കുക</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">വിവർത്തനം കാണിക്കുക</string>
     <string name="settings_color_theme">നിറ തീം</string>
     <string name="settings_feedback_bug_report">ഫീഡ്‌ബാക്ക് / പ്രശ്‌നം റിപ്പോർട്ട് ചെയ്യുക</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">ലൈബ്രറി QR തുറക്കാൻ ഫോൺ സ്ക്രീൻ താഴ്ത്തി മറിക്കുക.</string>
+    <string name="settings_flip_to_library_title">ലൈബ്രറി QR കാണിക്കാൻ മറിക്കുക</string>
+    <string name="settings_flip_to_library_unsupported">നിങ്ങളുടെ ഉപകരണത്തിൽ ആവശ്യമായ സെൻസർ ഇല്ല.</string>
     <string name="settings_invert_slider_direction">സ്ലൈഡർ ദിശ നേർമാറ്റം ചെയ്യുക</string>
     <string name="settings_language">ഭാഷ (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">വിവർത്തനം കാണിക്കുക</string>
     <string name="settings_color_theme">നിറ തീം</string>
     <string name="settings_feedback_bug_report">ഫീഡ്‌ബാക്ക് / പ്രശ്‌നം റിപ്പോർട്ട് ചെയ്യുക</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">സ്ലൈഡർ ദിശ നേർമാറ്റം ചെയ്യുക</string>
     <string name="settings_language">ഭാഷ (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">भाषांतर दर्शवा</string>
     <string name="settings_color_theme">रंग थीम</string>
     <string name="settings_feedback_bug_report">अभिप्राय / समस्या अहवाल</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">स्लायडर दिशा उलटवा</string>
     <string name="settings_language">भाषा (Language)</string>
     <string name="settings_language_english">इंग्रजी</string>

--- a/app/src/main/res/values-mr/strings.xml
+++ b/app/src/main/res/values-mr/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">तीव्र</string>
     <string name="haptic_preset_subtle">सौम्य</string>
     <string name="haptic_scenario_class_table_long_press">वर्ग सारणीवर दीर्घ दाब</string>
+    <string name="haptic_scenario_flip_to_library">लायब्ररी उघडण्यासाठी फ्लिप करा</string>
     <string name="haptic_scenario_library_warning">ग्रंथालय चेतावणी संवाद</string>
     <string name="haptic_scenario_pull_to_refresh">रिफ्रेशसाठी खेचा</string>
     <string name="haptic_scenario_tab_reorder">टॅब पुनर्मांडणी</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">भाषांतर दर्शवा</string>
     <string name="settings_color_theme">रंग थीम</string>
     <string name="settings_feedback_bug_report">अभिप्राय / समस्या अहवाल</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">लायब्ररी QR उघडण्यासाठी फोन स्क्रीन खाली करून फ्लिप करा.</string>
+    <string name="settings_flip_to_library_title">लायब्ररी QR दाखवण्यासाठी फ्लिप करा</string>
+    <string name="settings_flip_to_library_unsupported">तुमच्या डिव्हाइसमध्ये आवश्यक सेन्सर नाही.</string>
     <string name="settings_invert_slider_direction">स्लायडर दिशा उलटवा</string>
     <string name="settings_language">भाषा (Language)</string>
     <string name="settings_language_english">इंग्रजी</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Papar terjemahan</string>
     <string name="settings_color_theme">Tema warna</string>
     <string name="settings_feedback_bug_report">Maklum balas / Laporkan isu</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Songsangkan arah gelongsor</string>
     <string name="settings_language">Bahasa (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Kuat</string>
     <string name="haptic_preset_subtle">Halus</string>
     <string name="haptic_scenario_class_table_long_press">Tekan lama pada jadual kelas</string>
+    <string name="haptic_scenario_flip_to_library">Balik untuk buka perpustakaan</string>
     <string name="haptic_scenario_library_warning">Dialog amaran perpustakaan</string>
     <string name="haptic_scenario_pull_to_refresh">Tarik untuk muat semula</string>
     <string name="haptic_scenario_tab_reorder">Susun semula tab</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Papar terjemahan</string>
     <string name="settings_color_theme">Tema warna</string>
     <string name="settings_feedback_bug_report">Maklum balas / Laporkan isu</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Balik telefon dengan skrin menghadap bawah untuk membuka QR perpustakaan.</string>
+    <string name="settings_flip_to_library_title">Balik untuk tunjuk QR perpustakaan</string>
+    <string name="settings_flip_to_library_unsupported">Peranti anda tidak mempunyai penderia yang diperlukan.</string>
     <string name="settings_invert_slider_direction">Songsangkan arah gelongsor</string>
     <string name="settings_language">Bahasa (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Sterk</string>
     <string name="haptic_preset_subtle">Svak</string>
     <string name="haptic_scenario_class_table_long_press">Langt trykk i timeplanen</string>
+    <string name="haptic_scenario_flip_to_library">Snu for å åpne biblioteket</string>
     <string name="haptic_scenario_library_warning">Bibliotekadvarsel</string>
     <string name="haptic_scenario_pull_to_refresh">Trekk for å oppdatere</string>
     <string name="haptic_scenario_tab_reorder">Omorganiser faner</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversettelse</string>
     <string name="settings_color_theme">Fargetema</string>
     <string name="settings_feedback_bug_report">Tilbakemelding / Rapporter problem</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Snu telefonen med skjermen ned for å åpne bibliotekets QR.</string>
+    <string name="settings_flip_to_library_title">Snu for å vise bibliotekets QR</string>
+    <string name="settings_flip_to_library_unsupported">Enheten mangler den nødvendige sensoren.</string>
     <string name="settings_invert_slider_direction">Inverter glidebryterens retning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversettelse</string>
     <string name="settings_color_theme">Fargetema</string>
     <string name="settings_feedback_bug_report">Tilbakemelding / Rapporter problem</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter glidebryterens retning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Sterk</string>
     <string name="haptic_preset_subtle">Zacht</string>
     <string name="haptic_scenario_class_table_long_press">Lang indrukken in rooster</string>
+    <string name="haptic_scenario_flip_to_library">Omdraaien om bibliotheek te openen</string>
     <string name="haptic_scenario_library_warning">Bibliotheek waarschuwing</string>
     <string name="haptic_scenario_pull_to_refresh">Omlaag trekken om te vernieuwen</string>
     <string name="haptic_scenario_tab_reorder">Tabbladen herordenen</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vertaling weergeven</string>
     <string name="settings_color_theme">Kleurthema</string>
     <string name="settings_feedback_bug_report">Feedback / Probleem melden</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Leg je telefoon met het scherm naar beneden om de bibliotheek-QR te openen.</string>
+    <string name="settings_flip_to_library_title">Omdraaien om bibliotheek-QR te tonen</string>
+    <string name="settings_flip_to_library_unsupported">Dit apparaat heeft de vereiste sensor niet.</string>
     <string name="settings_invert_slider_direction">Schuifregelaarrichting omkeren</string>
     <string name="settings_language">Taal (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vertaling weergeven</string>
     <string name="settings_color_theme">Kleurthema</string>
     <string name="settings_feedback_bug_report">Feedback / Probleem melden</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Schuifregelaarrichting omkeren</string>
     <string name="settings_language">Taal (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Sterk</string>
     <string name="haptic_preset_subtle">Svak</string>
     <string name="haptic_scenario_class_table_long_press">Langt trykk i timeplanen</string>
+    <string name="haptic_scenario_flip_to_library">Snu for å åpne biblioteket</string>
     <string name="haptic_scenario_library_warning">Bibliotekadvarsel</string>
     <string name="haptic_scenario_pull_to_refresh">Trekk for å oppdatere</string>
     <string name="haptic_scenario_tab_reorder">Omorganiser faner</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversettelse</string>
     <string name="settings_color_theme">Fargetema</string>
     <string name="settings_feedback_bug_report">Tilbakemelding / Rapporter problem</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Snu telefonen med skjermen ned for å åpne bibliotekets QR.</string>
+    <string name="settings_flip_to_library_title">Snu for å vise bibliotekets QR</string>
+    <string name="settings_flip_to_library_unsupported">Enheten mangler den nødvendige sensoren.</string>
     <string name="settings_invert_slider_direction">Inverter glidebryterens retning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Vis oversettelse</string>
     <string name="settings_color_theme">Fargetema</string>
     <string name="settings_feedback_bug_report">Tilbakemelding / Rapporter problem</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter glidebryterens retning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">Engelsk</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">ਅਨੁਵਾਦ ਵਿਖਾਓ</string>
     <string name="settings_color_theme">ਰੰਗ ਥੀਮ</string>
     <string name="settings_feedback_bug_report">ਫੀਡਬੈਕ / ਸਮੱਸਿਆ ਰਿਪੋਰਟ ਕਰੋ</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">ਸਲਾਈਡਰ ਦਿਸ਼ਾ ਉਲਟੀ ਕਰੋ</string>
     <string name="settings_language">ਭਾਸ਼ਾ (Language)</string>
     <string name="settings_language_english">ਅੰਗਰੇਜ਼ੀ</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">ਮਜ਼ਬੂਤ</string>
     <string name="haptic_preset_subtle">ਹਲਕਾ</string>
     <string name="haptic_scenario_class_table_long_press">ਕਲਾਸ ਟੇਬਲ \'ਤੇ ਲੰਮਾ ਦਬਾਅ</string>
+    <string name="haptic_scenario_flip_to_library">ਲਾਇਬ੍ਰੇਰੀ ਖੋਲ੍ਹਣ ਲਈ ਫਲਿੱਪ ਕਰੋ</string>
     <string name="haptic_scenario_library_warning">ਲਾਇਬ੍ਰੇਰੀ ਚੇਤਾਵਨੀ ਡਾਇਲਾਗ</string>
     <string name="haptic_scenario_pull_to_refresh">ਰਿਫ੍ਰੈਸ਼ ਲਈ ਖਿੱਚੋ</string>
     <string name="haptic_scenario_tab_reorder">ਟੈਬ ਮੁੜ ਵਿਵਸਥਿਤ ਕਰੋ</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">ਅਨੁਵਾਦ ਵਿਖਾਓ</string>
     <string name="settings_color_theme">ਰੰਗ ਥੀਮ</string>
     <string name="settings_feedback_bug_report">ਫੀਡਬੈਕ / ਸਮੱਸਿਆ ਰਿਪੋਰਟ ਕਰੋ</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">ਲਾਇਬ੍ਰੇਰੀ QR ਖੋਲ੍ਹਣ ਲਈ ਫ਼ੋਨ ਨੂੰ ਸਕਰੀਨ ਹੇਠਾਂ ਕਰਕੇ ਫਲਿੱਪ ਕਰੋ।</string>
+    <string name="settings_flip_to_library_title">ਲਾਇਬ੍ਰੇਰੀ QR ਦਿਖਾਉਣ ਲਈ ਫਲਿੱਪ ਕਰੋ</string>
+    <string name="settings_flip_to_library_unsupported">ਤੁਹਾਡੇ ਡਿਵਾਈਸ ਵਿੱਚ ਲੋੜੀਂਦਾ ਸੈਂਸਰ ਨਹੀਂ ਹੈ।</string>
     <string name="settings_invert_slider_direction">ਸਲਾਈਡਰ ਦਿਸ਼ਾ ਉਲਟੀ ਕਰੋ</string>
     <string name="settings_language">ਭਾਸ਼ਾ (Language)</string>
     <string name="settings_language_english">ਅੰਗਰੇਜ਼ੀ</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Mocny</string>
     <string name="haptic_preset_subtle">Delikatny</string>
     <string name="haptic_scenario_class_table_long_press">Długie naciśnięcie w planie zajęć</string>
+    <string name="haptic_scenario_flip_to_library">Odwróć, aby otworzyć bibliotekę</string>
     <string name="haptic_scenario_library_warning">Ostrzeżenie biblioteki</string>
     <string name="haptic_scenario_pull_to_refresh">Pociągnij, aby odświeżyć</string>
     <string name="haptic_scenario_tab_reorder">Zmień kolejność kart</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Wyświetl tłumaczenie</string>
     <string name="settings_color_theme">Motyw kolorystyczny</string>
     <string name="settings_feedback_bug_report">Opinie / Zgłoś problem</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Odwróć telefon ekranem w dół, aby otworzyć QR biblioteki.</string>
+    <string name="settings_flip_to_library_title">Odwróć, aby pokazać QR biblioteki</string>
+    <string name="settings_flip_to_library_unsupported">Twoje urządzenie nie ma wymaganego czujnika.</string>
     <string name="settings_invert_slider_direction">Odwróć kierunek suwaka</string>
     <string name="settings_language">Język (Language)</string>
     <string name="settings_language_english">Angielski</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Wyświetl tłumaczenie</string>
     <string name="settings_color_theme">Motyw kolorystyczny</string>
     <string name="settings_feedback_bug_report">Opinie / Zgłoś problem</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Odwróć kierunek suwaka</string>
     <string name="settings_language">Język (Language)</string>
     <string name="settings_language_english">Angielski</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Forte</string>
     <string name="haptic_preset_subtle">Suave</string>
     <string name="haptic_scenario_class_table_long_press">Pressão longa no horário</string>
+    <string name="haptic_scenario_flip_to_library">Virar para abrir a biblioteca</string>
     <string name="haptic_scenario_library_warning">Aviso da biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Puxar para atualizar</string>
     <string name="haptic_scenario_tab_reorder">Reordenar abas</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Feedback / Reportar problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Vire o telefone com a tela para baixo para abrir o QR da biblioteca.</string>
+    <string name="settings_flip_to_library_title">Virar para mostrar o QR da biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">Seu dispositivo não possui o sensor necessário.</string>
     <string name="settings_invert_slider_direction">Inverter direção do controle deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Feedback / Reportar problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter direção do controle deslizante</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Forte</string>
     <string name="haptic_preset_subtle">Suave</string>
     <string name="haptic_scenario_class_table_long_press">Pressão longa no horário</string>
+    <string name="haptic_scenario_flip_to_library">Virar para abrir a biblioteca</string>
     <string name="haptic_scenario_library_warning">Aviso da biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Puxar para atualizar</string>
     <string name="haptic_scenario_tab_reorder">Reordenar separadores</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Comentários / Reportar problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Vire o telemóvel com o ecrã para baixo para abrir o QR da biblioteca.</string>
+    <string name="settings_flip_to_library_title">Virar para mostrar o QR da biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">O seu dispositivo não tem o sensor necessário.</string>
     <string name="settings_invert_slider_direction">Inverter direção do cursor</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Comentários / Reportar problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter direção do cursor</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Forte</string>
     <string name="haptic_preset_subtle">Suave</string>
     <string name="haptic_scenario_class_table_long_press">Pressão longa no horário</string>
+    <string name="haptic_scenario_flip_to_library">Virar para abrir a biblioteca</string>
     <string name="haptic_scenario_library_warning">Aviso da biblioteca</string>
     <string name="haptic_scenario_pull_to_refresh">Puxar para atualizar</string>
     <string name="haptic_scenario_tab_reorder">Reordenar separadores</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Comentários / Reportar problema</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Vire o telemóvel com o ecrã para baixo para abrir o QR da biblioteca.</string>
+    <string name="settings_flip_to_library_title">Virar para mostrar o QR da biblioteca</string>
+    <string name="settings_flip_to_library_unsupported">O seu dispositivo não tem o sensor necessário.</string>
     <string name="settings_invert_slider_direction">Inverter direção do cursor</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Mostrar tradução</string>
     <string name="settings_color_theme">Tema de cores</string>
     <string name="settings_feedback_bug_report">Comentários / Reportar problema</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inverter direção do cursor</string>
     <string name="settings_language">Idioma (Language)</string>
     <string name="settings_language_english">Inglês</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afișează traducere</string>
     <string name="settings_color_theme">Temă de culori</string>
     <string name="settings_feedback_bug_report">Feedback / Raportare problemă</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Inversează direcția glisorului</string>
     <string name="settings_language">Limbă (Language)</string>
     <string name="settings_language_english">Engleză</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Puternic</string>
     <string name="haptic_preset_subtle">Ușor</string>
     <string name="haptic_scenario_class_table_long_press">Apăsare lungă în orar</string>
+    <string name="haptic_scenario_flip_to_library">Întoarce pentru a deschide biblioteca</string>
     <string name="haptic_scenario_library_warning">Avertisment bibliotecă</string>
     <string name="haptic_scenario_pull_to_refresh">Trage pentru reîmprospătare</string>
     <string name="haptic_scenario_tab_reorder">Reordonare file</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Afișează traducere</string>
     <string name="settings_color_theme">Temă de culori</string>
     <string name="settings_feedback_bug_report">Feedback / Raportare problemă</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Întoarce telefonul cu ecranul în jos pentru a deschide QR-ul bibliotecii.</string>
+    <string name="settings_flip_to_library_title">Întoarce pentru a afișa QR-ul bibliotecii</string>
+    <string name="settings_flip_to_library_unsupported">Dispozitivul tău nu are senzorul necesar.</string>
     <string name="settings_invert_slider_direction">Inversează direcția glisorului</string>
     <string name="settings_language">Limbă (Language)</string>
     <string name="settings_language_english">Engleză</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Сильная</string>
     <string name="haptic_preset_subtle">Слабая</string>
     <string name="haptic_scenario_class_table_long_press">Долгое нажатие в расписании</string>
+    <string name="haptic_scenario_flip_to_library">Перевернуть и открыть библиотеку</string>
     <string name="haptic_scenario_library_warning">Предупреждение библиотеки</string>
     <string name="haptic_scenario_pull_to_refresh">Потяните для обновления</string>
     <string name="haptic_scenario_tab_reorder">Изменение порядка вкладок</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показать перевод</string>
     <string name="settings_color_theme">Цветовая тема</string>
     <string name="settings_feedback_bug_report">Отзыв / Сообщить о проблеме</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Переверните телефон экраном вниз, чтобы открыть QR библиотеки.</string>
+    <string name="settings_flip_to_library_title">Перевернуть для отображения QR библиотеки</string>
+    <string name="settings_flip_to_library_unsupported">На вашем устройстве нет необходимого датчика.</string>
     <string name="settings_invert_slider_direction">Инвертировать направление ползунка</string>
     <string name="settings_language">Язык (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показать перевод</string>
     <string name="settings_color_theme">Цветовая тема</string>
     <string name="settings_feedback_bug_report">Отзыв / Сообщить о проблеме</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Инвертировать направление ползунка</string>
     <string name="settings_language">Язык (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Silný</string>
     <string name="haptic_preset_subtle">Jemný</string>
     <string name="haptic_scenario_class_table_long_press">Dlhé stlačenie v rozvrhu</string>
+    <string name="haptic_scenario_flip_to_library">Otočiť a otvoriť knižnicu</string>
     <string name="haptic_scenario_library_warning">Upozornenie knižnice</string>
     <string name="haptic_scenario_pull_to_refresh">Ťahom obnoviť</string>
     <string name="haptic_scenario_tab_reorder">Zmena poradia kariet</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Zobraziť preklad</string>
     <string name="settings_color_theme">Farebná téma</string>
     <string name="settings_feedback_bug_report">Spätná väzba / Nahlásenie problému</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Otočte telefón obrazovkou nadol a otvoríte QR knižnice.</string>
+    <string name="settings_flip_to_library_title">Otočiť pre zobrazenie QR knižnice</string>
+    <string name="settings_flip_to_library_unsupported">Vaše zariadenie nemá potrebný senzor.</string>
     <string name="settings_invert_slider_direction">Invertovať smer posuvníka</string>
     <string name="settings_language">Jazyk (Language)</string>
     <string name="settings_language_english">Angličtina</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Zobraziť preklad</string>
     <string name="settings_color_theme">Farebná téma</string>
     <string name="settings_feedback_bug_report">Spätná väzba / Nahlásenie problému</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invertovať smer posuvníka</string>
     <string name="settings_language">Jazyk (Language)</string>
     <string name="settings_language_english">Angličtina</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Močno</string>
     <string name="haptic_preset_subtle">Nežno</string>
     <string name="haptic_scenario_class_table_long_press">Dolg pritisk v urniku</string>
+    <string name="haptic_scenario_flip_to_library">Obrni za odpiranje knjižnice</string>
     <string name="haptic_scenario_library_warning">Opozorilo knjižnice</string>
     <string name="haptic_scenario_pull_to_refresh">Povleci za osvežitev</string>
     <string name="haptic_scenario_tab_reorder">Prerazporeditev zavihkov</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Prikaži prevod</string>
     <string name="settings_color_theme">Barvna tema</string>
     <string name="settings_feedback_bug_report">Povratne informacije / Prijava napake</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Obrni telefon z zaslonom navzdol, da odpreš QR knjižnice.</string>
+    <string name="settings_flip_to_library_title">Obrni za prikaz QR knjižnice</string>
+    <string name="settings_flip_to_library_unsupported">Naprava nima zahtevanega senzorja.</string>
     <string name="settings_invert_slider_direction">Obrni smer drsnika</string>
     <string name="settings_language">Jezik (Language)</string>
     <string name="settings_language_english">Angleščina</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Prikaži prevod</string>
     <string name="settings_color_theme">Barvna tema</string>
     <string name="settings_feedback_bug_report">Povratne informacije / Prijava napake</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Obrni smer drsnika</string>
     <string name="settings_language">Jezik (Language)</string>
     <string name="settings_language_english">Angleščina</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Јако</string>
     <string name="haptic_preset_subtle">Нежно</string>
     <string name="haptic_scenario_class_table_long_press">Дуги притисак у распореду</string>
+    <string name="haptic_scenario_flip_to_library">Окрени за отварање библиотеке</string>
     <string name="haptic_scenario_library_warning">Упозорење библиотеке</string>
     <string name="haptic_scenario_pull_to_refresh">Потегни за освежавање</string>
     <string name="haptic_scenario_tab_reorder">Преуређивање картица</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Приказ превода</string>
     <string name="settings_color_theme">Тема боја</string>
     <string name="settings_feedback_bug_report">Повратне информације / Пријави проблем</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Окрените телефон екраном надоле да отворите QR библиотеке.</string>
+    <string name="settings_flip_to_library_title">Окрени за приказ QR-а библиотеке</string>
+    <string name="settings_flip_to_library_unsupported">Ваш уређај нема потребни сензор.</string>
     <string name="settings_invert_slider_direction">Обрни смер клизача</string>
     <string name="settings_language">Језик (Language)</string>
     <string name="settings_language_english">Енглески</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Приказ превода</string>
     <string name="settings_color_theme">Тема боја</string>
     <string name="settings_feedback_bug_report">Повратне информације / Пријави проблем</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Обрни смер клизача</string>
     <string name="settings_language">Језик (Language)</string>
     <string name="settings_language_english">Енглески</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Stark</string>
     <string name="haptic_preset_subtle">Mjuk</string>
     <string name="haptic_scenario_class_table_long_press">Långt tryck i schemat</string>
+    <string name="haptic_scenario_flip_to_library">Vänd för att öppna biblioteket</string>
     <string name="haptic_scenario_library_warning">Biblioteksvarning</string>
     <string name="haptic_scenario_pull_to_refresh">Dra för att uppdatera</string>
     <string name="haptic_scenario_tab_reorder">Ändra ordning på flikar</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Visa översättning</string>
     <string name="settings_color_theme">Färgtema</string>
     <string name="settings_feedback_bug_report">Feedback / Rapportera problem</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Vänd telefonen med skärmen nedåt för att öppna bibliotekets QR.</string>
+    <string name="settings_flip_to_library_title">Vänd för att visa bibliotekets QR</string>
+    <string name="settings_flip_to_library_unsupported">Enheten saknar den nödvändiga sensorn.</string>
     <string name="settings_invert_slider_direction">Invertera skjutreglageriktning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Visa översättning</string>
     <string name="settings_color_theme">Färgtema</string>
     <string name="settings_feedback_bug_report">Feedback / Rapportera problem</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invertera skjutreglageriktning</string>
     <string name="settings_language">Språk (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">வலிமையான</string>
     <string name="haptic_preset_subtle">மெல்லிய</string>
     <string name="haptic_scenario_class_table_long_press">வகுப்பு அட்டவணையில் நீண்ட அழுத்தம்</string>
+    <string name="haptic_scenario_flip_to_library">நூலகம் திறக்க திருப்பவும்</string>
     <string name="haptic_scenario_library_warning">நூலக எச்சரிக்கை உரையாடல்</string>
     <string name="haptic_scenario_pull_to_refresh">புதுப்பிக்க இழுக்கவும்</string>
     <string name="haptic_scenario_tab_reorder">தாவல்களை மறுவரிசைப்படுத்தவும்</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">மொழிபெயர்ப்பைக் காட்டு</string>
     <string name="settings_color_theme">நிற தீம்</string>
     <string name="settings_feedback_bug_report">கருத்து / சிக்கல் அறிக்கை</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">நூலக QR திறக்க தொலைபேசியை திரை கீழே வைத்து திருப்பவும்.</string>
+    <string name="settings_flip_to_library_title">நூலக QR காட்ட திருப்பவும்</string>
+    <string name="settings_flip_to_library_unsupported">உங்கள் சாதனத்தில் தேவையான சென்சார் இல்லை.</string>
     <string name="settings_invert_slider_direction">ஸ்லைடர் திசையை மாற்று</string>
     <string name="settings_language">மொழி (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">மொழிபெயர்ப்பைக் காட்டு</string>
     <string name="settings_color_theme">நிற தீம்</string>
     <string name="settings_feedback_bug_report">கருத்து / சிக்கல் அறிக்கை</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">ஸ்லைடர் திசையை மாற்று</string>
     <string name="settings_language">மொழி (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">బలమైన</string>
     <string name="haptic_preset_subtle">మృదువైన</string>
     <string name="haptic_scenario_class_table_long_press">క్లాస్ టేబుల్‌లో సుదీర్ఘ నొక్కుడు</string>
+    <string name="haptic_scenario_flip_to_library">లైబ్రరీ తెరవడానికి తిప్పండి</string>
     <string name="haptic_scenario_library_warning">లైబ్రరీ హెచ్చరిక డైలాగ్</string>
     <string name="haptic_scenario_pull_to_refresh">రిఫ్రెష్ కోసం లాగండి</string>
     <string name="haptic_scenario_tab_reorder">ట్యాబ్‌లను మళ్లీ వరుసలో పెట్టండి</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">అనువాదాన్ని చూపించు</string>
     <string name="settings_color_theme">రంగు థీమ్</string>
     <string name="settings_feedback_bug_report">ఫీడ్‌బ్యాక్ / సమస్య నివేదించు</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">లైబ్రరీ QR తెరవడానికి ఫోన్‌ని స్క్రీన్ కిందకు పెట్టి తిప్పండి.</string>
+    <string name="settings_flip_to_library_title">లైబ్రరీ QR చూపించడానికి తిప్పండి</string>
+    <string name="settings_flip_to_library_unsupported">మీ పరికరానికి అవసరమైన సెన్సార్ లేదు.</string>
     <string name="settings_invert_slider_direction">స్లైడర్ దిశ తిరగబెట్టండి</string>
     <string name="settings_language">భాష (Language)</string>
     <string name="settings_language_english">ఇంగ్లీష్</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">అనువాదాన్ని చూపించు</string>
     <string name="settings_color_theme">రంగు థీమ్</string>
     <string name="settings_feedback_bug_report">ఫీడ్‌బ్యాక్ / సమస్య నివేదించు</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">స్లైడర్ దిశ తిరగబెట్టండి</string>
     <string name="settings_language">భాష (Language)</string>
     <string name="settings_language_english">ఇంగ్లీష్</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">แสดงคำแปล</string>
     <string name="settings_color_theme">ธีมสี</string>
     <string name="settings_feedback_bug_report">ความคิดเห็น / รายงานปัญหา</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">สลับทิศทางแถบเลื่อน</string>
     <string name="settings_language">ภาษา (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">แรง</string>
     <string name="haptic_preset_subtle">เบา</string>
     <string name="haptic_scenario_class_table_long_press">กดค้างที่ตารางเรียน</string>
+    <string name="haptic_scenario_flip_to_library">พลิกเพื่อเปิดห้องสมุด</string>
     <string name="haptic_scenario_library_warning">กล่องโต้ตอบเตือนห้องสมุด</string>
     <string name="haptic_scenario_pull_to_refresh">ดึงเพื่อรีเฟรช</string>
     <string name="haptic_scenario_tab_reorder">เรียงลำดับแท็บใหม่</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">แสดงคำแปล</string>
     <string name="settings_color_theme">ธีมสี</string>
     <string name="settings_feedback_bug_report">ความคิดเห็น / รายงานปัญหา</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">พลิกโทรศัพท์คว่ำหน้าลงเพื่อเปิด QR ห้องสมุด</string>
+    <string name="settings_flip_to_library_title">พลิกเพื่อแสดง QR ห้องสมุด</string>
+    <string name="settings_flip_to_library_unsupported">อุปกรณ์ของคุณไม่มีเซ็นเซอร์ที่จำเป็น</string>
     <string name="settings_invert_slider_direction">สลับทิศทางแถบเลื่อน</string>
     <string name="settings_language">ภาษา (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Çevirisi göster</string>
     <string name="settings_color_theme">Renk teması</string>
     <string name="settings_feedback_bug_report">Geri bildirim / Sorun bildir</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Kaydırıcı yönünü ters çevir</string>
     <string name="settings_language">Dil (Language)</string>
     <string name="settings_language_english">İngilizce</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Güçlü</string>
     <string name="haptic_preset_subtle">Hafif</string>
     <string name="haptic_scenario_class_table_long_press">Ders tablosunda uzun basış</string>
+    <string name="haptic_scenario_flip_to_library">Kütüphaneyi açmak için çevir</string>
     <string name="haptic_scenario_library_warning">Kütüphane uyarı iletişim kutusu</string>
     <string name="haptic_scenario_pull_to_refresh">Yenilemek için çekin</string>
     <string name="haptic_scenario_tab_reorder">Sekmeleri yeniden sırala</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Çevirisi göster</string>
     <string name="settings_color_theme">Renk teması</string>
     <string name="settings_feedback_bug_report">Geri bildirim / Sorun bildir</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Kütüphane QR\'ını açmak için telefonu ekran aşağı gelecek şekilde çevir.</string>
+    <string name="settings_flip_to_library_title">Kütüphane QR\'ını göstermek için çevir</string>
+    <string name="settings_flip_to_library_unsupported">Cihazınızda gerekli sensör bulunmuyor.</string>
     <string name="settings_invert_slider_direction">Kaydırıcı yönünü ters çevir</string>
     <string name="settings_language">Dil (Language)</string>
     <string name="settings_language_english">İngilizce</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Сильна</string>
     <string name="haptic_preset_subtle">Слабка</string>
     <string name="haptic_scenario_class_table_long_press">Довге натискання в розкладі</string>
+    <string name="haptic_scenario_flip_to_library">Перевернути й відкрити бібліотеку</string>
     <string name="haptic_scenario_library_warning">Попередження бібліотеки</string>
     <string name="haptic_scenario_pull_to_refresh">Потягніть для оновлення</string>
     <string name="haptic_scenario_tab_reorder">Зміна порядку вкладок</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показати переклад</string>
     <string name="settings_color_theme">Кольорова тема</string>
     <string name="settings_feedback_bug_report">Відгук / Повідомити про проблему</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Переверніть телефон екраном донизу, щоб відкрити QR бібліотеки.</string>
+    <string name="settings_flip_to_library_title">Перевернути для показу QR бібліотеки</string>
+    <string name="settings_flip_to_library_unsupported">На вашому пристрої немає потрібного датчика.</string>
     <string name="settings_invert_slider_direction">Інвертувати напрямок повзунка</string>
     <string name="settings_language">Мова (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Показати переклад</string>
     <string name="settings_color_theme">Кольорова тема</string>
     <string name="settings_feedback_bug_report">Відгук / Повідомити про проблему</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Інвертувати напрямок повзунка</string>
     <string name="settings_language">Мова (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">مضبوط</string>
     <string name="haptic_preset_subtle">ہلکا</string>
     <string name="haptic_scenario_class_table_long_press">کلاس ٹیبل پر لمبا دباؤ</string>
+    <string name="haptic_scenario_flip_to_library">لائبریری کھولنے کے لیے پلٹائیں</string>
     <string name="haptic_scenario_library_warning">لائبریری وارننگ ڈائیلاگ</string>
     <string name="haptic_scenario_pull_to_refresh">ریفریش کے لیے کھینچیں</string>
     <string name="haptic_scenario_tab_reorder">ٹیب دوبارہ ترتیب دیں</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">ترجمہ دکھائیں</string>
     <string name="settings_color_theme">رنگ تھیم</string>
     <string name="settings_feedback_bug_report">رائے / مسئلہ رپورٹ کریں</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">لائبریری QR کھولنے کے لیے فون کو اسکرین نیچے کر کے پلٹائیں۔</string>
+    <string name="settings_flip_to_library_title">لائبریری QR دکھانے کے لیے پلٹائیں</string>
+    <string name="settings_flip_to_library_unsupported">آپ کے آلے میں مطلوبہ سینسر نہیں ہے۔</string>
     <string name="settings_invert_slider_direction">سلائیڈر کی سمت پلٹائیں</string>
     <string name="settings_language">(Language) زبان</string>
     <string name="settings_language_english">انگریزی</string>

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">ترجمہ دکھائیں</string>
     <string name="settings_color_theme">رنگ تھیم</string>
     <string name="settings_feedback_bug_report">رائے / مسئلہ رپورٹ کریں</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">سلائیڈر کی سمت پلٹائیں</string>
     <string name="settings_language">(Language) زبان</string>
     <string name="settings_language_english">انگریزی</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Hiển thị bản dịch</string>
     <string name="settings_color_theme">Chủ đề màu</string>
     <string name="settings_feedback_bug_report">Phản hồi / Báo lỗi</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Đảo hướng thanh trượt</string>
     <string name="settings_language">Ngôn ngữ (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Mạnh</string>
     <string name="haptic_preset_subtle">Nhẹ</string>
     <string name="haptic_scenario_class_table_long_press">Nhấn giữ trong bảng thời khóa biểu</string>
+    <string name="haptic_scenario_flip_to_library">Lật để mở thư viện</string>
     <string name="haptic_scenario_library_warning">Hộp thoại cảnh báo thư viện</string>
     <string name="haptic_scenario_pull_to_refresh">Kéo để làm mới</string>
     <string name="haptic_scenario_tab_reorder">Sắp xếp lại thẻ</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Hiển thị bản dịch</string>
     <string name="settings_color_theme">Chủ đề màu</string>
     <string name="settings_feedback_bug_report">Phản hồi / Báo lỗi</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">Lật điện thoại úp màn hình xuống để mở QR thư viện.</string>
+    <string name="settings_flip_to_library_title">Lật để hiển thị QR thư viện</string>
+    <string name="settings_flip_to_library_unsupported">Thiết bị của bạn không có cảm biến cần thiết.</string>
     <string name="settings_invert_slider_direction">Đảo hướng thanh trượt</string>
     <string name="settings_language">Ngôn ngữ (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">強</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">課程表長按</string>
+    <string name="haptic_scenario_flip_to_library">翻轉開圖書館</string>
     <string name="haptic_scenario_library_warning">圖書館警告視窗</string>
     <string name="haptic_scenario_pull_to_refresh">下拉重新整理</string>
     <string name="haptic_scenario_tab_reorder">分頁編輯器重新排列</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">將手機屏幕向下即可開啟圖書館 QR。</string>
+    <string name="settings_flip_to_library_title">翻轉顯示圖書館 QR</string>
+    <string name="settings_flip_to_library_unsupported">此裝置冇所需嘅感應器。</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-yue-rHK/strings.xml
+++ b/app/src/main/res/values-yue-rHK/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">颜色主题</string>
     <string name="settings_feedback_bug_report">回馈/问题回报</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">反转滑条方向</string>
     <string name="settings_language">语言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">强</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">课程表长按</string>
+    <string name="haptic_scenario_flip_to_library">翻转打开图书馆</string>
     <string name="haptic_scenario_library_warning">图书馆警告对话框</string>
     <string name="haptic_scenario_pull_to_refresh">下拉刷新</string>
     <string name="haptic_scenario_tab_reorder">标签编辑器重新排序</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">颜色主题</string>
     <string name="settings_feedback_bug_report">回馈/问题回报</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">将手机屏幕朝下即可打开图书馆 QR。</string>
+    <string name="settings_flip_to_library_title">翻转显示图书馆 QR</string>
+    <string name="settings_flip_to_library_unsupported">此设备缺少所需的传感器。</string>
     <string name="settings_invert_slider_direction">反转滑条方向</string>
     <string name="settings_language">语言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">強</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">課程表長按</string>
+    <string name="haptic_scenario_flip_to_library">翻轉開圖書館</string>
     <string name="haptic_scenario_library_warning">圖書館警告視窗</string>
     <string name="haptic_scenario_pull_to_refresh">下拉重新整理</string>
     <string name="haptic_scenario_tab_reorder">分頁編輯器重新排列</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">將手機屏幕向下即可開啟圖書館 QR。</string>
+    <string name="settings_flip_to_library_title">翻轉顯示圖書館 QR</string>
+    <string name="settings_flip_to_library_unsupported">此裝置冇所需嘅感應器。</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">強</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">課程表長按</string>
+    <string name="haptic_scenario_flip_to_library">翻轉開圖書館</string>
     <string name="haptic_scenario_library_warning">圖書館警告視窗</string>
     <string name="haptic_scenario_pull_to_refresh">下拉重新整理</string>
     <string name="haptic_scenario_tab_reorder">分頁編輯器重新排列</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">將手機屏幕向下即可開啟圖書館 QR。</string>
+    <string name="settings_flip_to_library_title">翻轉顯示圖書館 QR</string>
+    <string name="settings_flip_to_library_unsupported">此裝置冇所需嘅感應器。</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rMO/strings.xml
+++ b/app/src/main/res/values-zh-rMO/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">颜色主题</string>
     <string name="settings_feedback_bug_report">回馈/问题回报</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">反转滑条方向</string>
     <string name="settings_language">语言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rSG/strings.xml
+++ b/app/src/main/res/values-zh-rSG/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">强</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">课程表长按</string>
+    <string name="haptic_scenario_flip_to_library">翻转打开图书馆</string>
     <string name="haptic_scenario_library_warning">图书馆警告对话框</string>
     <string name="haptic_scenario_pull_to_refresh">下拉刷新</string>
     <string name="haptic_scenario_tab_reorder">标签编辑器重新排序</string>
@@ -555,9 +556,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">颜色主题</string>
     <string name="settings_feedback_bug_report">回馈/问题回报</string>
-    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
-    <string name="settings_flip_to_library_title">Flip to show library QR</string>
-    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
+    <string name="settings_flip_to_library_summary">将手机屏幕朝下即可打开图书馆 QR。</string>
+    <string name="settings_flip_to_library_title">翻转显示图书馆 QR</string>
+    <string name="settings_flip_to_library_unsupported">此设备缺少所需的传感器。</string>
     <string name="settings_invert_slider_direction">反转滑条方向</string>
     <string name="settings_language">语言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">強</string>
     <string name="haptic_preset_subtle">弱</string>
     <string name="haptic_scenario_class_table_long_press">課表長按</string>
+    <string name="haptic_scenario_flip_to_library">翻轉開啟圖書館</string>
     <string name="haptic_scenario_library_warning">圖書館警告對話框</string>
     <string name="haptic_scenario_pull_to_refresh">下拉重新整理</string>
     <string name="haptic_scenario_tab_reorder">分頁編輯器拖移</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">顏色主題</string>
     <string name="settings_feedback_bug_report">回饋/問題回報</string>
+    <string name="settings_flip_to_library_summary">將手機螢幕朝下即可開啟圖書館 QR。</string>
+    <string name="settings_flip_to_library_title">翻轉顯示圖書館 QR</string>
+    <string name="settings_flip_to_library_unsupported">此裝置缺少所需的感應器。</string>
     <string name="settings_invert_slider_direction">反轉滑條方向</string>
     <string name="settings_language">語言 (Language)</string>
     <string name="settings_language_english">English</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,7 @@
     <string name="haptic_preset_strong">Strong</string>
     <string name="haptic_preset_subtle">Subtle</string>
     <string name="haptic_scenario_class_table_long_press">Class table long-press</string>
+    <string name="haptic_scenario_flip_to_library">Flip to open library</string>
     <string name="haptic_scenario_library_warning">Library warning dialog</string>
     <string name="haptic_scenario_pull_to_refresh">Pull to refresh</string>
     <string name="haptic_scenario_tab_reorder">Tab editor reorder</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -555,6 +555,9 @@
     <string name="settings_classroom_mandarin_display_translated">Display translated</string>
     <string name="settings_color_theme">Color theme</string>
     <string name="settings_feedback_bug_report">Feedback / Report issue</string>
+    <string name="settings_flip_to_library_summary">Flip your phone face-down to open the library QR.</string>
+    <string name="settings_flip_to_library_title">Flip to show library QR</string>
+    <string name="settings_flip_to_library_unsupported">Your device doesn\'t have the required sensor.</string>
     <string name="settings_invert_slider_direction">Invert slider direction</string>
     <string name="settings_language">Language</string>
     <string name="settings_language_english">English</string>

--- a/app/src/test/java/org/ntust/app/tigerduck/sensor/FlipDetectorAngleTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/sensor/FlipDetectorAngleTest.kt
@@ -1,0 +1,81 @@
+package org.ntust.app.tigerduck.sensor
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Tests for [FlipDetector.isFaceDown] — pure JVM tests over the rotation-matrix
+ * thresholding. Inputs are authored as quaternions `(x*sin(θ/2), y*sin(θ/2),
+ * z*sin(θ/2), cos(θ/2))`; [FlipDetector.isFaceDown] extracts R[8] from the
+ * quaternion via pure arithmetic so no Android SDK stub is required.
+ *
+ * Vector axes used (Android device frame):
+ *   X = right, Y = up (top of screen), Z = out of screen (toward user).
+ * A face-up device has its Z-axis pointing up in world coords (R[8] ≈ +1).
+ * A face-down device has its Z-axis pointing down (R[8] ≈ -1).
+ */
+class FlipDetectorAngleTest {
+
+    @Test
+    fun `face up flat is not face down`() {
+        // Identity rotation: device Z-axis is world Z-axis (up).
+        assertFalse(FlipDetector.isFaceDown(identity()))
+    }
+
+    @Test
+    fun `face down flat is face down`() {
+        // 180-degree rotation about world X-axis flips the device upside down.
+        assertTrue(FlipDetector.isFaceDown(rotateAroundX(PI)))
+    }
+
+    @Test
+    fun `face down tilted 20 degrees is still face down`() {
+        // 180 - 20 = 160 deg about X: screen mostly faces down, 20-deg tilt.
+        assertTrue(FlipDetector.isFaceDown(rotateAroundX(PI - 20.0 * PI / 180.0)))
+    }
+
+    @Test
+    fun `face down tilted 45 degrees is rejected as too tilted`() {
+        // 180 - 45 = 135 deg about X: screen tilted past the threshold (~32 deg
+        // of flat). This is the "phone in pocket leaning against thigh" geometry
+        // we don't want to fire on.
+        assertFalse(FlipDetector.isFaceDown(rotateAroundX(PI - 45.0 * PI / 180.0)))
+    }
+
+    @Test
+    fun `portrait vertical screen toward user is not face down`() {
+        // 90 deg about X: device standing on its bottom edge, screen vertical.
+        assertFalse(FlipDetector.isFaceDown(rotateAroundX(PI / 2.0)))
+    }
+
+    @Test
+    fun `landscape vertical is not face down`() {
+        // 90 deg about Y: device on its side, screen vertical.
+        assertFalse(FlipDetector.isFaceDown(rotateAroundY(PI / 2.0)))
+    }
+
+    // --- helpers --------------------------------------------------------
+
+    /** Identity rotation = device aligned with world frame, screen up. */
+    private fun identity(): FloatArray = floatArrayOf(0f, 0f, 0f, 1f)
+
+    /**
+     * Rotation vector for an angle [theta] around the X-axis.
+     * Format: `(x*sin(θ/2), y*sin(θ/2), z*sin(θ/2), cos(θ/2))`.
+     */
+    private fun rotateAroundX(theta: Double): FloatArray {
+        val s = sin(theta / 2.0).toFloat()
+        val c = cos(theta / 2.0).toFloat()
+        return floatArrayOf(s, 0f, 0f, c)
+    }
+
+    private fun rotateAroundY(theta: Double): FloatArray {
+        val s = sin(theta / 2.0).toFloat()
+        val c = cos(theta / 2.0).toFloat()
+        return floatArrayOf(0f, s, 0f, c)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/sensor/FlipDetectorDebounceTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/sensor/FlipDetectorDebounceTest.kt
@@ -1,0 +1,103 @@
+package org.ntust.app.tigerduck.sensor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+private val DEBOUNCE_NANOS = FlipDetector.DEBOUNCE_NANOS
+
+class FlipDetectorDebounceTest {
+
+    @Test
+    fun `unknown stays unknown until the debounce window elapses`() {
+        val s0 = FlipDetector.DetectorState.initial()
+        val s1 = FlipDetector.nextState(s0, isFaceDown = true, timestampNanos = 0L)
+        assertEquals(FlipDetector.Phase.Unknown, s1.phase)
+        assertFalse(s1.fired)
+
+        // Halfway through the window: still Unknown.
+        val s2 = FlipDetector.nextState(s1, isFaceDown = true, timestampNanos = DEBOUNCE_NANOS / 2)
+        assertEquals(FlipDetector.Phase.Unknown, s2.phase)
+    }
+
+    @Test
+    fun `cold start face down does not fire the callback`() {
+        // Even after holding face-down past the debounce window, an
+        // Unknown -> FaceDown transition must not fire — the user did not
+        // intentionally flip from upright.
+        val s0 = FlipDetector.DetectorState.initial()
+        val s1 = FlipDetector.nextState(s0, isFaceDown = true, timestampNanos = 0L)
+        val s2 = FlipDetector.nextState(s1, isFaceDown = true, timestampNanos = DEBOUNCE_NANOS + 1)
+        assertEquals(FlipDetector.Phase.FaceDown, s2.phase)
+        assertFalse("Unknown -> FaceDown must not fire", s2.fired)
+    }
+
+    @Test
+    fun `flip from upright to face down fires after debounce window`() {
+        // Seed: hold upright past the window so state settles to Upright.
+        var s = FlipDetector.DetectorState.initial()
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = 0L)
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = DEBOUNCE_NANOS + 1)
+        assertEquals(FlipDetector.Phase.Upright, s.phase)
+        assertFalse(s.fired)
+
+        // Start flipping at t = window + 1ns.
+        val flipStart = DEBOUNCE_NANOS + 1
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = flipStart + 1)
+        // Still Upright — window not elapsed yet.
+        assertEquals(FlipDetector.Phase.Upright, s.phase)
+        assertFalse(s.fired)
+
+        // Past the window: transition fires.
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = flipStart + DEBOUNCE_NANOS + 1)
+        assertEquals(FlipDetector.Phase.FaceDown, s.phase)
+        assertTrue("Upright -> FaceDown must fire", s.fired)
+    }
+
+    @Test
+    fun `brief face down flicker does not fire`() {
+        // Seed Upright.
+        var s = FlipDetector.DetectorState.initial()
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = 0L)
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = DEBOUNCE_NANOS + 1)
+        assertEquals(FlipDetector.Phase.Upright, s.phase)
+
+        // Face-down for half the window, then back to upright.
+        val flicker = DEBOUNCE_NANOS + 1
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = flicker)
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = flicker + DEBOUNCE_NANOS / 2)
+        assertEquals(FlipDetector.Phase.Upright, s.phase)
+        assertFalse(s.fired)
+    }
+
+    @Test
+    fun `subsequent flip after rearm fires again`() {
+        var s = FlipDetector.DetectorState.initial()
+
+        // Seed Upright.
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = 0L)
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = DEBOUNCE_NANOS + 1)
+
+        // First flip fires.
+        val t1 = DEBOUNCE_NANOS + 1
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = t1)
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = t1 + DEBOUNCE_NANOS + 1)
+        assertTrue(s.fired)
+        assertEquals(FlipDetector.Phase.FaceDown, s.phase)
+
+        // Re-arm: hold upright past the window.
+        val t2 = t1 + DEBOUNCE_NANOS + 1
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = t2)
+        s = FlipDetector.nextState(s, isFaceDown = false, timestampNanos = t2 + DEBOUNCE_NANOS + 1)
+        assertEquals(FlipDetector.Phase.Upright, s.phase)
+        assertFalse("rearm transition must not fire", s.fired)
+
+        // Second flip fires again.
+        val t3 = t2 + DEBOUNCE_NANOS + 1
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = t3)
+        s = FlipDetector.nextState(s, isFaceDown = true, timestampNanos = t3 + DEBOUNCE_NANOS + 1)
+        assertTrue(s.fired)
+        assertEquals(FlipDetector.Phase.FaceDown, s.phase)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/ui/haptics/HapticsTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/ui/haptics/HapticsTest.kt
@@ -8,7 +8,7 @@ class HapticsTest {
     @Test
     fun `tunable filter excludes library warning`() {
         val tunable = HapticScenario.tunable
-        assertEquals(5, tunable.size)
+        assertEquals(6, tunable.size)
         assert(HapticScenario.LibraryWarning !in tunable)
     }
 


### PR DESCRIPTION
#86 

## Summary

- New opt-in gesture: flip the phone face-down to jump to the Library QR screen. Lives behind a Settings toggle (default off); the toggle is greyed out on devices without a rotation-vector sensor and disabled when the library feature itself is off.
- Detection uses the rotation vector's R[8] (cos of screen-normal vs world-up) with a 400 ms debounce. Cold-start in an `Unknown` phase so opening the app while already face-down does NOT auto-trigger; an Upright→FaceDown transition is the only thing that fires.
- Fires a tunable haptic (`HapticScenario.FlipToLibrary`, default Medium / Medium) only when the gate fully passes — library feature enabled, signed-in to library, and not already on Library. The scenario is exposed in the Vibration Customization screen so the user can adjust or zero it out.
- Localized in all 55 source locales. Moves the existing `settings_flip_to_library_*` strings from the ad-hoc Android-side commit (f72d71e) into the canonical `shared` group of the `app-translation` submodule so iOS can reuse them; non-en/zh-Hant locales now get real translations instead of the English placeholder.

## Test plan

- [ ] On a device with a rotation-vector sensor: enable the toggle, sign into the library, flip the phone — verify nav lands on Library QR and a single short buzz fires. Flip back upright + back down within ~400 ms repeatedly: only one fire per Upright→FaceDown transition.
- [ ] Open the app while the phone is already face-down — should NOT auto-navigate.
- [ ] Library not signed in: flipping is silent (no nav, no buzz).
- [ ] Library feature off in Settings: the flip toggle is greyed out and a flip does nothing.
- [ ] Vibration Customization screen: `Flip to open library` row is present between `Class table long-press` and `Library warning dialog`; the sliders work, preview fires, Reset restores defaults.
- [ ] Emulator / device without a rotation-vector sensor: toggle shows the "device doesn't have the required sensor" hint and is non-interactive.
- [ ] Unit tests pass: `FlipDetectorAngleTest`, `FlipDetectorDebounceTest`, `HapticsTest`.