### PR TITLE
fix: smooth watch progress bar + tile timeline + remove runBlocking

### DIFF
--- a/shared/src/main/java/org/ntust/app/tigerduck/shared/NextClassResolver.kt
+++ b/shared/src/main/java/org/ntust/app/tigerduck/shared/NextClassResolver.kt
@@ -53,16 +53,10 @@ object NextClassResolver {
                 minuteOfDay,
                 excluding = ongoing.course.courseNo
             )
-            val (currentStart, currentEnd) = currentPeriodBoundsMinutes(
-                ongoing.course,
-                weekday,
-                minuteOfDay
-            )
-                ?: (ongoing.startMinute to ongoing.endMinute)
             return NextClassResult.Ongoing(
                 course = ongoing.course,
-                startMinute = currentStart,
-                endMinute = currentEnd,
+                startMinute = ongoing.startMinute,
+                endMinute = ongoing.endMinute,
                 nextToday = nextToday?.let {
                     NextClassResult.NextToday(
                         it.first,
@@ -146,19 +140,5 @@ object NextClassResolver {
                 firstMinute?.let { course to it }
             }
             .minByOrNull { it.second }
-    }
-
-    /** Returns (start, end) minutes of the specific period that contains [minuteOfDay]. */
-    private fun currentPeriodBoundsMinutes(
-        course: Course,
-        weekday: Int,
-        minuteOfDay: Int
-    ): Pair<Int, Int>? {
-        val periods = course.schedule[weekday] ?: return null
-        return periods.mapNotNull { pid ->
-            val start = parseHm(PeriodTimes.mapping[pid]?.first) ?: return@mapNotNull null
-            val end = parseHm(PeriodTimes.mapping[pid]?.second) ?: return@mapNotNull null
-            if (minuteOfDay in start..end) (start to end) else null
-        }.minByOrNull { it.first }
     }
 }

--- a/shared/src/test/java/org/ntust/app/tigerduck/shared/NextClassResolverTest.kt
+++ b/shared/src/test/java/org/ntust/app/tigerduck/shared/NextClassResolverTest.kt
@@ -27,7 +27,7 @@ class NextClassResolverTest {
         assertTrue(r is NextClassResult.Ongoing)
         r as NextClassResult.Ongoing
         assertEquals("CN", r.course.courseNo)
-        assertEquals(9 * 60, r.endMinute)
+        assertEquals(10 * 60, r.endMinute)   // full block end (periods 1+2)
         assertEquals("AI", r.nextToday?.course?.courseNo)
         assertEquals(14 * 60 + 20, r.nextToday?.startMinute)
     }
@@ -98,64 +98,37 @@ class NextClassResolverTest {
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Mid-block test
+    // Block-level bounds tests
     //
     // mondayMorningCourse has periods ["1","2"] on Monday:
     //   period "1": 08:10–09:00  (490–540)
     //   period "2": 09:10–10:00  (550–600)
     //
-    // At 09:30 (= 570), the query falls inside period "2".
-    // currentPeriodBoundsMinutes finds that 570 ∈ 550..600 → returns (550, 600).
-    // The Ongoing result must carry those tighter per-period bounds, not the
-    // full block bounds (490–600).
-    //
-    // PeriodTimes.mapping:
-    //   "2" → ("09:10" to "10:00")  →  startMinute = 9*60+10 = 550, endMinute = 10*60 = 600
+    // Ongoing always uses the full contiguous block bounds (490–600) regardless
+    // of which individual period the current minute falls in. This gives one
+    // smooth 0→100% progress arc and a stable "Ends at" display.
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `Ongoing mid-block uses current period bounds not full block bounds`() {
+    fun `Ongoing mid-block uses full block bounds for smooth progress`() {
         val courses = listOf(mondayMorningCourse)
         // 09:30 on Monday — inside period "2" (09:10–10:00).
         val r = NextClassResolver.resolve(courses, weekday = 1, minuteOfDay = 9 * 60 + 30)
         assertTrue(r is NextClassResult.Ongoing)
         r as NextClassResult.Ongoing
         assertEquals("CN", r.course.courseNo)
-        // Must reflect period "2" bounds, not the full block start (08:10).
-        assertEquals(9 * 60 + 10, r.startMinute)   // 09:10 = 550
-        assertEquals(10 * 60, r.endMinute)          // 10:00 = 600
+        assertEquals(8 * 60 + 10, r.startMinute)   // block start = 08:10 = 490
+        assertEquals(10 * 60, r.endMinute)          // block end   = 10:00 = 600
     }
 
-    // ──────────────────────────────────────────────────────────────────────────
-    // Inter-period break test
-    //
-    // At 09:05 (= 545), we are in the 10-minute gap between period "1" (ends
-    // 09:00 = 540) and period "2" (starts 09:10 = 550).
-    //
-    // computeOngoingCourses uses the BLOCK span (490..600), so 545 ∈ 490..600 →
-    // the course is still considered Ongoing.
-    //
-    // currentPeriodBoundsMinutes inspects individual periods: 545 ∉ 490..540
-    // and 545 ∉ 550..600 → returns null → the resolver falls back to
-    // (ongoing.startMinute, ongoing.endMinute) = (490, 600).
-    //
-    // This test documents EXISTING semantics.  The intra-block gap is intentionally
-    // treated as Ongoing because both periods form one logical teaching block.
-    // If the semantics are ever changed (e.g. to NextToday during the break),
-    // update this test and note the deliberate behavioral change.
-    // ──────────────────────────────────────────────────────────────────────────
-
     @Test
-    fun `Ongoing during intra-block break uses full block bounds (documents existing semantics)`() {
+    fun `Ongoing during intra-block break uses full block bounds`() {
         val courses = listOf(mondayMorningCourse)
         // 09:05 on Monday — 5 min AFTER period "1" ends (09:00), BEFORE period "2" starts (09:10).
         val r = NextClassResolver.resolve(courses, weekday = 1, minuteOfDay = 9 * 60 + 5)
-        // Current behavior: still Ongoing (block span 490..600 contains 545).
         assertTrue(r is NextClassResult.Ongoing)
         r as NextClassResult.Ongoing
         assertEquals("CN", r.course.courseNo)
-        // currentPeriodBoundsMinutes returns null for this minute (not in any single
-        // period's range), so the resolver falls back to the full block bounds.
         assertEquals(8 * 60 + 10, r.startMinute)   // block start = 08:10 = 490
         assertEquals(10 * 60, r.endMinute)          // block end   = 10:00 = 600
     }

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/complication/NextClassComplicationService.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/complication/NextClassComplicationService.kt
@@ -10,11 +10,10 @@ import androidx.wear.watchface.complications.data.LongTextComplicationData
 import androidx.wear.watchface.complications.data.NoDataComplicationData
 import androidx.wear.watchface.complications.data.PlainComplicationText
 import androidx.wear.watchface.complications.data.ShortTextComplicationData
-import androidx.wear.watchface.complications.datasource.ComplicationDataSourceService
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
 import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import androidx.wear.watchface.complications.datasource.SuspendingComplicationDataSourceService
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
 import org.ntust.app.tigerduck.shared.NextClassResolver
 import org.ntust.app.tigerduck.shared.NextClassResult
 import org.ntust.app.tigerduck.shared.clock.AppClock
@@ -22,17 +21,13 @@ import org.ntust.app.tigerduck.wear.MainActivity
 import org.ntust.app.tigerduck.wear.data.SchedulePersistenceHolder
 import org.ntust.app.tigerduck.wear.data.WatchSnapshot
 
-class NextClassComplicationService : ComplicationDataSourceService() {
+class NextClassComplicationService : SuspendingComplicationDataSourceService() {
 
-    override fun onComplicationRequest(
+    override suspend fun onComplicationRequest(
         request: ComplicationRequest,
-        listener: ComplicationRequestListener,
-    ) {
-        val data = runBlocking {
-            val snapshot = SchedulePersistenceHolder.get(this@NextClassComplicationService).flow.first()
-            renderComplication(snapshot, request.complicationType)
-        }
-        listener.onComplicationData(data)
+    ): ComplicationData {
+        val snapshot = SchedulePersistenceHolder.get(this).flow.first()
+        return renderComplication(snapshot, request.complicationType)
     }
 
     override fun getPreviewData(type: ComplicationType): ComplicationData? = when (type) {

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
@@ -12,8 +12,12 @@ import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.TileBuilders
 import androidx.wear.tiles.TileService
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.shared.NextClassResolver
 import org.ntust.app.tigerduck.shared.NextClassResult
 import org.ntust.app.tigerduck.shared.clock.AppClock
@@ -21,17 +25,30 @@ import org.ntust.app.tigerduck.wear.MainActivity
 import org.ntust.app.tigerduck.wear.R
 import org.ntust.app.tigerduck.wear.data.SchedulePersistenceHolder
 import org.ntust.app.tigerduck.wear.data.WatchSnapshot
+import java.time.ZoneId
 
 class NextClassTileService : TileService() {
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceScope.cancel()
+    }
 
     override fun onTileRequest(
         request: RequestBuilders.TileRequest,
     ): ListenableFuture<TileBuilders.Tile> {
-        val tile = runBlocking {
-            val snapshot = SchedulePersistenceHolder.get(this@NextClassTileService).flow.first()
-            buildTile(snapshot)
+        val future = ResolvableFuture.create<TileBuilders.Tile>()
+        serviceScope.launch {
+            try {
+                val snapshot = SchedulePersistenceHolder.get(this@NextClassTileService).flow.first()
+                future.set(buildTile(snapshot))
+            } catch (e: Exception) {
+                future.setException(e)
+            }
         }
-        return ResolvableFuture.create<TileBuilders.Tile>().also { it.set(tile) }
+        return future
     }
 
     override fun onTileResourcesRequest(
@@ -46,17 +63,79 @@ class NextClassTileService : TileService() {
         val weekday = now.dayOfWeek.value
         val minuteOfDay = now.hour * 60 + now.minute
 
+        val timeline = TimelineBuilders.Timeline.Builder()
+
+        timeline.addTimelineEntry(
+            TimelineBuilders.TimelineEntry.Builder()
+                .setLayout(layoutFor(snapshot, weekday, minuteOfDay))
+                .build()
+        )
+
+        if (snapshot.syncedAtMs != null && snapshot.courses.isNotEmpty()) {
+            addFutureEntries(timeline, snapshot, weekday, minuteOfDay, now)
+        }
+
+        return TileBuilders.Tile.Builder()
+            .setResourcesVersion(RESOURCES_VERSION)
+            .setTileTimeline(timeline.build())
+            .setFreshnessIntervalMillis(FALLBACK_FRESHNESS_MS)
+            .build()
+    }
+
+    /**
+     * Pre-compute timeline entries for each future class-state transition today
+     * so the platform swaps layouts at class boundaries without waking the service.
+     */
+    private fun addFutureEntries(
+        timeline: TimelineBuilders.Timeline.Builder,
+        snapshot: WatchSnapshot,
+        weekday: Int,
+        minuteOfDay: Int,
+        now: java.time.LocalDateTime,
+    ) {
+        val todayBaseMs = now.toLocalDate()
+            .atStartOfDay(ZoneId.of("Asia/Taipei"))
+            .toInstant().toEpochMilli()
+
+        val blocks = NextClassResolver.todaysClasses(snapshot.courses, weekday, minuteOfDay)
+            .filter { it.endMinute > minuteOfDay }
+
+        val transitions = mutableListOf<Int>()
+        for (block in blocks) {
+            if (block.startMinute > minuteOfDay) transitions += block.startMinute
+            transitions += block.endMinute + 1
+        }
+
+        for (i in transitions.indices) {
+            val from = transitions[i]
+            val to = transitions.getOrElse(i + 1) { END_OF_DAY_MINUTE }
+
+            timeline.addTimelineEntry(
+                TimelineBuilders.TimelineEntry.Builder()
+                    .setValidity(
+                        TimelineBuilders.TimeInterval.Builder()
+                            .setStartMillis(todayBaseMs + from.toLong() * 60_000L)
+                            .setEndMillis(todayBaseMs + to.toLong() * 60_000L)
+                            .build()
+                    )
+                    .setLayout(layoutFor(snapshot, weekday, from))
+                    .build()
+            )
+        }
+    }
+
+    private fun layoutFor(
+        snapshot: WatchSnapshot,
+        weekday: Int,
+        minuteOfDay: Int,
+    ): LayoutElementBuilders.Layout {
         val (label, body, sub) = when {
             snapshot.syncedAtMs == null -> Triple(
-                getString(R.string.watch_open_phone_to_sync),
-                "",
-                ""
+                getString(R.string.watch_open_phone_to_sync), "", ""
             )
 
             snapshot.courses.isEmpty() -> Triple(
-                getString(R.string.watch_no_courses_synced),
-                "",
-                ""
+                getString(R.string.watch_no_courses_synced), "", ""
             )
 
             else -> when (val r =
@@ -95,9 +174,7 @@ class NextClassTileService : TileService() {
                 )
 
                 NextClassResult.Empty -> Triple(
-                    getString(R.string.watch_no_upcoming_classes),
-                    "",
-                    ""
+                    getString(R.string.watch_no_upcoming_classes), "", ""
                 )
             }
         }
@@ -121,24 +198,12 @@ class NextClassTileService : TileService() {
             )
             .build()
 
-        val root: LayoutElementBuilders.LayoutElement = LayoutElementBuilders.Box.Builder()
+        val root = LayoutElementBuilders.Box.Builder()
             .addContent(column)
             .setModifiers(ModifiersBuilders.Modifiers.Builder().setClickable(launchClick).build())
             .build()
 
-        val timeline = TimelineBuilders.Timeline.Builder()
-            .addTimelineEntry(
-                TimelineBuilders.TimelineEntry.Builder()
-                    .setLayout(LayoutElementBuilders.Layout.Builder().setRoot(root).build())
-                    .build()
-            )
-            .build()
-
-        return TileBuilders.Tile.Builder()
-            .setResourcesVersion(RESOURCES_VERSION)
-            .setTileTimeline(timeline)
-            .setFreshnessIntervalMillis(60_000)
-            .build()
+        return LayoutElementBuilders.Layout.Builder().setRoot(root).build()
     }
 
     private fun textLine(text: String): LayoutElementBuilders.LayoutElement =
@@ -163,6 +228,8 @@ class NextClassTileService : TileService() {
 
     companion object {
         private const val RESOURCES_VERSION = "1"
+        private const val END_OF_DAY_MINUTE = 24 * 60
+        private const val FALLBACK_FRESHNESS_MS = 3_600_000L
 
         fun requestUpdate(context: Context) {
             getUpdater(context).requestUpdate(NextClassTileService::class.java)

--- a/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
+++ b/wear/src/main/java/org/ntust/app/tigerduck/wear/tile/NextClassTileService.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
 import org.ntust.app.tigerduck.shared.NextClassResolver
 import org.ntust.app.tigerduck.shared.NextClassResult
 import org.ntust.app.tigerduck.shared.clock.AppClock
@@ -44,6 +45,8 @@ class NextClassTileService : TileService() {
             try {
                 val snapshot = SchedulePersistenceHolder.get(this@NextClassTileService).flow.first()
                 future.set(buildTile(snapshot))
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 future.setException(e)
             }
@@ -109,6 +112,7 @@ class NextClassTileService : TileService() {
         for (i in transitions.indices) {
             val from = transitions[i]
             val to = transitions.getOrElse(i + 1) { END_OF_DAY_MINUTE }
+            if (from >= to) continue
 
             timeline.addTimelineEntry(
                 TimelineBuilders.TimelineEntry.Builder()


### PR DESCRIPTION
## Summary

Fixes three deferred audit findings (§2.1, §4.1, §4.2) in the watch module:

- **§2.1 — Progress bar jumps:** `NextClassResolver.resolve()` now always returns full block-level bounds for `Ongoing`, giving one smooth 0→100% progress arc across the entire teaching session. No more discontinuous jumps during inter-period breaks or resets at period boundaries. Removed the now-unused `currentPeriodBoundsMinutes()`.

- **§4.1 — Tile timeline transitions:** `NextClassTileService` now builds a multi-entry `Timeline` with validity windows at each class-state boundary. The platform swaps tile layouts automatically without waking the service. Freshness interval drops from 60s to 1h (fallback only — data-push invalidation still triggers immediate updates).

- **§4.2 — `runBlocking` on binder threads:** Tile service replaced `runBlocking` with a service-scoped `CoroutineScope` + `ResolvableFuture` (tiles 1.6.0 removed `SuspendingTileService`). Complication service migrated to `SuspendingComplicationDataSourceService` from the existing `-ktx` artifact.

## Test plan

- [x] `NextClassResolverTest` updated and passing — block-level bounds verified for mid-block and inter-period break scenarios
- [x] `:wear:compileDebugKotlin` passes
- [ ] On-device: verify progress bar sweeps smoothly through a multi-period block (debug clock override)
- [ ] On-device: verify tile text updates at class start/end boundaries without visible delay
- [ ] On-device: verify complication still shows correct next-class info