### PR TITLE
refactor: restructure announcements/ and update/ packages

### DIFF
--- a/.claude/skills/upgrade-safe-persistence/SKILL.md
+++ b/.claude/skills/upgrade-safe-persistence/SKILL.md
@@ -42,7 +42,6 @@ You're about to edit ANY of:
     - `data.model.**`
     - `data.cache.DataCache$*`
     - `wear.WearScheduleBridge$*`
-    - `announcements.{BulletinSummary, BulletinDetail, BulletinListResponse, OrgLabel, TagLabel, TaxonomyResponse, SubscriptionRule, SubscriptionsResponse, SubscriptionsPutRequest}`
     - `org.ntust.app.tigerduck.shared.**`
 - `app/proguard-rules.pro` itself
 

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -24,11 +24,10 @@ launch after upgrade:
 
 - `shared/src/main/java/org/ntust/app/tigerduck/shared/Course.kt`
 - Any class kept by `app/proguard-rules.pro`:
-  `org.ntust.app.tigerduck.shared.**`, `network.model.**`,
-  `data.model.**`, `data.cache.DataCache$*`, `wear.WearScheduleBridge$*`,
-  `announcements.{BulletinSummary, BulletinDetail, BulletinListResponse,
-  OrgLabel, TagLabel, TaxonomyResponse, SubscriptionRule,
-  SubscriptionsResponse, SubscriptionsPutRequest}`
+  `org.ntust.app.tigerduck.shared.**`, `network.model.**` (includes
+  Bulletin DTOs moved from announcements/), `data.model.**` (includes
+  WhatsNewContent moved from update/), `data.cache.DataCache$*`,
+  `wear.WearScheduleBridge$*`
 - `app/src/play/java/org/ntust/app/tigerduck/wear/WearScheduleBridge.kt`
   (`CourseDto` wire format)
 - `wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,8 @@ before modifying any of:
 - `app/src/play/java/org/ntust/app/tigerduck/wear/WearScheduleBridge.kt`
 - `wear/src/main/java/org/ntust/app/tigerduck/wear/data/SchedulePersistence.kt`
 - `app/proguard-rules.pro` (R8 keep list)
-- Anything under `network/model/**`, `data/model/**`, or the announcements
-  DTOs listed in `proguard-rules.pro`
+- Anything under `network/model/**`, `data/model/**` (both are wildcard-
+  kept by R8 — includes Bulletin DTOs and WhatsNewContent)
 
 **The one-line rule:** any new field added to a Gson-deserialized data
 class persisted across upgrades must be **nullable** (`String?`), a

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -7,23 +7,7 @@
 # and WearScheduleBridge$CourseDto.<init> NPEs from TigerDuckApp.onCreate
 # on the first open after upgrade.
 -keep class org.ntust.app.tigerduck.shared.** { *; }
-# Gson DTOs that live outside the model.** packages. Most fields here lack
-# @SerializedName, so without { *; } R8 renames the JVM fields and Gson
-# silently deserializes nulls — same failure mode as the TypeToken bug.
--keep class org.ntust.app.tigerduck.announcements.BulletinSummary { *; }
--keep class org.ntust.app.tigerduck.announcements.BulletinDetail { *; }
--keep class org.ntust.app.tigerduck.announcements.BulletinListResponse { *; }
--keep class org.ntust.app.tigerduck.announcements.OrgLabel { *; }
--keep class org.ntust.app.tigerduck.announcements.TagLabel { *; }
--keep class org.ntust.app.tigerduck.announcements.TaxonomyResponse { *; }
--keep class org.ntust.app.tigerduck.announcements.SubscriptionRule { *; }
--keep class org.ntust.app.tigerduck.announcements.SubscriptionsResponse { *; }
--keep class org.ntust.app.tigerduck.announcements.SubscriptionsPutRequest { *; }
 -keep class org.ntust.app.tigerduck.data.cache.DataCache$* { *; }
-# What's-new content (assets/whatsnew.json) is Gson-deserialized into
-# WhatsNewContent. Without this keep, R8 renames its fields and Gson reads
-# nulls — same failure mode as the other unannotated DTOs above.
--keep class org.ntust.app.tigerduck.update.WhatsNewContent { *; }
 # Wire DTO Gson-serializes to the watch. Unannotated fields, so R8 must
 # not rename them — otherwise the phone sends obfuscated JSON keys the
 # watch-side CourseWire can't recognize.

--- a/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/fdroid/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.ntust.app.tigerduck.data.model.ManualCheckResult
+import org.ntust.app.tigerduck.data.model.PendingUpdate
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/MainActivity.kt
@@ -45,8 +45,8 @@ import org.ntust.app.tigerduck.ui.screen.whatsnew.WhatsNewDialog
 import org.ntust.app.tigerduck.ui.theme.TigerDuckAppTheme
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import org.ntust.app.tigerduck.update.UpdateChecker
-import org.ntust.app.tigerduck.update.UpdatePromptDialog
-import org.ntust.app.tigerduck.update.WhatsNewContent
+import org.ntust.app.tigerduck.ui.screen.update.UpdatePromptDialog
+import org.ntust.app.tigerduck.data.model.WhatsNewContent
 import org.ntust.app.tigerduck.update.WhatsNewGate
 import org.ntust.app.tigerduck.update.WhatsNewRepository
 import javax.inject.Inject

--- a/app/src/main/java/org/ntust/app/tigerduck/auth/AuthService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/auth/AuthService.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.ntust.app.tigerduck.R
-import org.ntust.app.tigerduck.announcements.BulletinCache
-import org.ntust.app.tigerduck.announcements.BulletinReadStateStore
+import org.ntust.app.tigerduck.data.cache.BulletinCache
+import org.ntust.app.tigerduck.data.BulletinReadStateStore
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import org.ntust.app.tigerduck.di.ApplicationScope

--- a/app/src/main/java/org/ntust/app/tigerduck/data/BulletinReadStateStore.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/BulletinReadStateStore.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.data
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/app/src/main/java/org/ntust/app/tigerduck/data/BulletinRepository.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/BulletinRepository.kt
@@ -1,7 +1,10 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.data
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.ntust.app.tigerduck.network.model.BulletinDetail
+import org.ntust.app.tigerduck.network.model.BulletinSummary
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/BulletinCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/BulletinCache.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.data.cache
 
 import android.content.Context
 import android.util.Log
@@ -9,6 +9,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.ntust.app.tigerduck.network.model.BulletinDetail
+import org.ntust.app.tigerduck.network.model.BulletinSummary
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/ManualCheckResult.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/ManualCheckResult.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.update
+package org.ntust.app.tigerduck.data.model
 
 /**
  * Outcome of a manual "Check for updates" tap from Settings → About.

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/PendingUpdate.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/PendingUpdate.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.update
+package org.ntust.app.tigerduck.data.model
 
 /**
  * One pending "an update is available" prompt waiting to be surfaced. Lives in

--- a/app/src/main/java/org/ntust/app/tigerduck/data/model/WhatsNewModels.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/model/WhatsNewModels.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.update
+package org.ntust.app.tigerduck.data.model
 
 /**
  * One localized "What's new" block, deserialized by Gson from

--- a/app/src/main/java/org/ntust/app/tigerduck/network/ApiEndpointOverride.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/ApiEndpointOverride.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.network
 
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.ntust.app.tigerduck.BuildConfig

--- a/app/src/main/java/org/ntust/app/tigerduck/network/BulletinApiClient.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/BulletinApiClient.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.network
 
 import android.util.Log
 import com.google.gson.Gson
@@ -12,6 +12,12 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
 import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.network.model.BulletinDetail
+import org.ntust.app.tigerduck.network.model.BulletinListResponse
+import org.ntust.app.tigerduck.network.model.SubscriptionRule
+import org.ntust.app.tigerduck.network.model.SubscriptionsPutRequest
+import org.ntust.app.tigerduck.network.model.SubscriptionsResponse
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app/src/main/java/org/ntust/app/tigerduck/network/model/BulletinModels.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/model/BulletinModels.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.network.model
 
 import com.google.gson.annotations.SerializedName
 

--- a/app/src/main/java/org/ntust/app/tigerduck/push/PushApiClient.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/push/PushApiClient.kt
@@ -10,7 +10,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.logging.HttpLoggingInterceptor
 import org.ntust.app.tigerduck.BuildConfig
-import org.ntust.app.tigerduck.announcements.resolveAnnouncementEndpoint
+import org.ntust.app.tigerduck.network.resolveAnnouncementEndpoint
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/navigation/AppNavigation.kt
@@ -51,9 +51,9 @@ import kotlinx.coroutines.flow.first
 import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.R
-import org.ntust.app.tigerduck.announcements.AnnouncementDetailScreen
-import org.ntust.app.tigerduck.announcements.AnnouncementsScreen
-import org.ntust.app.tigerduck.announcements.SubscriptionSettingsScreen
+import org.ntust.app.tigerduck.ui.screen.announcements.AnnouncementDetailScreen
+import org.ntust.app.tigerduck.ui.screen.announcements.AnnouncementsScreen
+import org.ntust.app.tigerduck.ui.screen.announcements.SubscriptionSettingsScreen
 import org.ntust.app.tigerduck.data.model.AppFeature
 import org.ntust.app.tigerduck.shared.clock.AppClock
 import org.ntust.app.tigerduck.ui.AppState

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementDetailScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementDetailScreen.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent
@@ -45,6 +45,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mikepenz.markdown.m3.Markdown
 import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.network.model.BulletinSummary
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
+import org.ntust.app.tigerduck.network.model.localizedTagLabel
+import org.ntust.app.tigerduck.network.model.orgLabel
 
 @OptIn(
     ExperimentalLayoutApi::class,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementDetailViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementDetailViewModel.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -11,6 +11,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.ntust.app.tigerduck.data.BulletinReadStateStore
+import org.ntust.app.tigerduck.data.BulletinRepository
+import org.ntust.app.tigerduck.data.cache.BulletinCache
+import org.ntust.app.tigerduck.network.BulletinApiClient
+import org.ntust.app.tigerduck.network.model.BulletinDetail
+import org.ntust.app.tigerduck.network.model.BulletinSummary
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 import javax.inject.Inject
 
 @HiltViewModel

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsScreen.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.spring
@@ -80,6 +80,10 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.network.model.BulletinSummary
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
+import org.ntust.app.tigerduck.network.model.localizedTagLabel
+import org.ntust.app.tigerduck.network.model.orgLabel
 import org.ntust.app.tigerduck.ui.component.EmptyStateView
 import org.ntust.app.tigerduck.ui.component.PageHeader
 import org.ntust.app.tigerduck.ui.component.SyncIndicator

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/AnnouncementsViewModel.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -14,7 +14,13 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.ntust.app.tigerduck.data.BulletinReadStateStore
+import org.ntust.app.tigerduck.data.BulletinRepository
+import org.ntust.app.tigerduck.data.cache.BulletinCache
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.network.BulletinApiClient
+import org.ntust.app.tigerduck.network.model.BulletinSummary
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 import java.time.Instant
 import javax.inject.Inject
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionRuleEditorScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionRuleEditorScreen.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -44,6 +44,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.network.model.SubscriptionRule
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 
 /**
  * Full-screen rule editor. Replaces the prior `AlertDialog`-based editor

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import android.Manifest
 import android.os.Build
@@ -62,6 +62,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.ntust.app.tigerduck.BuildConfig
 import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.network.model.SubscriptionRule
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
+import org.ntust.app.tigerduck.network.model.localizedTagLabel
+import org.ntust.app.tigerduck.network.model.orgLabel
 import org.ntust.app.tigerduck.notification.AppPermission
 import org.ntust.app.tigerduck.notification.SystemPermissions
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsViewModel.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.announcements
+package org.ntust.app.tigerduck.ui.screen.announcements
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,6 +12,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
+import org.ntust.app.tigerduck.data.BulletinRepository
+import org.ntust.app.tigerduck.network.BulletinApiClient
+import org.ntust.app.tigerduck.network.model.SubscriptionRule
+import org.ntust.app.tigerduck.network.model.TaxonomyResponse
 import org.ntust.app.tigerduck.notification.SystemPermissions
 import org.ntust.app.tigerduck.push.PushIdentity
 import javax.inject.Inject

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/debug/ApiEndpointDebugScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/debug/ApiEndpointDebugScreen.kt
@@ -41,8 +41,8 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.ntust.app.tigerduck.announcements.OverrideValidator
-import org.ntust.app.tigerduck.announcements.resolveAnnouncementEndpoint
+import org.ntust.app.tigerduck.network.OverrideValidator
+import org.ntust.app.tigerduck.network.resolveAnnouncementEndpoint
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.push.PushRegistrationService
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/SettingsScreen.kt
@@ -96,11 +96,11 @@ import org.ntust.app.tigerduck.ui.screen.whatsnew.WhatsNewDialog
 import org.ntust.app.tigerduck.ui.theme.ContentAlpha
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import org.ntust.app.tigerduck.ui.theme.tigerDuckSwitchColors
-import org.ntust.app.tigerduck.update.ManualCheckResult
+import org.ntust.app.tigerduck.data.model.ManualCheckResult
 import org.ntust.app.tigerduck.update.UpdateChecker
-import org.ntust.app.tigerduck.update.WhatsNewContent
+import org.ntust.app.tigerduck.data.model.WhatsNewContent
 import org.ntust.app.tigerduck.update.WhatsNewRepository
-import org.ntust.app.tigerduck.update.replaceIosArg
+import org.ntust.app.tigerduck.util.replaceIosArg
 import java.util.Locale
 
 @Composable

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/update/UpdatePromptDialog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/update/UpdatePromptDialog.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.update
+package org.ntust.app.tigerduck.ui.screen.update
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.ntust.app.tigerduck.R
+import org.ntust.app.tigerduck.data.model.PendingUpdate
+import org.ntust.app.tigerduck.util.replaceIosArg
 
 /**
  * Three-action "an update is ready" prompt, mounted at the app root by

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/whatsnew/WhatsNewDialog.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import org.ntust.app.tigerduck.ui.component.TigerDuckDialog
-import org.ntust.app.tigerduck.update.WhatsNewContent
+import org.ntust.app.tigerduck.data.model.WhatsNewContent
 
 /**
  * Shown on the first launch after an upgrade. Content comes from

--- a/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/update/WhatsNewRepository.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.qualifiers.ApplicationContext
+import org.ntust.app.tigerduck.data.model.WhatsNewContent
 import org.ntust.app.tigerduck.update.WhatsNewRepository.Companion.parse
 import org.ntust.app.tigerduck.update.WhatsNewRepository.Companion.select
 import javax.inject.Inject

--- a/app/src/main/java/org/ntust/app/tigerduck/util/IosPlaceholder.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/util/IosPlaceholder.kt
@@ -1,4 +1,4 @@
-package org.ntust.app.tigerduck.update
+package org.ntust.app.tigerduck.util
 
 /**
  * Substitute the iOS-style positional placeholder `%1$@` (or `%2$@`, etc.) with

--- a/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/update/UpdateChecker.kt
@@ -13,6 +13,8 @@ import com.google.android.play.core.install.model.UpdateAvailability
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.ntust.app.tigerduck.data.model.ManualCheckResult
+import org.ntust.app.tigerduck.data.model.PendingUpdate
 import kotlinx.coroutines.flow.asStateFlow
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import javax.inject.Inject


### PR DESCRIPTION
## Summary
- **§3.1** Split flat `announcements/` package by layer: DTOs → `network/model/`, API client → `network/`, cache → `data/cache/`, repository + read-state → `data/`, screens + ViewModels → `ui/screen/announcements/`
- **§3.2** Extract misplaced files from `update/`: models → `data/model/`, dialog → `ui/screen/update/`, `IosPlaceholder` → `util/`. Gates + `WhatsNewRepository` stay in `update/`
- **§3.3** Rename `AnnouncementApiOverride` → `ApiEndpointOverride` in `network/` (consumed cross-package by push + debug screens)
- Removed 10 individual R8 keep rules (9 announcements DTOs + `WhatsNewContent`) — all now covered by existing `network.model.**` and `data.model.**` wildcards
- Updated `.greptile/rules.md`, `CLAUDE.md`, and upgrade-safe-persistence skill to reflect new locations

Depends on #103 (`build/r8-strict-mode`) which enables strict R8 mode — any stale keep rule after this move would fail the build instead of silently breaking serialization.

Audit findings: §3.1, §3.2, §3.3

## Verification
- All three R8 strict-mode release builds pass (playRelease, fdroidRelease, wearRelease)
- Both flavor debug compiles pass
- All unit tests pass

## Test plan
- [ ] Announcements list loads, detail opens, back-navigates
- [ ] Subscription settings screen loads, rules editable
- [ ] What's New dialog shows on version upgrade
- [ ] Update prompt dialog appears (play flavor, when update available)
- [ ] Debug API endpoint override still works
- [ ] Upgrade from current Play Store version does not crash (cache deserialization intact)