### PR TITLE
fix: remaining deferred audit findings (2.3, 5.3, 7.1, 7.2b)

### DIFF
--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -369,10 +369,14 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
     ): T? =
         cacheMutex.withLock {
             withContext(Dispatchers.IO) {
-                val file = File(cacheDir, filename)
-                if (!file.exists()) return@withContext null
-                val text = file.readText()
-                parseJsonIfContains(text, requireContent, gson, type)
+                try {
+                    val file = File(cacheDir, filename)
+                    if (!file.exists()) return@withContext null
+                    val text = file.readText()
+                    parseJsonIfContains(text, requireContent, gson, type)
+                } catch (_: Exception) {
+                    null
+                }
             }
         }
 
@@ -420,10 +424,14 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
     ): T? =
         userDataMutex.withLock {
             withContext(Dispatchers.IO) {
-                val file = File(userDataDir, filename)
-                if (!file.exists()) return@withContext null
-                val text = file.readText()
-                parseJsonIfContains(text, requireContent, gson, type)
+                try {
+                    val file = File(userDataDir, filename)
+                    if (!file.exists()) return@withContext null
+                    val text = file.readText()
+                    parseJsonIfContains(text, requireContent, gson, type)
+                } catch (_: Exception) {
+                    null
+                }
             }
         }
 

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -369,17 +369,10 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
     ): T? =
         cacheMutex.withLock {
             withContext(Dispatchers.IO) {
-                try {
-                    val file = File(cacheDir, filename)
-                    if (!file.exists()) return@withContext null
-                    val text = file.readText()
-                    if (requireContent != null && !text.contains(requireContent)) {
-                        return@withContext null
-                    }
-                    gson.fromJson(text, type)
-                } catch (e: Exception) {
-                    null
-                }
+                val file = File(cacheDir, filename)
+                if (!file.exists()) return@withContext null
+                val text = file.readText()
+                parseJsonIfContains(text, requireContent, gson, type)
             }
         }
 
@@ -427,21 +420,14 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
     ): T? =
         userDataMutex.withLock {
             withContext(Dispatchers.IO) {
-                try {
-                    val file = File(userDataDir, filename)
-                    if (!file.exists()) return@withContext null
-                    val text = file.readText()
-                    if (requireContent != null && !text.contains(requireContent)) {
-                        return@withContext null
-                    }
-                    gson.fromJson(text, type)
-                } catch (e: Exception) {
-                    null
-                }
+                val file = File(userDataDir, filename)
+                if (!file.exists()) return@withContext null
+                val text = file.readText()
+                parseJsonIfContains(text, requireContent, gson, type)
             }
         }
 
