### PR TITLE
fix(ClassTable): support the 115-1 term NTUST opened ahead of the calendar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.4.2"
+        versionCode = 21
+        versionName = "1.4.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,13 @@ android {
         buildConfig = true
     }
 
+    testOptions {
+        // Matches :shared. Without it any JVM unit test that reaches a real
+        // android.util.Log call throws "not mocked" — which meant migration
+        // and cache code could only be covered by stripping its logging.
+        unitTests.isReturnDefaultValues = true
+    }
+
     // Two distribution channels:
     //   * play   — Google Play Store + sideload. Uses FCM for real-time push.
     //   * fdroid — F-Droid. 100% FOSS, no Google Play Services. The

--- a/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
@@ -1,5 +1,7 @@
 package org.ntust.app.tigerduck
 
+import org.ntust.app.tigerduck.shared.clock.AppClock
+import java.time.LocalDate
 import java.time.ZoneId
 import java.util.TimeZone
 
@@ -12,4 +14,53 @@ object AppConstants {
 
     val Periods = org.ntust.app.tigerduck.shared.Periods
     val PeriodTimes = org.ntust.app.tigerduck.shared.PeriodTimes
+
+    /**
+     * The academic term the app currently considers "now".
+     *
+     * Hard-coded on purpose: nothing in the app knows when classes actually
+     * start or end. [org.ntust.app.tigerduck.network.CourseService.heuristicSemesterCode]
+     * only guesses a term *code* from the gregorian month, and
+     * [org.ntust.app.tigerduck.network.SemesterCatalog] reports which term the
+     * 選課 system has open — which runs weeks ahead of the term in session.
+     *
+     * Swap [CODE] / [START] / [END] for the academic calendar feed
+     * ([org.ntust.app.tigerduck.network.CalendarService] already fetches the ICS
+     * carrying 開學/結業) when that lands; every consumer reads [CODE] or
+     * [isInSession] and needs no change.
+     */
+    object CurrentTerm {
+        /** 115 學年度第 1 學期. */
+        const val CODE = "1151"
+
+        /** First day of classes, Taipei wall time. */
+        val START: Long = taipeiEpochMillis(2026, 9, 7)
+
+        /**
+         * Exclusive upper bound — the day *after* the last day of classes, so
+         * 2026-12-25 counts as in session right up to midnight.
+         */
+        val END: Long = taipeiEpochMillis(2026, 12, 26)
+
+        /**
+         * True while classes are in session.
+         *
+         * Gates the "today"-scoped surfaces — Home's time slider and the class
+         * table's today carousel — which outside the term would either sit
+         * empty or scrub a day that has no classes.
+         */
+        fun isInSession(): Boolean {
+            val now = AppClock.nowMillis()
+            return now in START..<END
+        }
+
+        /**
+         * Fails closed: an unbuildable date lands in the distant future, so
+         * [isInSession] reads false rather than true-forever.
+         */
+        private fun taipeiEpochMillis(year: Int, month: Int, day: Int): Long =
+            runCatching {
+                LocalDate.of(year, month, day).atStartOfDay(TAIPEI_ZONE).toInstant().toEpochMilli()
+            }.getOrDefault(Long.MAX_VALUE)
+    }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/TigerDuckApp.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/TigerDuckApp.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import org.ntust.app.tigerduck.auth.AuthService
+import org.ntust.app.tigerduck.data.DataMigration
 import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.preferences.AppLanguageManager
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
@@ -32,6 +33,8 @@ class TigerDuckApp : Application(), Configuration.Provider {
     @Inject
     lateinit var fcmBootstrap: FcmBootstrap
     @Inject
+    lateinit var dataMigration: DataMigration
+    @Inject
     lateinit var dataCache: DataCache
     @Inject
     lateinit var authService: AuthService
@@ -49,6 +52,12 @@ class TigerDuckApp : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        // First, before anything can read or write DataCache. BootReceiver and
+        // BackgroundSyncWorker both run without an Activity, so leaving this
+        // to AppState let WorkManager's persisted periodic sync fire on the
+        // upgrade launch and rebuild caches that a pending migration step then
+        // deleted. AppState re-reads the cached outcome for the reset prompt.
+        dataMigration.run()
         debugClockController.bootstrap()
         AppLanguageManager.apply(appPreferences.appLanguage)
         createNotificationChannels()

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -64,6 +64,7 @@ class DataMigration(
             when (current) {
                 0 -> migrate0to1()
                 1 -> migrate1to2()
+                2 -> migrate2to3()
             }
             current++
             prefs.dataSchemaVersion = current
@@ -121,8 +122,55 @@ class DataMigration(
             }
     }
 
+    /**
+     * Drops cached `courses_<semester>.json` files written by builds that
+     * filed 選課清單 enrolments under the month heuristic instead of the term
+     * the 選課 system was actually serving.
+     *
+     * NTUST opened 115-1 on 2026-08-20, weeks before the heuristic would have
+     * rolled off 114-2. Any install that synced in that window has a
+     * `courses_1142.json` holding a mix of both terms, and nothing rewrites it
+     * on upgrade — the class table only refetches the semester it is showing,
+     * and a non-empty cache renders as-is. See
+     * [org.ntust.app.tigerduck.network.SemesterCatalog].
+     *
+     * Only the evictable `cacheDir` copies are dropped. Manual courses live in
+     * `filesDir/manual_courses_<semester>.json`, are per-semester already, and
+     * have no remote source to rebuild from — deleting those would destroy
+     * courses the user typed in by hand.
+     */
+    private fun migrate2to3() {
+        val cacheDir = File(context.cacheDir, CACHE_SUBDIR)
+        deleteCourseCaches(cacheDir)
+    }
+
     companion object {
         private const val TAG = "DataMigration"
+
+        /**
+         * Unconditionally removes every remote course cache in [dir]. Unlike
+         * [sweepCourseFiles] this does not inspect content — the wrong-semester
+         * payload is indistinguishable from a correct one at the file level,
+         * since both carry well-formed `"courseNo":` keys. The next sync
+         * rebuilds each semester from its own sources.
+         */
+        internal fun deleteCourseCaches(dir: File) {
+            if (!dir.isDirectory) return
+            dir.listFiles()
+                ?.filter {
+                    it.isFile && (
+                        it.name == LEGACY_COURSES_FILENAME ||
+                            (it.name.startsWith(COURSES_PREFIX) && it.name.endsWith(".json"))
+                        )
+                }
+                ?.forEach { file ->
+                    runCatching {
+                        if (file.delete()) {
+                            Log.i(TAG, "Cleared wrong-semester course cache: ${file.name}")
+                        }
+                    }.onFailure { Log.w(TAG, "Failed to delete ${file.name}", it) }
+                }
+        }
 
         // Mirrors DataCache. Kept in sync deliberately — DataMigration must
         // run before any DataCache access, so we don't import the cache
@@ -142,7 +190,7 @@ class DataMigration(
         private const val COURSE_NO_TOKEN = "\"courseNo\":"
 
         /** Highest schema this build writes. Bump when adding a new step. */
-        const val CURRENT_SCHEMA = 2
+        const val CURRENT_SCHEMA = 3
 
         /**
          * Lowest schema this build can migrate forward from. Anything below

--- a/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/DataMigration.kt
@@ -2,9 +2,12 @@ package org.ntust.app.tigerduck.data
 
 import android.content.Context
 import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
 import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.data.preferences.CredentialManager
 import java.io.File
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /**
  * One-shot runner for on-device data migrations.
@@ -22,9 +25,24 @@ import java.io.File
  *      credential store, user downgraded the app, old-and-unsupported
  *      layout) — [run] returns [Outcome.NeedsUserReset] and the UI is
  *      expected to show a "please re-login and reconfigure" prompt.
+ *
+ * [run] is called from [org.ntust.app.tigerduck.TigerDuckApp.onCreate], so
+ * migrations complete before anything can read or write
+ * [org.ntust.app.tigerduck.data.cache.DataCache] — including entry points that
+ * never create an Activity, such as `BackgroundSyncWorker` and `BootReceiver`.
+ * Running it from `AppState` alone was not enough: WorkManager persists its
+ * periodic request across an upgrade and can fire before the user first opens
+ * the app, so a cache-clearing step could delete data a sync had just
+ * correctly rebuilt.
+ *
+ * The outcome is cached, so the later call from `AppState` — which needs it to
+ * decide whether to show the reset prompt — reuses this result rather than
+ * re-running the steps. `performFullReset` clears its own UI flag and re-stamps
+ * the schema version, so the stale cached value cannot re-fire the prompt.
  */
-class DataMigration(
-    private val context: Context,
+@Singleton
+class DataMigration @Inject constructor(
+    @param:ApplicationContext private val context: Context,
     private val prefs: AppPreferences,
     private val credentials: CredentialManager,
 ) {
@@ -36,7 +54,19 @@ class DataMigration(
         NeedsUserReset,
     }
 
-    fun run(): Outcome {
+    /**
+     * Runs every pending step once per process and caches the verdict.
+     *
+     * Synchronous on purpose. The steady-state path is a single
+     * `SharedPreferences.getInt` and an early return — file I/O happens only
+     * on the one launch that actually migrates, which is the launch that must
+     * not be raced.
+     */
+    private val outcome: Outcome by lazy(LazyThreadSafetyMode.SYNCHRONIZED) { doRun() }
+
+    fun run(): Outcome = outcome
+
+    private fun doRun(): Outcome {
         // If Keystore corruption forced CredentialManager to rebuild the
         // credential store from scratch, the user's logins are gone and
         // the app is effectively logged out. Surface it so the dialog

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -15,7 +15,6 @@ import org.ntust.app.tigerduck.data.model.Course
 import org.ntust.app.tigerduck.data.model.ScoreReport
 import org.ntust.app.tigerduck.network.model.CourseSearchResult
 import java.io.File
-import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -166,17 +165,15 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         }
     }
 
-    private fun currentSemesterCode(): String {
-        val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ)
-        val year = cal.get(Calendar.YEAR)
-        val month = cal.get(Calendar.MONTH) + 1
-        val rocYear = year - 1911
-        return when (month) {
-            in 2..8 -> "${rocYear - 1}2"
-            in 9..12 -> "${rocYear}1"
-            else -> "${rocYear - 1}1"
-        }
-    }
+    /**
+     * Must stay identical to [org.ntust.app.tigerduck.network.CourseService.currentSemesterCode]
+     * — the no-arg course aliases above key cache files off this, so any drift
+     * between the two would file "today's" courses under a semester nothing
+     * else reads. Duplicated rather than injected so DataCache keeps no
+     * dependency on the network layer.
+     */
+    private fun currentSemesterCode(): String =
+        org.ntust.app.tigerduck.AppConstants.CurrentTerm.CODE
 
     // MARK: - Assignments
 

--- a/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/preferences/AppPreferences.kt
@@ -279,6 +279,44 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
             editor.apply()
         }
 
+    /**
+     * Semester codes published by NTUST, newest first — see
+     * [org.ntust.app.tigerduck.network.SemesterCatalog]. Empty until the first
+     * successful fetch, which the catalogue reads as "fall back to the month
+     * heuristic".
+     *
+     * Stored as a delimited string rather than a `StringSet` because
+     * `SharedPreferences` sets are unordered, and this list's whole value is
+     * that it is newest-first.
+     */
+    var semesterCatalogTerms: List<String>
+        get() = prefs.getString("semesterCatalogTerms", null)
+            ?.split(SEMESTER_LIST_DELIMITER)
+            ?.filter { it.isNotBlank() }
+            ?: emptyList()
+        set(value) = prefs.edit()
+            .putString("semesterCatalogTerms", value.joinToString(SEMESTER_LIST_DELIMITER))
+            .apply()
+
+    /**
+     * The term the 選課 system is currently open for (`LoginEnable`). Runs
+     * weeks ahead of the term in session, so it is not interchangeable with
+     * [org.ntust.app.tigerduck.AppConstants.CurrentTerm.CODE].
+     */
+    var semesterCatalogSelection: String?
+        get() = prefs.getString("semesterCatalogSelection", null)
+        set(value) {
+            val editor = prefs.edit()
+            if (value == null) editor.remove("semesterCatalogSelection")
+            else editor.putString("semesterCatalogSelection", value)
+            editor.apply()
+        }
+
+    /** Wall-clock millis of the last successful catalogue fetch. 0 = never. */
+    var semesterCatalogRefreshedAt: Long
+        get() = prefs.getLong("semesterCatalogRefreshedAt", 0L)
+        set(value) = prefs.edit().putLong("semesterCatalogRefreshedAt", value).apply()
+
     fun hapticStrength(scenario: HapticScenario): Int =
         prefs.getInt("haptic_strength_${scenario.prefKey}", scenario.defaultStrengthPct)
             .coerceIn(0, 100)
@@ -303,6 +341,9 @@ class AppPreferences @Inject constructor(@ApplicationContext context: Context) {
     }
 
     companion object {
+        /** Comma is safe: NTUST semester codes are `[0-9]{3}[12H]`. */
+        private const val SEMESTER_LIST_DELIMITER = ","
+
         const val MIN_TUNABLE_HAPTIC_DURATION_MS = 5
         const val MAX_TUNABLE_HAPTIC_DURATION_MS = 60
 

--- a/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/CourseService.kt
@@ -20,7 +20,6 @@ import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.network.model.CourseSearchRequest
 import org.ntust.app.tigerduck.network.model.CourseSearchResult
 import org.ntust.app.tigerduck.network.model.MoodleEnrolledCourse
-import java.util.Calendar
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -233,17 +232,27 @@ class CourseService @Inject constructor(
         return map
     }
 
-    fun currentSemesterCode(): String {
-        val cal = Calendar.getInstance(org.ntust.app.tigerduck.AppConstants.TAIPEI_TZ)
-        val year = cal.get(Calendar.YEAR)
-        val month = cal.get(Calendar.MONTH) + 1
-        val rocYear = year - 1911
-        return when (month) {
-            in 2..8 -> "${rocYear - 1}2"   // Spring semester
-            in 9..12 -> "${rocYear}1"       // Fall semester
-            else -> "${rocYear - 1}1"       // January: still in prior fall semester
-        }
-    }
+    /**
+     * The term in session right now — what "today's courses" means for the
+     * widget, the Wear tile, Home's carousel and every current-semester cache
+     * key.
+     *
+     * Pinned to [org.ntust.app.tigerduck.AppConstants.CurrentTerm]. The month
+     * heuristic this replaced still says 114-2 through August, which mislabels
+     * the 115-1 term the school opened early. Swap the body for
+     * [heuristicSemesterCode] to hand control back — it is left intact, so
+     * lifting the pin is a one-line change.
+     *
+     * Not to be confused with [SemesterCatalog.selectionSemesterCode] — 選課
+     * opens the *next* term weeks before this one ends.
+     */
+    fun currentSemesterCode(): String = org.ntust.app.tigerduck.AppConstants.CurrentTerm.CODE
+
+    /**
+     * The month-based guess [currentSemesterCode] used before it was pinned.
+     * Kept so lifting the pin is a one-line change.
+     */
+    fun heuristicSemesterCode(): String = SemesterCodes.heuristic()
 
     companion object {
         // Course metadata (name, instructor, schedule, caps) is stable within

--- a/app/src/main/java/org/ntust/app/tigerduck/network/SemesterCatalog.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/SemesterCatalog.kt
@@ -1,0 +1,184 @@
+package org.ntust.app.tigerduck.network
+
+import android.util.Log
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import org.ntust.app.tigerduck.AppConstants
+import org.ntust.app.tigerduck.data.preferences.AppPreferences
+import org.ntust.app.tigerduck.network.model.SemesterInfo
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Server-driven semester list, sourced from the public `querycourse` catalogue.
+ *
+ * [SemesterCodes.heuristic] is a gregorian-month guess, so it lags whenever
+ * NTUST publishes a term early. On 2026-08-20 it still said 114-2 while the
+ * school had already opened 115-1, which broke the class table two ways:
+ *
+ *  1. The picker walked back four terms from the heuristic, so 115-1 never
+ *     appeared in it.
+ *  2. The 選課 system had *already* flipped to 115-1, and its 選課清單 page
+ *     carries no term marker anywhere in the HTML — so those enrolments were
+ *     filed under the heuristic's 114-2 and both terms rendered into one grid.
+ *
+ * `api/semestersinfo` is the same endpoint the official course-query site uses
+ * to populate its own semester menu. `LoginEnable` marks the single term the
+ * 選課 system is operating on, which is exactly the attribution the 選課清單
+ * scrape is missing.
+ *
+ * Every reader falls back to the month heuristic when the endpoint is
+ * unreachable, so a failed fetch degrades to the pre-catalogue behaviour
+ * rather than emptying the picker.
+ */
+@Singleton
+class SemesterCatalog @Inject constructor(
+    private val sessionManager: NtustSessionManager,
+    private val appPreferences: AppPreferences,
+) {
+    /**
+     * Terms the picker offers, newest first. Falls back to walking back from
+     * the month heuristic until the first successful [refresh].
+     */
+    fun availableSemesters(): List<String> {
+        val cached = appPreferences.semesterCatalogTerms
+        if (cached.isEmpty()) return SemesterCodes.walkBack(FALLBACK_TERM, 4)
+        return cached.take(PICKER_DEPTH)
+    }
+
+    /**
+     * The term the picker should open on: the user's last pick, or the newest
+     * published term when they have never picked one.
+     *
+     * The stored pick is passed in rather than read here so the rule stays
+     * testable, and callers deliberately do *not* persist the fallback — an
+     * untouched picker should keep tracking the newest term rather than
+     * freezing on whichever one happened to be newest at first launch.
+     */
+    fun selectedSemester(storedPick: String?): String =
+        storedPick
+            ?: availableSemesters().firstOrNull()
+            ?: FALLBACK_TERM
+
+    /**
+     * The term the 選課 system is currently serving — the one whose enrolments
+     * [CourseService.fetchEnrolledCourseNos] returns.
+     *
+     * This runs *ahead* of the term actually in session (選課 for the next term
+     * opens weeks before it starts), so it is deliberately not a replacement
+     * for [CourseService.currentSemesterCode]; it answers "which bucket do the
+     * 選課清單 course numbers belong in", nothing else.
+     */
+    fun selectionSemesterCode(): String =
+        appPreferences.semesterCatalogSelection ?: FALLBACK_TERM
+
+    /**
+     * Refreshes both cached values when the last successful fetch has aged out.
+     * Safe to call from every course-fetch entry point.
+     */
+    suspend fun refreshIfStale() {
+        val last = appPreferences.semesterCatalogRefreshedAt
+        // Wall-clock, not AppClock: this is a network cache TTL, which the
+        // debug clock deliberately does not move (see AppClock's contract).
+        if (System.currentTimeMillis() - last <= REFRESH_TTL_MS) return
+        refresh()
+    }
+
+    /**
+     * Refreshes both cached values. Failures are swallowed — every caller
+     * degrades to the month heuristic, which is the pre-existing behaviour.
+     */
+    suspend fun refresh() {
+        val list = runCatching { fetch() }.getOrElse {
+            Log.w(TAG, "Semester catalogue fetch failed; keeping previous values", it)
+            return
+        }
+        val terms = list.mapNotNull { it.semester?.takeIf(String::isNotBlank) }
+        if (terms.isEmpty()) return
+        appPreferences.semesterCatalogTerms = terms
+        appPreferences.semesterCatalogRefreshedAt = System.currentTimeMillis()
+        // Exactly one entry carries LoginEnable. If NTUST ever ships zero, keep
+        // the previous value rather than falling back to the heuristic that
+        // caused this bug in the first place.
+        openTerm(list)?.let { appPreferences.semesterCatalogSelection = it }
+    }
+
+    private suspend fun fetch(): List<SemesterInfo> = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(SEMESTERS_API)
+            // querycourse does strict content negotiation and answers HTTP 500
+            // with an XML error body when Accept prefers text/html — the shared
+            // client's default header would do exactly that.
+            .header("Accept", "application/json")
+            .get()
+            .build()
+        sessionManager.client.newCall(request).execute().use { response ->
+            decodeSemesters(response.body.string())
+        }
+    }
+
+    companion object {
+        private const val TAG = "SemesterCatalog"
+
+        /**
+         * What every reader falls back to before the first successful fetch,
+         * or when the endpoint is unreachable.
+         *
+         * The pinned term, *not* [SemesterCodes.heuristic]. The heuristic is
+         * the known-stale answer this whole class exists to replace — anchoring
+         * the fallbacks on it would drop 115-1 out of the picker and skip the
+         * 選課 fetch entirely whenever the catalogue is unreachable, which is
+         * the original bug. It also buys no protection against a future
+         * overlap: during one, the heuristic names the term in session, so it
+         * would mis-attribute 選課 enrolments exactly as the pin does.
+         *
+         * Matches iOS, whose fallbacks resolve through its own
+         * `currentSemesterCode()` — pinned to the same term.
+         */
+        private val FALLBACK_TERM: String get() = AppConstants.CurrentTerm.CODE
+
+        private const val SEMESTERS_API =
+            "https://querycourse.ntust.edu.tw/QueryCourse/api/semestersinfo"
+
+        /**
+         * Term boundaries move on the scale of weeks, so this only has to beat
+         * the month heuristic — hourly is plenty, and it keeps the fetch off
+         * the hot path when several callers refresh at once.
+         */
+        private const val REFRESH_TTL_MS = 60L * 60L * 1000L
+
+        /**
+         * Terms offered by the semester picker. Six rather than the previous
+         * four because the catalogue interleaves 暑期 terms (`114H`) between
+         * the regular ones, so four slots would no longer reach back two full
+         * years.
+         */
+        internal const val PICKER_DEPTH = 6
+
+        private val gson = Gson()
+
+        /**
+         * Split out from [fetch] so the two things that actually matter about
+         * the payload — its shape, and that the open term is picked by
+         * `LoginEnable` rather than by position — are testable offline.
+         *
+         * Returns empty on malformed JSON; [refresh] reads that as "keep the
+         * previous values" rather than emptying the picker.
+         */
+        internal fun decodeSemesters(json: String): List<SemesterInfo> {
+            val type = object : TypeToken<List<SemesterInfo>>() {}.type
+            return runCatching { gson.fromJson<List<SemesterInfo>?>(json, type) }
+                .getOrNull()
+                .orEmpty()
+                // A row can arrive with a null Semester; drop it here so no
+                // caller has to re-check.
+                .filter { !it.semester.isNullOrBlank() }
+        }
+
+        internal fun openTerm(list: List<SemesterInfo>): String? =
+            list.firstOrNull { it.loginEnable }?.semester?.takeIf(String::isNotBlank)
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/network/SemesterCodes.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/SemesterCodes.kt
@@ -1,0 +1,66 @@
+package org.ntust.app.tigerduck.network
+
+import org.ntust.app.tigerduck.AppConstants
+import java.util.Calendar
+
+/**
+ * Semester-code arithmetic, split out of [CourseService] so [SemesterCatalog]
+ * can reach it without a Hilt dependency cycle (CourseService already depends
+ * on the catalogue's attribution).
+ *
+ * A code is `<ROC year><term>`, e.g. `1151` = 115 學年度第 1 學期. The
+ * catalogue also publishes 暑期 terms as `114H`, which this arithmetic
+ * deliberately cannot produce — see [previous].
+ */
+object SemesterCodes {
+
+    /**
+     * The month-based guess [CourseService.currentSemesterCode] used before it
+     * was pinned to [AppConstants.CurrentTerm]. Kept as the last-resort
+     * fallback for [SemesterCatalog] when the endpoint is unreachable on a
+     * fresh install.
+     *
+     * Inherently lags: NTUST publishes a term weeks before the month rolls
+     * over, which is the whole reason the pin and the catalogue exist.
+     */
+    fun heuristic(): String {
+        // Pin to gregorian — Calendar.getInstance on a TW device can return
+        // ROC-era years and would shift the rocYear math.
+        val cal = Calendar.getInstance(AppConstants.TAIPEI_TZ)
+        val year = cal.get(Calendar.YEAR)
+        val month = cal.get(Calendar.MONTH) + 1
+        val rocYear = year - 1911
+        return when (month) {
+            in 2..8 -> "${rocYear - 1}2"   // Spring semester
+            in 9..12 -> "${rocYear}1"       // Fall semester
+            else -> "${rocYear - 1}1"       // January: still in prior fall semester
+        }
+    }
+
+    /**
+     * The term before [code], or [code] itself when it isn't a regular term.
+     *
+     * Returning the input unchanged for 暑期 (`114H`) or malformed codes lets
+     * [walkBack] dedupe the repeat away rather than emit garbage — the walk is
+     * only ever a pre-catalogue fallback, so a short list beats a wrong one.
+     */
+    fun previous(code: String): String {
+        val year = code.dropLast(1).toIntOrNull() ?: return code
+        return when (code.last()) {
+            '2' -> "${year}1"
+            '1' -> "${year - 1}2"
+            else -> code
+        }
+    }
+
+    /** [count] terms ending at [from], newest first, with repeats dropped. */
+    fun walkBack(from: String, count: Int): List<String> {
+        val result = LinkedHashSet<String>()
+        var code = from
+        repeat(count) {
+            if (!result.add(code)) return result.toList()
+            code = previous(code)
+        }
+        return result.toList()
+    }
+}

--- a/app/src/main/java/org/ntust/app/tigerduck/network/model/SemesterInfo.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/model/SemesterInfo.kt
@@ -1,0 +1,29 @@
+package org.ntust.app.tigerduck.network.model
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * One row of `querycourse.ntust.edu.tw/QueryCourse/api/semestersinfo` — the
+ * endpoint the official course-query site uses to populate its own semester
+ * menu. Rows arrive newest-first and interleave 暑期 terms (`114H`) between
+ * the regular ones.
+ *
+ * Only the two fields the app acts on are modelled; Gson ignores the rest
+ * (`EngSemester`, `Static`, `ShowRemind`, `CurrentSemester`).
+ *
+ * Both fields are upgrade-safe per the persistence checklist — [semester] is
+ * nullable and [loginEnable] is a primitive — so a payload missing either key
+ * degrades instead of NPE-ing. Lives in the `network.model` package, which
+ * `proguard-rules.pro` keeps wholesale, so R8 cannot rename the fields out
+ * from under `@SerializedName`.
+ */
+data class SemesterInfo(
+    @SerializedName("Semester") val semester: String?,
+    /**
+     * Marks the single term the 選課 system is operating on. That term runs
+     * *ahead* of the one in session — 選課 for the next term opens weeks
+     * before it starts — so this answers "which bucket do 選課清單 course
+     * numbers belong in", nothing else.
+     */
+    @SerializedName("LoginEnable") val loginEnable: Boolean,
+)

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/BackgroundSyncWorker.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/BackgroundSyncWorker.kt
@@ -20,6 +20,7 @@ import org.ntust.app.tigerduck.data.cache.DataCache
 import org.ntust.app.tigerduck.data.model.Course
 import org.ntust.app.tigerduck.network.CourseService
 import org.ntust.app.tigerduck.network.MoodleService
+import org.ntust.app.tigerduck.network.SemesterCatalog
 import java.util.concurrent.TimeUnit
 
 @HiltWorker
@@ -29,6 +30,7 @@ class BackgroundSyncWorker @AssistedInject constructor(
     private val authService: AuthService,
     private val moodleService: MoodleService,
     private val courseService: CourseService,
+    private val semesterCatalog: SemesterCatalog,
     private val dataCache: DataCache,
     private val notificationScheduler: AssignmentNotificationScheduler,
     private val liveActivityManager: org.ntust.app.tigerduck.liveactivity.LiveActivityManager,
@@ -61,9 +63,19 @@ class BackgroundSyncWorker @AssistedInject constructor(
 
     private suspend fun syncCourses(studentId: String, password: String): Boolean {
         return try {
+            // TTL-throttled; resolved before the gate below, which depends
+            // on it.
+            semesterCatalog.refreshIfStale()
             val semester = courseService.currentSemesterCode()
+            // 選課 serves exactly one term and its 選課清單 page carries no
+            // term marker, so its course numbers belong to whichever term the
+            // catalogue reports as open. That runs ahead of the term in
+            // session, and importing them here would file the *next* term's
+            // enrolments into this term's cache.
+            val servesSelectionSemester = semester == semesterCatalog.selectionSemesterCode()
             val (selectionNos, moodleAll) = coroutineScope {
                 val selectionDef = async {
+                    if (!servesSelectionSemester) return@async emptyList()
                     try {
                         courseService.fetchEnrolledCourseNos(studentId, password)
                     } catch (e: Exception) {
@@ -83,6 +95,10 @@ class BackgroundSyncWorker @AssistedInject constructor(
             }
 
             if (selectionNos == null && moodleAll == null) return false
+            // With 選課 gated off, Moodle is the only source — its failure is
+            // a total failure, so retry rather than report success on an
+            // empty roster.
+            if (!servesSelectionSemester && moodleAll == null) return false
             val moodleForSemester = moodleAll
                 .orEmpty()
                 .filter { it.semesterCode == semester && it.courseNo.isNotEmpty() }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/AppState.kt
@@ -1,6 +1,5 @@
 package org.ntust.app.tigerduck.ui
 
-import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateMapOf
@@ -8,7 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.graphics.Color
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -44,8 +42,8 @@ class AppState @Inject constructor(
     val dataCache: DataCache,
     val calendarService: CalendarService,
     val systemPermissions: SystemPermissions,
+    private val dataMigration: DataMigration,
     private val widgetUpdater: org.ntust.app.tigerduck.widget.WidgetUpdater,
-    @param:ApplicationContext private val appContext: Context,
 ) {
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var syncJob: Job? = null
@@ -65,7 +63,10 @@ class AppState @Inject constructor(
     val needsUserReset: StateFlow<Boolean> = _needsUserReset
 
     init {
-        when (DataMigration(appContext, prefs, credentials).run()) {
+        // Already run — and cached — by TigerDuckApp.onCreate, which is what
+        // guarantees migrations beat every non-Activity cache reader. This
+        // call only reads the verdict so the reset prompt can fire.
+        when (dataMigration.run()) {
             DataMigration.Outcome.NeedsUserReset -> _needsUserReset.value = true
             DataMigration.Outcome.Ok -> Unit
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/component/AssignmentItem.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/component/AssignmentItem.kt
@@ -195,7 +195,7 @@ private fun statusBadge(status: AssignmentStatus): Pair<String, Color>? = when (
  * triggered a recomposition.
  */
 @Composable
-private fun rememberAppClockVersion(): State<Long> =
+internal fun rememberAppClockVersion(): State<Long> =
     produceState(initialValue = AppClock.version()) {
         val listener: (Long) -> Unit = { value = value + 1 }
         AppClock.addOverrideListener(listener)

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableScreen.kt
@@ -88,6 +88,7 @@ fun ClassTableScreen(
     // body invites readers from the wrong scope and is fragile if the
     // condition changes.
     val selectedSemester by viewModel.currentSemester.collectAsStateWithLifecycle()
+    val availableSemesters by viewModel.availableSemesters.collectAsStateWithLifecycle()
     val todayCourses = remember(courses, currentMinute) { viewModel.todayCourses }
     val ongoingCourses = remember(courses, currentMinute) { viewModel.ongoingCourses }
     val activePeriods = remember(courses) { viewModel.activePeriods }
@@ -269,7 +270,7 @@ fun ClassTableScreen(
                 ) {
                     SemesterPicker(
                         current = selectedSemester,
-                        options = viewModel.availableSemesters,
+                        options = availableSemesters,
                         labelFor = viewModel::displayLabel,
                         onPick = { viewModel.setSemester(it) }
                     )

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -31,6 +31,7 @@ import org.ntust.app.tigerduck.data.preferences.AppPreferences
 import org.ntust.app.tigerduck.network.CourseService
 import org.ntust.app.tigerduck.network.MoodleService
 import org.ntust.app.tigerduck.network.NetworkChecker
+import org.ntust.app.tigerduck.network.SemesterCatalog
 import org.ntust.app.tigerduck.network.decodeHtmlEntities
 import org.ntust.app.tigerduck.network.model.MoodleEnrolledCourse
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
@@ -46,6 +47,7 @@ class ClassTableViewModel @Inject constructor(
     private val dataCache: DataCache,
     private val courseColorStore: CourseColorStore,
     private val appPreferences: AppPreferences,
+    private val semesterCatalog: SemesterCatalog,
     private val widgetUpdater: org.ntust.app.tigerduck.widget.WidgetUpdater,
 ) : ViewModel() {
 
@@ -75,8 +77,11 @@ class ClassTableViewModel @Inject constructor(
     private val _selectedWeekday = MutableStateFlow<Int?>(null)
     private val _selectedPeriodId = MutableStateFlow<String?>(null)
 
+    // Stored pick, else the newest published term, else the pinned term.
+    // The catalogue can land after construction on a cold launch, so
+    // followNewestSemesterIfUnpicked re-applies the rule once it does.
     private val _currentSemester = MutableStateFlow(
-        appPreferences.classTableSelectedSemester ?: courseService.currentSemesterCode()
+        semesterCatalog.selectedSemester(appPreferences.classTableSelectedSemester)
     )
     val currentSemester: StateFlow<String> = _currentSemester
 
@@ -183,27 +188,45 @@ class ClassTableViewModel @Inject constructor(
         get() = courseService.currentSemesterCode()
 
     /**
-     * The four most recent semesters, anchored on the *actual* current
-     * semester — not whatever the user last switched to. Matches iOS so
-     * the picker always offers the same range regardless of selection.
+     * Terms the picker offers, newest first, as published by NTUST — see
+     * [SemesterCatalog]. A `StateFlow` rather than a computed getter so a term
+     * the school publishes ahead of the month heuristic (115-1 opened weeks
+     * before the heuristic rolled off 114-2) becomes selectable in the same
+     * session the catalogue lands.
      */
-    val availableSemesters: List<String>
-        get() {
-            val code = courseService.currentSemesterCode()
-            val year = code.dropLast(1).toIntOrNull() ?: return listOf(code)
-            val sem = code.last().digitToIntOrNull() ?: 1
-            val result = mutableListOf<String>()
-            var y = year
-            var s = sem
-            repeat(4) {
-                result.add("$y$s")
-                s--
-                if (s < 1) {
-                    s = 2; y--
-                }
-            }
-            return result
-        }
+    private val _availableSemesters = MutableStateFlow(semesterOptions(_currentSemester.value))
+    val availableSemesters: StateFlow<List<String>> = _availableSemesters
+
+    /**
+     * Keeps the persisted selection selectable even after it ages out of the
+     * catalogue window — a picker whose selected value matches no option
+     * renders blank.
+     */
+    private fun semesterOptions(selected: String): List<String> {
+        val options = semesterCatalog.availableSemesters()
+        return if (options.contains(selected)) options else options + selected
+    }
+
+    /**
+     * The catalogue can land after construction on a cold launch, so re-apply
+     * the "never picked → newest term" rule once it does.
+     *
+     * Deliberately does not persist the move: an untouched picker should keep
+     * tracking the newest term rather than freezing on whichever one happened
+     * to be newest at first launch.
+     */
+    private suspend fun followNewestSemesterIfUnpicked() {
+        if (appPreferences.classTableSelectedSemester != null) return
+        val newest = semesterCatalog.availableSemesters().firstOrNull() ?: return
+        if (newest == _currentSemester.value) return
+        _currentSemester.value = newest
+        // The grid is still showing the term we just moved off. Swap in the
+        // new term's cache immediately rather than leaving the wrong timetable
+        // up for the length of the network round-trip.
+        val cached = dataCache.loadCourses(newest)
+        _courses.value = cached
+        TigerDuckTheme.buildCourseColorMap(cached)
+    }
 
     /** Format semester code for display, e.g. "1142" → "114-2". */
     fun displayLabel(code: String): String {
@@ -227,6 +250,10 @@ class ClassTableViewModel @Inject constructor(
 
     val todayCourses: List<Course>
         get() {
+            // Outside the term there is no "today" worth showing — the
+            // carousel would either be empty or surface a stale day. Empty
+            // here also hides the section, which keys off `isNotEmpty()`.
+            if (!AppConstants.CurrentTerm.isInSession()) return emptyList()
             val today = _currentDayTime.value.weekday
             return _courses.value
                 .filter { it.schedule.containsKey(today) }
@@ -698,22 +725,39 @@ class ClassTableViewModel @Inject constructor(
         }
         _isLoading.value = true
         try {
+            // Before anything else, so a newly-published term is offered by the
+            // picker and 選課 enrolments are attributed to the term the portal
+            // is actually serving. TTL-throttled, so this costs one request an
+            // hour no matter how often the class table refreshes.
+            semesterCatalog.refreshIfStale()
+            followNewestSemesterIfUnpicked()
             val semester = _currentSemester.value
+            _availableSemesters.value = semesterOptions(semester)
+            // Assignments are "upcoming from now", so they belong to the term
+            // in session.
             val isCurrentSemester = semester == courseService.currentSemesterCode()
+            // 選課 serves exactly one term and its 選課清單 page has no term
+            // marker, so its course numbers belong to whichever term the
+            // catalogue reports as open — not to whatever term is in session.
+            // Keying this off currentSemesterCode() mis-filed 115-1 enrolments
+            // into 114-2 for the weeks between 選課 opening and the month
+            // heuristic rolling over.
+            val servesSelectionSemester = semester == semesterCatalog.selectionSemesterCode()
             Log.i(
                 "ClassTableVM",
-                "fetchData start: semester=$semester isCurrent=$isCurrentSemester"
+                "fetchData start: semester=$semester isCurrent=$isCurrentSemester " +
+                    "servesSelection=$servesSelectionSemester"
             )
 
             // Kick off the two enrolment sources concurrently — they hit
             // different hosts (courseselection.ntust.edu.tw vs.
             // moodle2.ntust.edu.tw) and neither depends on the other.
-            //   Source 1: course-selection portal, current term only.
+            //   Source 1: course-selection portal, open term only.
             //   Source 2: Moodle enrolment list, all semesters (needed for
             //             historical terms and for fanning out assignments).
             val (selectionNos, moodleAll) = coroutineScope {
                 val selectionDef = async {
-                    if (isCurrentSemester) {
+                    if (servesSelectionSemester) {
                         try {
                             courseService.fetchEnrolledCourseNos(studentId, password)
                         } catch (e: Exception) {

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.R
 import org.ntust.app.tigerduck.data.model.Assignment
 import org.ntust.app.tigerduck.data.model.AssignmentFilter
@@ -74,6 +75,20 @@ fun HomeScreen(
     val context = LocalContext.current
     val resources = LocalResources.current
     val sections by viewModel.sections.collectAsStateWithLifecycle()
+    // Slow pulse (60s, plus every debug-clock flip) so the term gate below
+    // flips on its own when wall-clock time crosses CurrentTerm.START / .END
+    // while Home stays mounted. Both boundaries land at midnight, so a minute
+    // of latency is ample.
+    val termClockVersion by rememberAppClockVersion()
+    // Home's time slider is a "today" surface, so it is dropped outside the
+    // term rather than left to scrub a day with no classes. Reorder is
+    // unaffected — the drag handler resolves both ends by section id, never by
+    // this list's indices — and the add-section dialog still sees the full
+    // list, so a hidden section can't be added twice.
+    val visibleSections = remember(sections, termClockVersion) {
+        if (AppConstants.CurrentTerm.isInSession()) sections
+        else sections.filterNot { it.type == HomeSection.HomeSectionType.TODAY_COURSES }
+    }
     val allCourses by viewModel.allCourses.collectAsStateWithLifecycle()
     val upcomingAssignments by viewModel.upcomingAssignments.collectAsStateWithLifecycle()
     val assignmentFilter by viewModel.assignmentFilter.collectAsStateWithLifecycle()
@@ -197,7 +212,7 @@ fun HomeScreen(
                 }
 
                 itemsIndexed(
-                    items = sections,
+                    items = visibleSections,
                     key = { _, s -> s.id },
                 ) { index, section ->
                     ReorderableSection(
@@ -212,25 +227,27 @@ fun HomeScreen(
                         },
                         onDrag = { delta ->
                             dragOffsetY += delta
-                            val fromIdx = sections.indexOfFirst { it.id == section.id }
+                            val fromIdx = visibleSections.indexOfFirst { it.id == section.id }
                             if (fromIdx < 0) return@ReorderableSection
 
                             // Threshold-based swap: when the drag has crossed half of
                             // the neighbor's height, swap in the data model and
                             // compensate `dragOffsetY` so the card stays visually
                             // under the user's finger (no snap-back).
-                            if (dragOffsetY > 0 && fromIdx < sections.lastIndex) {
-                                val nextH = sectionHeights[sections[fromIdx + 1].id]
+                            if (dragOffsetY > 0 && fromIdx < visibleSections.lastIndex) {
+                                val next = visibleSections[fromIdx + 1]
+                                val nextH = sectionHeights[next.id]
                                     ?: return@ReorderableSection
                                 if (dragOffsetY > nextH / 2f) {
-                                    viewModel.moveSections(fromIdx, fromIdx + 1)
+                                    viewModel.moveSections(section.id, next.id)
                                     dragOffsetY -= nextH
                                 }
                             } else if (dragOffsetY < 0 && fromIdx > 0) {
-                                val prevH = sectionHeights[sections[fromIdx - 1].id]
+                                val prev = visibleSections[fromIdx - 1]
+                                val prevH = sectionHeights[prev.id]
                                     ?: return@ReorderableSection
                                 if (dragOffsetY < -prevH / 2f) {
-                                    viewModel.moveSections(fromIdx, fromIdx - 1)
+                                    viewModel.moveSections(section.id, prev.id)
                                     dragOffsetY += prevH
                                 }
                             }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/home/HomeViewModel.kt
@@ -36,6 +36,7 @@ import org.ntust.app.tigerduck.liveactivity.LiveActivityManager
 import org.ntust.app.tigerduck.network.CourseService
 import org.ntust.app.tigerduck.network.MoodleService
 import org.ntust.app.tigerduck.network.NetworkChecker
+import org.ntust.app.tigerduck.network.SemesterCatalog
 import org.ntust.app.tigerduck.notification.AssignmentNotificationScheduler
 import org.ntust.app.tigerduck.ui.theme.TigerDuckTheme
 import java.time.format.DateTimeFormatter
@@ -53,6 +54,7 @@ class HomeViewModel @Inject constructor(
     private val notificationScheduler: AssignmentNotificationScheduler,
     private val prefs: AppPreferences,
     private val courseColorStore: CourseColorStore,
+    private val semesterCatalog: SemesterCatalog,
     private val liveActivityManager: LiveActivityManager,
     private val widgetUpdater: org.ntust.app.tigerduck.widget.WidgetUpdater,
 ) : ViewModel() {
@@ -364,7 +366,16 @@ class HomeViewModel @Inject constructor(
         studentId: String,
         password: String,
     ): Pair<List<Course>?, List<Assignment>?> = coroutineScope {
+        // TTL-throttled, so this costs one request an hour however often Home
+        // refreshes. Resolved before the gate below, which depends on it.
+        semesterCatalog.refreshIfStale()
         val semester = courseService.currentSemesterCode()
+        // 選課 serves exactly one term and its 選課清單 page carries no term
+        // marker, so its course numbers belong to whichever term the catalogue
+        // reports as open. While that runs ahead of the term in session —
+        // 選課 for the next term opens weeks before it starts — importing them
+        // here would file the *next* term's enrolments into this term's cache.
+        val servesSelectionSemester = semester == semesterCatalog.selectionSemesterCode()
 
         // Moodle webservice calls auth with a long-lived wstoken, so they
         // don't need the NTUST SSO cookies that ensureAuthenticated refreshes.
@@ -378,6 +389,7 @@ class HomeViewModel @Inject constructor(
             }
         }
         val courseNosDef = async {
+            if (!servesSelectionSemester) return@async emptyList()
             val authed = runCatching { authService.ensureAuthenticated() }.getOrDefault(false)
             if (!authed) return@async null
             try {
@@ -617,10 +629,21 @@ class HomeViewModel @Inject constructor(
         prefs.homeSections = _sections.value
     }
 
-    fun moveSections(from: Int, to: Int) {
+    /**
+     * Moves [fromId] to [toId]'s slot.
+     *
+     * Id-based rather than index-based because Home renders a *filtered* list
+     * — the today-courses section drops out of the term window (see
+     * [org.ntust.app.tigerduck.AppConstants.CurrentTerm]) — so a position in
+     * what the user dragged is not a position in the stored layout. Resolving
+     * both ends here keeps the two from drifting.
+     */
+    fun moveSections(fromId: String, toId: String) {
         val list = _sections.value.toMutableList()
-        val item = list.removeAt(from)
-        list.add(to, item)
+        val from = list.indexOfFirst { it.id == fromId }
+        val to = list.indexOfFirst { it.id == toId }
+        if (from < 0 || to < 0 || from == to) return
+        list.add(to, list.removeAt(from))
         _sections.value = list.mapIndexed { i, s -> s.copy(sortOrder = i) }
         prefs.homeSections = _sections.value
     }

--- a/app/src/test/java/org/ntust/app/tigerduck/CurrentTermTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/CurrentTermTest.kt
@@ -1,0 +1,59 @@
+package org.ntust.app.tigerduck
+
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ntust.app.tigerduck.shared.clock.AppClock
+import org.ntust.app.tigerduck.shared.clock.ClockOverride
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class CurrentTermTest {
+
+    @After
+    fun tearDown() = AppClock.setOverride(null)
+
+    private fun freezeAt(dateTime: LocalDateTime) {
+        val millis = dateTime.atZone(AppConstants.TAIPEI_ZONE).toInstant().toEpochMilli()
+        AppClock.setOverride(
+            ClockOverride(
+                instantMillis = millis,
+                savedAtRealMillis = System.currentTimeMillis(),
+                frozen = true,
+            )
+        )
+    }
+
+    @Test
+    fun `the day before term start is out of session`() {
+        freezeAt(LocalDate.of(2026, 9, 6).atTime(23, 59))
+        assertFalse(AppConstants.CurrentTerm.isInSession())
+    }
+
+    @Test
+    fun `midnight on the first day of classes is in session`() {
+        freezeAt(LocalDate.of(2026, 9, 7).atStartOfDay())
+        assertTrue(AppConstants.CurrentTerm.isInSession())
+    }
+
+    @Test
+    fun `the last day of classes stays in session up to midnight`() {
+        freezeAt(LocalDate.of(2026, 12, 25).atTime(23, 59))
+        assertTrue(AppConstants.CurrentTerm.isInSession())
+    }
+
+    @Test
+    fun `the end bound is exclusive`() {
+        freezeAt(LocalDate.of(2026, 12, 26).atStartOfDay())
+        assertFalse(AppConstants.CurrentTerm.isInSession())
+    }
+
+    @Test
+    fun `the window is a real range, not a fail-closed sentinel`() {
+        // A date that fails to build lands at Long.MAX_VALUE, which would make
+        // isInSession false forever and silently hide today-scoped surfaces.
+        assertTrue(AppConstants.CurrentTerm.START < AppConstants.CurrentTerm.END)
+        assertTrue(AppConstants.CurrentTerm.END < Long.MAX_VALUE)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/data/DataMigrationCourseCacheTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/data/DataMigrationCourseCacheTest.kt
@@ -1,0 +1,75 @@
+package org.ntust.app.tigerduck.data
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+/**
+ * Covers the schema 2 → 3 sweep: dropping course caches that were written
+ * while 選課 served a term the month heuristic hadn't rolled over to yet.
+ */
+class DataMigrationCourseCacheTest {
+
+    @get:Rule
+    val tmp = TemporaryFolder()
+
+    private fun write(dir: File, name: String, body: String = """[{"courseNo":"AT1234"}]""") =
+        File(dir, name).apply { writeText(body) }
+
+    @Test
+    fun `drops every semester-scoped course cache`() {
+        val dir = tmp.newFolder("TigerDuckCache")
+        val spring = write(dir, "courses_1142.json")
+        val fall = write(dir, "courses_1151.json")
+
+        DataMigration.deleteCourseCaches(dir)
+
+        assertFalse(spring.exists())
+        assertFalse(fall.exists())
+    }
+
+    @Test
+    fun `drops the pre-semester-scoped legacy cache too`() {
+        val dir = tmp.newFolder("TigerDuckCache")
+        val legacy = write(dir, "courses.json")
+
+        DataMigration.deleteCourseCaches(dir)
+
+        assertFalse(legacy.exists())
+    }
+
+    @Test
+    fun `deletes well-formed caches, unlike the content-sniffing v1_4_0 sweep`() {
+        // The wrong-semester payload is indistinguishable from a correct one
+        // at the file level — both carry un-obfuscated `"courseNo":` keys — so
+        // this step must not gate on content the way migrate1to2 does.
+        val dir = tmp.newFolder("TigerDuckCache")
+        val healthy = write(dir, "courses_1151.json", """[{"courseNo":"AT1234","displayName":"X"}]""")
+
+        DataMigration.deleteCourseCaches(dir)
+
+        assertFalse(healthy.exists())
+    }
+
+    @Test
+    fun `leaves manual courses and unrelated caches alone`() {
+        // Manual courses have no remote source to rebuild from — deleting them
+        // would destroy timetable rows the user typed in by hand.
+        val dir = tmp.newFolder("TigerDuckData")
+        val manual = write(dir, "manual_courses_1151.json")
+        val assignments = write(dir, "assignments.json")
+
+        DataMigration.deleteCourseCaches(dir)
+
+        assertTrue(manual.exists())
+        assertTrue(assignments.exists())
+    }
+
+    @Test
+    fun `a missing directory is a no-op`() {
+        DataMigration.deleteCourseCaches(File(tmp.root, "does-not-exist"))
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/network/SemesterCatalogTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/network/SemesterCatalogTest.kt
@@ -1,0 +1,82 @@
+package org.ntust.app.tigerduck.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SemesterCatalogTest {
+
+    /** Trimmed verbatim from the live endpoint on 2026-08-22. */
+    private val realPayload = """
+        [{"Semester":"1151","EngSemester":"2026 Fall","Static":false,"LoginEnable":true,"ShowRemind":false,"CurrentSemester":true},
+         {"Semester":"114H","EngSemester":"2026 Summer","Static":false,"LoginEnable":false,"ShowRemind":false,"CurrentSemester":true},
+         {"Semester":"1142","EngSemester":"2026 Spring","Static":false,"LoginEnable":false,"ShowRemind":false,"CurrentSemester":true},
+         {"Semester":"1141","EngSemester":"2025 Fall","Static":false,"LoginEnable":false,"ShowRemind":false,"CurrentSemester":true}]
+    """.trimIndent()
+
+    @Test
+    fun `decodes the live payload newest first`() {
+        val list = SemesterCatalog.decodeSemesters(realPayload)
+        assertEquals(listOf("1151", "114H", "1142", "1141"), list.map { it.semester })
+    }
+
+    @Test
+    fun `open term comes from LoginEnable, not from position`() {
+        // Deliberately puts the open term third: the whole point of reading
+        // LoginEnable is that "newest published" and "what 選課 is serving"
+        // are different questions.
+        val outOfOrder = """
+            [{"Semester":"1152","LoginEnable":false},
+             {"Semester":"1151","LoginEnable":false},
+             {"Semester":"1142","LoginEnable":true}]
+        """.trimIndent()
+        assertEquals("1142", SemesterCatalog.openTerm(SemesterCatalog.decodeSemesters(outOfOrder)))
+    }
+
+    @Test
+    fun `no open term yields null so the caller keeps its previous value`() {
+        val none = """[{"Semester":"1151","LoginEnable":false}]"""
+        assertNull(SemesterCatalog.openTerm(SemesterCatalog.decodeSemesters(none)))
+    }
+
+    @Test
+    fun `missing LoginEnable key defaults to not-open rather than crashing`() {
+        // Gson instantiates data classes through Unsafe, so an absent key
+        // leaves the JVM zero value. For a Boolean that is `false`, which is
+        // the safe reading — see the upgrade-safe-persistence checklist.
+        val list = SemesterCatalog.decodeSemesters("""[{"Semester":"1151"}]""")
+        assertEquals(1, list.size)
+        assertNull(SemesterCatalog.openTerm(list))
+    }
+
+    @Test
+    fun `rows without a semester code are dropped`() {
+        val list = SemesterCatalog.decodeSemesters(
+            """[{"LoginEnable":true},{"Semester":"","LoginEnable":true},{"Semester":"1151","LoginEnable":true}]"""
+        )
+        assertEquals(listOf("1151"), list.map { it.semester })
+    }
+
+    @Test
+    fun `malformed payload decodes to empty instead of throwing`() {
+        assertTrue(SemesterCatalog.decodeSemesters("not json").isEmpty())
+        assertTrue(SemesterCatalog.decodeSemesters("").isEmpty())
+    }
+
+    @Test
+    fun `picker depth reaches back two years across interleaved summer terms`() {
+        // 1151, 114H, 1142, 1141, 113H, 1132 — four slots would stop at 1141.
+        val list = SemesterCatalog.decodeSemesters(
+            """
+            [{"Semester":"1151","LoginEnable":true},{"Semester":"114H","LoginEnable":false},
+             {"Semester":"1142","LoginEnable":false},{"Semester":"1141","LoginEnable":false},
+             {"Semester":"113H","LoginEnable":false},{"Semester":"1132","LoginEnable":false},
+             {"Semester":"1131","LoginEnable":false}]
+            """.trimIndent()
+        )
+        val offered = list.mapNotNull { it.semester }.take(SemesterCatalog.PICKER_DEPTH)
+        assertTrue("1132" in offered)
+        assertEquals(SemesterCatalog.PICKER_DEPTH, offered.size)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/network/SemesterCodesTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/network/SemesterCodesTest.kt
@@ -1,0 +1,66 @@
+package org.ntust.app.tigerduck.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SemesterCodesTest {
+
+    @Test
+    fun `previous walks term 2 back to term 1 of the same year`() {
+        assertEquals("1151", SemesterCodes.previous("1152"))
+    }
+
+    @Test
+    fun `previous walks term 1 back across the year boundary`() {
+        assertEquals("1142", SemesterCodes.previous("1151"))
+    }
+
+    @Test
+    fun `previous leaves a summer term alone rather than inventing one`() {
+        // The catalogue publishes 暑期 as `114H`; the arithmetic has no rule
+        // for it, and returning garbage would be worse than standing still.
+        assertEquals("114H", SemesterCodes.previous("114H"))
+    }
+
+    @Test
+    fun `previous leaves a malformed code alone`() {
+        assertEquals("", SemesterCodes.previous(""))
+        assertEquals("abc", SemesterCodes.previous("abc"))
+    }
+
+    @Test
+    fun `walkBack yields the requested number of terms newest first`() {
+        assertEquals(
+            listOf("1151", "1142", "1141", "1132"),
+            SemesterCodes.walkBack("1151", 4),
+        )
+    }
+
+    @Test
+    fun `walkBack stops early rather than repeating a fixed point`() {
+        // `previous` is identity for summer terms, so the walk would otherwise
+        // emit the same code four times.
+        assertEquals(listOf("114H"), SemesterCodes.walkBack("114H", 4))
+    }
+
+    @Test
+    fun `walking back from the pinned term reaches the term it replaced`() {
+        // The pre-catalogue picker fallback must anchor on the pinned term,
+        // not on the month heuristic. Anchoring on the heuristic in August
+        // 2026 would produce 1142, 1141, 1132, 1131 — dropping the 115-1 term
+        // NTUST had already opened, which is the bug this hotfix fixes.
+        val offered = SemesterCodes.walkBack(org.ntust.app.tigerduck.AppConstants.CurrentTerm.CODE, 4)
+        assertEquals(listOf("1151", "1142", "1141", "1132"), offered)
+    }
+
+    @Test
+    fun `heuristic returns a well-formed code`() {
+        // Deliberately not asserting a specific term: the heuristic reads the
+        // wall clock, and pinning it here would make the test expire. What
+        // matters is that the fallback stays parseable by `previous`.
+        val code = SemesterCodes.heuristic()
+        assertEquals(4, code.length)
+        assert(code.last() == '1' || code.last() == '2')
+        assert(code.dropLast(1).toIntOrNull() != null)
+    }
+}

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.4.2-fdroid
-    versionCode: 20
+  - versionName: 1.4.3-fdroid
+    versionCode: 21
     commit: bfd52def4fea37d7f8c473c1a4b3c01512bf1b07
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.2-fdroid
-CurrentVersionCode: 20
+CurrentVersion: 1.4.3-fdroid
+CurrentVersionCode: 21

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 30
         targetSdk = 36
-        versionCode = 20
-        versionName = "1.4.2"
+        versionCode = 21
+        versionName = "1.4.3"
     }
 
     buildTypes {


### PR DESCRIPTION
Ports the iOS 115-1 hotfix cluster (`tigerduck-app` `ad50850`, `d47e82f`, `4c9db92`, `3cae3aa`, `90bbce7`) to Android.

## Note
This is a hotfix, not localization (i18n) submodule is INTENTIONALLY NOT UPDATED for the app to work.

## The bug

`currentSemesterCode()` was a gregorian-month heuristic, so it lagged whenever NTUST published a term early. On 2026-08-20 it still returned `114-2` while the school had already opened `115-1`, breaking the class table two ways:

- the picker walked back four terms from the heuristic, so **115-1 never appeared in it**;
- the 選課 system had already flipped to 115-1, and its 選課清單 page carries **no term marker anywhere in the HTML**, so those enrolments were filed under the heuristic's 114-2 and **both terms rendered into one grid**.

## Changes

- **`AppConstants.CurrentTerm`** pins 115-1 to 2026-09-07 → 2026-12-25 (Taipei). Deliberately hard-coded — nothing in the app knows when classes start or end. Every consumer (today's courses, widget, Wear tile, cache keys) now agrees on 115-1. The month heuristic survives as `SemesterCodes.heuristic()` / `CourseService.heuristicSemesterCode()`, so lifting the pin is a one-line change. The date window fails closed.
- **`SemesterCatalog`** resolves the term list from the public `querycourse` endpoint the official course-query site uses for its own menu. Its `LoginEnable` flag marks the single term 選課 is operating on — exactly the attribution the scrape was missing. TTL-throttled to one request an hour.
- **Attribution split.** 選課 enrolments are now gated and filed by the *open* term rather than the term *in session* — those differ for weeks at a time. Applied in `ClassTableViewModel`, `HomeViewModel` and `BackgroundSyncWorker`.
- **Picker default** is the last pick, else the newest published term. The fallback is not persisted, so an untouched picker keeps tracking the newest term instead of freezing on whichever was newest at install.
- **`DataMigration` step 2 → 3** drops `courses_<semester>.json` written while 選課 served 115-1. Cache-dir only — manual courses live in `filesDir`, are already per-semester, and have no remote source to rebuild from.
- **Term gate.** Home's time slider and the class table's today carousel render only while `isInSession`. Home's reorder became id-based, since the rendered list is now filtered and its indices no longer match the stored layout.
- **`DataMigration` moved to `TigerDuckApp.onCreate`.** It previously only ran from `AppState.init`, which `MainActivity` constructs — but `BackgroundSyncWorker` is registered with `enqueueUniquePeriodicWork` and WorkManager persists that across an upgrade, so it could fire with no Activity, sync, and write a cache the pending migration then deleted. `BootReceiver` reaches the cache the same way. Mirrors iOS `47dabe4` / `be3b3fc`.

Two iOS commits needed no port: `classTableSelectedSemester` was already `String?` here, and manual courses already live in per-semester `manual_courses_<sem>.json`, so iOS #183 is structurally satisfied.

## Notable deviation from iOS

The catalogue's offline fallbacks anchor on the **pinned term**, not on the month heuristic. Anchoring on the heuristic reproduces the original bug whenever the endpoint is unreachable (115-1 drops out of the picker, 選課 fetch is skipped) and buys no protection during a future overlap, since the heuristic then names the term in session and mis-attributes anyway. This matches iOS in effect — its fallbacks route through its own `currentSemesterCode()`, which is pinned to the same term.

## Verification

**Upgrade test on a physical phone (ASUS_I01WD), release builds, R8 + resource shrinking:**

Installed v1.4.2 `playRelease`, logged in, synced a real timetable, then installed this branch's `playRelease` over it. First launch after upgrade:

```
I/DataMigration: Cleared wrong-semester course cache: courses_1142.json
I/ClassTableVM:  fetchData start: semester=1151 isCurrent=true servesSelection=true
I/ClassTableVM:  selectionNos=7 -> [CS3009301, CS3025301, CS3044701, CS3051701, CS4001301, FE1592701, PE115A053]
I/ClassTableVM:  moodleForSem[1151]=7 -> [PE115A053, FE1592701, CS4001301, CS3051701, CS3044701, CS3025301, CS3009301]
```

That `courses_1142.json` **is the bug** — the 1.4.2 install had filed its 115-1 enrolments under 114-2. The migration caught it, and both enrolment sources then agreed on 7 courses under 1151. No `FATAL EXCEPTION`, no NPE, no ANR.

Caveat: these APKs were signed with the debug keystore rather than `app/keystore.jks`, whose password lives only in CI env vars. The key only needs to be consistent across the two installs; it has no bearing on the R8/Gson behaviour under test.

**Other:** 42 unit tests pass (24 new — `SemesterCatalogTest`, `SemesterCodesTest`, `CurrentTermTest`, `DataMigrationCourseCacheTest`). `play` + `fdroid` + `wear` all compile. R8 release `mapping.txt` confirms `network.model.SemesterInfo` survives unrenamed, so `@SerializedName` cannot be undercut.

`:app` gains `unitTests.isReturnDefaultValues`, matching `:shared`, so migration code can be covered without stripping its logging.

## For the checklist

- Flavors were compiled via Gradle directly, not the `debug/` scripts. One pre-existing deprecation warning remains (`Haptics.kt:68`, `HAPTIC_FEEDBACK_ENABLED`) — not introduced here.
- The 1.4.2 → 1.4.3 upgrade path is verified above on a real device.
- **Not verified: upgrades from 3 versions back** (1.3.8 / 1.4.0 / 1.4.1). The `0→1→2→3` migration chain covers them by construction, and step `1→2`'s content sentinel is untouched, but no device test was run for those paths.
