### PR TITLE
fix: run DataMigration in Application.onCreate before BootReceiver

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/TigerDuckApp.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/TigerDuckApp.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.DataMigration
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.preferences.AppLanguageManager
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
@@ -43,6 +44,9 @@ class TigerDuckApp : Application(), Configuration.Provider {
     lateinit var wearBridge: WearScheduleBridge
 
     @Inject
+    lateinit var dataMigration: DataMigration
+
+    @Inject
     lateinit var debugClockController: DebugClockController
 
     // The DI singleton, not a private scope: it carries a logging
@@ -61,6 +65,7 @@ class TigerDuckApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        dataMigration.run()
         debugClockController.bootstrap()
         AppLanguageManager.apply(appPreferences.appLanguage)
         createNotificationChannels()

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -45,13 +45,9 @@ class DataMigration @Inject constructor(
         NeedsUserReset,
     }
 
-    @Volatile
-    private var cachedOutcome: Outcome? = null
+    private val outcome: Outcome by lazy(LazyThreadSafetyMode.SYNCHRONIZED) { doRun() }
 
-    fun run(): Outcome {
-        cachedOutcome?.let { return it }
-        return doRun().also { cachedOutcome = it }
-    }
+    fun run(): Outcome = outcome
 
     private fun doRun(): Outcome {
         // If Keystore corruption forced CredentialManager to rebuild the

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -2,9 +2,12 @@ package org.ntust.app.tigerduck.data
 
 import android.content.Context
 import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * One-shot runner for on-device data migrations.
@@ -22,9 +25,15 @@ import java.io.File
  *      credential store, user downgraded the app, old-and-unsupported
  *      layout) — [run] returns [Outcome.NeedsUserReset] and the UI is
  *      expected to show a "please re-login and reconfigure" prompt.
+ *
+ * [run] is called from [org.ntust.app.tigerduck.TigerDuckApp.onCreate] so
+ * migrations complete before any component (BootReceiver, WearScheduleBridge,
+ * AppState) reads [org.ntust.app.tigerduck.data.cache.DataCache]. The result
+ * is cached; subsequent calls return the same outcome without re-running.
  */
-class DataMigration(
-    private val context: Context,
+@Singleton
+class DataMigration @Inject constructor(
+    @param:ApplicationContext private val context: Context,
     private val prefs: AppPreferences,
     private val credentials: CredentialManager,
 ) {
@@ -36,7 +45,15 @@ class DataMigration(
         NeedsUserReset,
     }
 
+    @Volatile
+    private var cachedOutcome: Outcome? = null
+
     fun run(): Outcome {
+        cachedOutcome?.let { return it }
+        return doRun().also { cachedOutcome = it }
+    }
+
+    private fun doRun(): Outcome {
         // If Keystore corruption forced CredentialManager to rebuild the
         // credential store from scratch, the user's logins are gone and
         // the app is effectively logged out. Surface it so the dialog
@@ -127,9 +144,8 @@ class DataMigration(
                 }
         }
 
-        // Mirrors DataCache. Kept in sync deliberately — DataMigration must
-        // run before any DataCache access, so we don't import the cache
-        // class here to avoid pulling DI into the migration boot path.
+        // Mirrors DataCache constants. Kept in sync deliberately so
+        // DataMigration doesn't depend on the DataCache class.
         private const val CACHE_SUBDIR = "TigerDuckCache"
         private const val USER_DATA_SUBDIR = "TigerDuckData"
         private const val LEGACY_COURSES_FILENAME = "courses.json"

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
@@ -1,6 +1,5 @@
 package org.ntust.app.tigerduck.ui
 
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableIntStateOf
@@ -9,7 +8,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -47,7 +45,7 @@ class AppState @Inject constructor(
     val calendarService: CalendarService,
     val systemPermissions: SystemPermissions,
     private val widgetUpdater: org.ntust.app.tigerduck.widget.WidgetUpdater,
-    @param:ApplicationContext private val appContext: Context,
+    private val dataMigration: DataMigration,
 ) {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var syncJob: Job? = null
@@ -67,7 +65,7 @@ class AppState @Inject constructor(
     val needsUserReset: StateFlow<Boolean> = _needsUserReset
 
     init {
-        when (DataMigration(appContext, prefs, credentials).run()) {
+        when (dataMigration.run()) {
             DataMigration.Outcome.NeedsUserReset -> _needsUserReset.value = true
             DataMigration.Outcome.Ok -> Unit
         }


### PR DESCRIPTION
## Summary
- Make `DataMigration` a Hilt `@Singleton` with an idempotent `run()` (cached outcome via `@Volatile` field)
- Inject and call `dataMigration.run()` in `TigerDuckApp.onCreate()` — before any component (BootReceiver, WearScheduleBridge, AppState) reads `DataCache`
- Update `AppState` to inject the same singleton and read the cached result instead of constructing its own instance; remove now-unused `appContext` parameter

**Audit finding §2.2**: On a cold post-upgrade boot (device restarts before user opens the app), `BootReceiver` fires and reads `DataCache` — but `DataMigration.run()` only ran from `AppState.init{}` (triggered by `MainActivity`). Today this is safe by accident: the `"courseNo":` sentinel in `DataCache.loadCourses` rejects pre-migration caches. But the protection is incidental and fragile.

## Test plan
- [ ] Install a previous version, sync a timetable, then install the new build over it — first launch must not crash
- [ ] Verify `DataMigrationTest` passes (`./gradlew :app:testPlayDebugUnitTest --tests "*.DataMigrationTest"`)
- [ ] Cold reboot after upgrade — BootReceiver reschedules alarms without error (check logcat for `BootReceiver` and `DataMigration` tags)