-    private companion object {
+    internal companion object {
         private const val TAG = "DataCache"
 
         // Sentinel literal present in any course JSON written by a build
@@ -451,6 +437,20 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         // string value that contains the substring `courseNo` would not
         // include an unescaped quote+colon pair, so it can't satisfy the
         // check and slip past as if the keys were un-obfuscated.
-        const val COURSE_NO_TOKEN = "\"courseNo\":"
+        internal const val COURSE_NO_TOKEN = "\"courseNo\":"
+
+        internal fun <T> parseJsonIfContains(
+            text: String,
+            requiredToken: String?,
+            gson: Gson,
+            type: java.lang.reflect.Type,
+        ): T? {
+            if (requiredToken != null && !text.contains(requiredToken)) return null
+            return try {
+                gson.fromJson(text, type)
+            } catch (_: Exception) {
+                null
+            }
+        }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/ContentCard.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/ContentCard.kt
@@ -12,12 +12,13 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun ContentCard(
     modifier: Modifier = Modifier,
+    applyOuterPadding: Boolean = true,
     content: @Composable () -> Unit
 ) {
     Card(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 4.dp),
+            .let { if (applyOuterPadding) it.padding(horizontal = 16.dp, vertical = 4.dp) else it },
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
         )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import org.ntust.app.tigerduck.ui.component.ContentCard
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -257,7 +258,7 @@ fun SubscriptionSettingsScreen(
 
 @Composable
 private fun FdroidNoticeCard() {
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
@@ -291,7 +292,7 @@ private fun DefaultRulesBanner(
     onApply: () -> Unit,
 ) {
     val canApply = (taxonomy?.defaultTags?.isNotEmpty() == true)
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
                 text = stringResource(R.string.bulletin_default_rules_footer),
@@ -428,7 +429,7 @@ private fun NotificationPermissionCard(systemPermissions: SystemPermissions) {
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -516,16 +517,4 @@ private fun AddRuleRow(onClick: () -> Unit) {
     }
 }
 
-// Local variant of ui/component/ContentCard (different shape/padding contract,
-// so not a drop-in swap), but the container color must match it — every other
-// settings card in the app renders on `surface`, and `surfaceVariant` here made
-// these cards visibly two-tier.
-@Composable
-private fun ContentCard(content: @Composable () -> Unit) {
-    Surface(
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surface,
-        modifier = Modifier.fillMaxWidth(),
-    ) { content() }
-}
 

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/announcements/SubscriptionSettingsScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import org.ntust.app.tigerduck.ui.component.ContentCard
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -69,6 +68,7 @@ import org.ntust.app.tigerduck.network.model.localizedTagLabel
 import org.ntust.app.tigerduck.network.model.orgLabel
 import org.ntust.app.tigerduck.notification.AppPermission
 import org.ntust.app.tigerduck.notification.SystemPermissions
+import org.ntust.app.tigerduck.ui.component.ContentCard
 
 private data class EditingTarget(
     val rule: SubscriptionRule,

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/ServerPushScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/ServerPushScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import org.ntust.app.tigerduck.ui.component.ContentCard
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
@@ -72,6 +71,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.push.PushDiagnostic
+import org.ntust.app.tigerduck.ui.component.ContentCard
 import org.ntust.app.tigerduck.push.PushIdentity
 import org.ntust.app.tigerduck.push.PushRegistrationService
 import java.text.DateFormat

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/ServerPushScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/settings/ServerPushScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
+import org.ntust.app.tigerduck.ui.component.ContentCard
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.CheckCircle
@@ -38,7 +38,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -238,7 +237,7 @@ private fun ServerPushToggleCard(
     enabled: Boolean,
     onCheckedChange: (Boolean) -> Unit,
 ) {
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -302,7 +301,7 @@ private fun PushStatusCard(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
                 text = stringResource(R.string.push_server_status_section),
@@ -389,7 +388,7 @@ private fun PushStatusCard(
 
 @Composable
 private fun IdsCard(userId: String, deviceId: String) {
-    ContentCard {
+    ContentCard(applyOuterPadding = false) {
         Column(modifier = Modifier.padding(vertical = 4.dp)) {
             Text(
                 text = stringResource(R.string.push_server_ids_section),
@@ -489,17 +488,6 @@ private fun LabeledText(
     }
 }
 
-// Local variant of ui/component/ContentCard (different shape/padding contract,
-// so not a drop-in swap), but the container color must match it — see the
-// matching note in SubscriptionSettingsScreen.
-@Composable
-private fun ContentCard(content: @Composable () -> Unit) {
-    Surface(
-        shape = RoundedCornerShape(12.dp),
-        color = MaterialTheme.colorScheme.surface,
-        modifier = Modifier.fillMaxWidth(),
-    ) { content() }
-}
 
 private fun openAppSettings(context: Context) {
     val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {

--- a/app/src/play/java/org/ntust/app/tigerduck/wear/WearScheduleBridge.kt
+++ b/app/src/play/java/org/ntust/app/tigerduck/wear/WearScheduleBridge.kt
@@ -152,25 +152,7 @@ class WearScheduleBridge @Inject constructor(
         }
     }
 
-    private fun Course.toDto(): CourseDto = CourseDto(
-        courseNo = courseNo,
-        // Send the resolved label so any user-set customCourseName survives the
-        // round-trip. The watch-side wire schema has no customCourseName field,
-        // so baking the override into courseName is the lightest fix.
-        courseName = displayName,
-        instructor = instructor,
-        credits = credits,
-        classroom = classroom,
-        scheduleJson = scheduleJson,
-        // Coalesce so v1.3.x / v1.4.1 cached Courses (deserialized via
-        // Gson Unsafe with this field absent from JSON) don't pass null
-        // into CourseDto's non-null parameter and NPE the safety-net
-        // publish() launched from TigerDuckApp.onCreate.
-        classroomMapJson = classroomMapJson ?: "{}",
-        moodleIdNumber = moodleIdNumber,
-        customColorHex = customColorHex,
-        isManual = isManual,
-    )
+    private fun Course.toDto(): CourseDto = toWearDto()
 
     /** On-the-wire shape; explicit so we can evolve [Course] without breaking watch JSON. */
     data class CourseDto(
@@ -191,3 +173,16 @@ class WearScheduleBridge @Inject constructor(
         const val KEY_CRED_EPOCH = "libraryCredentialEpoch"
     }
 }
+
+internal fun Course.toWearDto(): WearScheduleBridge.CourseDto = WearScheduleBridge.CourseDto(
+    courseNo = courseNo,
+    courseName = displayName,
+    instructor = instructor,
+    credits = credits,
+    classroom = classroom,
+    scheduleJson = scheduleJson,
+    classroomMapJson = classroomMapJson ?: "{}",
+    moodleIdNumber = moodleIdNumber,
+    customColorHex = customColorHex,
+    isManual = isManual,
+)

--- a/app/src/test/java/org/ntust/app/tigerduck/data/DataCacheParseTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/data/DataCacheParseTest.kt
@@ -1,0 +1,62 @@
+package org.ntust.app.tigerduck.data
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.ntust.app.tigerduck.data.cache.DataCache
+import org.ntust.app.tigerduck.shared.Course
+
+class DataCacheParseTest {
+
+    private val gson = Gson()
+    private val courseListType = object : TypeToken<List<Course>>() {}.type
+
+    @Test
+    fun `valid JSON with sentinel token parses successfully`() {
+        val json = """[{"courseNo":"CS101","courseName":"Algorithms"}]"""
+        val result: List<Course>? = DataCache.parseJsonIfContains(
+            json, DataCache.COURSE_NO_TOKEN, gson, courseListType,
+        )
+        assertEquals(1, result!!.size)
+        assertEquals("CS101", result[0].courseNo)
+    }
+
+    @Test
+    fun `JSON without sentinel token returns null`() {
+        val json = """[{"a":"x","b":"y"}]"""
+        val result: List<Course>? = DataCache.parseJsonIfContains(
+            json, DataCache.COURSE_NO_TOKEN, gson, courseListType,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `null requiredToken skips sentinel check`() {
+        val json = """[{"a":"x","b":"y"}]"""
+        val result: List<Map<String, String>>? = DataCache.parseJsonIfContains(
+            json, null, gson, object : TypeToken<List<Map<String, String>>>() {}.type,
+        )
+        assertEquals(1, result!!.size)
+        assertEquals("x", result[0]["a"])
+    }
+
+    @Test
+    fun `courseNo as payload value (not key) is rejected`() {
+        val json = """[{"x":"courseNo is mentioned"}]"""
+        val result: List<Course>? = DataCache.parseJsonIfContains(
+            json, DataCache.COURSE_NO_TOKEN, gson, courseListType,
+        )
+        assertNull(result)
+    }
+
+    @Test
+    fun `malformed JSON returns null`() {
+        val json = """not json at all"""
+        val result: List<Course>? = DataCache.parseJsonIfContains(
+            json, null, gson, courseListType,
+        )
+        assertNull(result)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/wear/WearScheduleBridgeDtoTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/wear/WearScheduleBridgeDtoTest.kt
@@ -1,0 +1,69 @@
+package org.ntust.app.tigerduck.wear
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.ntust.app.tigerduck.shared.Course
+
+class WearScheduleBridgeDtoTest {
+
+    @Test
+    fun `null classroomMapJson is coalesced to empty object`() {
+        val course = Course(
+            courseNo = "CS101",
+            courseName = "Algorithms",
+            classroomMapJson = null,
+        )
+        val dto = course.toWearDto()
+        assertEquals("{}", dto.classroomMapJson)
+    }
+
+    @Test
+    fun `non-null classroomMapJson is preserved`() {
+        val map = """{"1-3":"T3-101"}"""
+        val course = Course(
+            courseNo = "CS102",
+            courseName = "Data Structures",
+            classroomMapJson = map,
+        )
+        val dto = course.toWearDto()
+        assertEquals(map, dto.classroomMapJson)
+    }
+
+    @Test
+    fun `displayName is used instead of courseName when customCourseName is set`() {
+        val course = Course(
+            courseNo = "CS103",
+            courseName = "Operating Systems",
+            customCourseName = "OS",
+        )
+        val dto = course.toWearDto()
+        assertEquals("OS", dto.courseName)
+    }
+
+    @Test
+    fun `all fields are mapped correctly`() {
+        val course = Course(
+            courseNo = "CS104",
+            courseName = "Networks",
+            instructor = "Prof. Lin",
+            credits = 3,
+            classroom = "T3-101",
+            scheduleJson = """{"1":["3","4"]}""",
+            classroomMapJson = """{"1-3":"T3-101"}""",
+            moodleIdNumber = "12345",
+            customColorHex = "#FF0000",
+            isManual = true,
+        )
+        val dto = course.toWearDto()
+        assertEquals("CS104", dto.courseNo)
+        assertEquals("Networks", dto.courseName)
+        assertEquals("Prof. Lin", dto.instructor)
+        assertEquals(3, dto.credits)
+        assertEquals("T3-101", dto.classroom)
+        assertEquals("""{"1":["3","4"]}""", dto.scheduleJson)
+        assertEquals("""{"1-3":"T3-101"}""", dto.classroomMapJson)
+        assertEquals("12345", dto.moodleIdNumber)
+        assertEquals("#FF0000", dto.customColorHex)
+        assertEquals(true, dto.isManual)
+    }
+}


### PR DESCRIPTION
## Summary

- **2.3** Unify `ContentCard`: add `applyOuterPadding` parameter, delete private copies in `ServerPushScreen` and `SubscriptionSettingsScreen`
- **5.3** Delete orphaned `REVEAL_PASS` repo secret (recover-secrets workflow already removed)
- **7.1** Extract `DataCache` sentinel parse to testable `parseJsonIfContains` + add `DataCacheParseTest` (5 tests)
- **7.2b** Extract `WearScheduleBridge.toDto` as internal `toWearDto` + add `WearScheduleBridgeDtoTest` (4 tests)
- **5.2** Already resolved — no foojay redirect IDs in use

This closes out all actionable deferred findings from the 2026-06-11 audit. Only blocked items remain (1.1, 1.2, 1.3, 6.1, 6.2 — pending product/design/submodule decisions).

## Test plan

- [x] `testPlayDebugUnitTest` passes (including new tests)
- [x] `compilePlayDebugKotlin` clean
- [x] `compileFdroidDebugKotlin` clean
- [ ] Visual check: ServerPushScreen and SubscriptionSettingsScreen cards render identically (Card vs former Surface — same 12dp corners, same `surface` color, no padding shift since `applyOuterPadding = false` and LazyColumn supplies margins)