### PR TITLE
hotfix: 1.4.4 — fix 1.4.3 launch crash, gate class notifications and widgets on 開學

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,8 +46,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 29
         targetSdk = 36
-        versionCode = 21
-        versionName = "1.4.3"
+        versionCode = 22
+        versionName = "1.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/AppConstants.kt
@@ -30,10 +30,16 @@ object AppConstants {
      * [isInSession] and needs no change.
      */
     object CurrentTerm {
+        // TODO(開學時間): CODE / START / END are hard-coded for 115-1. Replace
+        //  them with a backend-served 開學時間 / 結業時間 so a term rollover stops
+        //  needing an app release. Every consumer already goes through [CODE],
+        //  [isInSession] or [containsDate], so only this object has to change
+        //  when that lands.
+
         /** 115 學年度第 1 學期. */
         const val CODE = "1151"
 
-        /** First day of classes, Taipei wall time. */
+        /** First day of classes (開學日), Taipei wall time. */
         val START: Long = taipeiEpochMillis(2026, 9, 7)
 
         /**
@@ -52,6 +58,27 @@ object AppConstants {
         fun isInSession(): Boolean {
             val now = AppClock.nowMillis()
             return now in START..<END
+        }
+
+        /**
+         * True when [date] falls inside the term.
+         *
+         * Date-level counterpart to [isInSession], for the notification paths
+         * that decide per-day rather than per-instant: class-preparing alarms
+         * are armed several days ahead, and the Live Update resolves today's
+         * slots. Both read straight from the timetable, which is already
+         * populated well before 開學 — 選課 opens weeks ahead of the term — so
+         * without this gate the app fires 即將上課 for classes that have not
+         * started yet.
+         *
+         * Fails closed exactly as [isInSession] does: a date that cannot be
+         * resolved reads false rather than leaking a notification.
+         */
+        fun containsDate(date: LocalDate): Boolean {
+            val startOfDay = runCatching {
+                date.atStartOfDay(TAIPEI_ZONE).toInstant().toEpochMilli()
+            }.getOrNull() ?: return false
+            return startOfDay in START..<END
         }
 
         /**

--- a/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/data/cache/DataCache.kt
@@ -88,12 +88,12 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
             type,
             coursesFilename(semester),
             requireContent = COURSE_NO_TOKEN,
-        ) ?: emptyList()
+        )?.let(::usableRows) ?: emptyList()
         val manual = loadFromUserData<List<Course>>(
             type,
             manualCoursesFilename(semester),
             requireContent = COURSE_NO_TOKEN,
-        ) ?: emptyList()
+        )?.let(::usableRows) ?: emptyList()
         if (manual.isEmpty()) return remote
         val manualNos = manual.map { it.courseNo }.toSet()
         return remote.filter { it.courseNo !in manualNos } + manual
@@ -407,7 +407,7 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
             }
         }
 
-    private companion object {
+    internal companion object {
         // Sentinel literal present in any course JSON written by a build
         // with un-obfuscated field names. Used by loadCourses to reject
         // R8-obfuscated v1.4.0 cache files before they reach Gson.
@@ -416,5 +416,28 @@ class DataCache @Inject constructor(@ApplicationContext context: Context) {
         // include an unescaped quote+colon pair, so it can't satisfy the
         // check and slip past as if the keys were un-obfuscated.
         const val COURSE_NO_TOKEN = "\"courseNo\":"
+
+        /**
+         * Drops rows Gson left un-populated.
+         *
+         * [COURSE_NO_TOKEN] is necessary but not sufficient: it proves the
+         * writer used un-obfuscated field names, but only that the *key* is
+         * present — `{"courseNo":null}` satisfies it just as well. Gson's
+         * `Unsafe.allocateInstance` path bypasses the Kotlin constructor, so an
+         * absent or explicitly-null key leaves a non-null-declared `String`
+         * holding null, with no intrinsic check at the read site to catch it.
+         *
+         * [Course.courseNo] is the identity every lookup keys on and
+         * [Course.courseName] backs [Course.displayName], so a row missing
+         * either is unusable — and it NPEs far from here, in
+         * `TigerDuckTheme.courseHashIndex` (`courseNo.fold {}`) or
+         * `WearScheduleBridge.toDto`, neither of which null-checks first.
+         *
+         * Deliberately additive to the sentinel, not a replacement for it —
+         * the sentinel still rejects whole obfuscated files before Gson runs.
+         */
+        @Suppress("SENSELESS_COMPARISON")
+        internal fun usableRows(courses: List<Course>): List<Course> =
+            courses.filter { it.courseNo != null && it.courseName != null }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolver.kt
@@ -105,6 +105,12 @@ class LiveActivityResolver {
             else -> 1
         }
         val today = now.toInstant().atZone(AppConstants.TAIPEI_ZONE).toLocalDate()
+        // Outside the term there are no class slots to surface, so the Live
+        // Update shows neither 上課中 nor 即將上課 before 開學 — the timetable is
+        // already cached by then because 選課 runs weeks ahead of the term.
+        // Gating here rather than in resolve() also stops todaySlotsAfter from
+        // arming boundary alarms for pre-term days.
+        if (!AppConstants.CurrentTerm.containsDate(today)) return emptyList()
 
         val results = mutableListOf<Slot>()
         for (course in courses) {

--- a/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/network/MoodleService.kt
@@ -185,13 +185,11 @@ class MoodleService @Inject constructor(
             response.body.string()
         }
         MoodleWebserviceError.fromJsonBody(body)?.let { throw it }
-        val type = object : TypeToken<List<MoodleEnrolledCourse>>() {}.type
-        val courses: List<MoodleEnrolledCourse> = try {
-            gson.fromJson(body, type)
+        return try {
+            decodeEnrolledCourses(body)
         } catch (e: Exception) {
             throw MoodleWebserviceError.MalformedResponse("enrolled response not decodable: ${e.message}")
-        } ?: emptyList()
-        return courses
+        }
     }
 
     private fun callGetAssignments(token: String, courseIds: List<Int>): MoodleAssignmentsEnvelope {
@@ -254,5 +252,36 @@ class MoodleService @Inject constructor(
         val courseNoRegex = Regex("3?[A-Z]{2}[A-Z0-9]{6,7}")
         val idx = parts.indexOfFirst { courseNoRegex.containsMatchIn(it) }
         return if (idx >= 0 && idx + 1 < parts.size) parts[idx + 1] else fullname
+    }
+
+    companion object {
+        private val decodeGson = Gson()
+
+        /**
+         * Decodes a `core_enrol_get_users_courses` payload, dropping rows Gson
+         * could not build.
+         *
+         * Split out from [callEnrolledCourses] so the case that actually
+         * matters is testable offline, mirroring [SemesterCatalog.decodeSemesters].
+         *
+         * Gson does not strip nulls out of a JSON array: `[null, {...}]`
+         * decodes to a list *holding* a null while Kotlin's type system insists
+         * the element type is non-null, and the familiar `?: emptyList()` only
+         * covers the whole list being null. Every downstream read in
+         * [org.ntust.app.tigerduck.ui.screen.classtable.ClassTableViewModel]'s
+         * `fetchData` — `it.idnumber`, `it.semesterCode`, `it.courseNo` — then
+         * dereferences elements outside any try/catch, so one null row used to
+         * reach the default uncaught handler and take down the process rather
+         * than fail a single refresh.
+         *
+         * Gson decode failures propagate; the caller wraps them in
+         * [MoodleWebserviceError.MalformedResponse].
+         */
+        internal fun decodeEnrolledCourses(json: String): List<MoodleEnrolledCourse> {
+            val type = object : TypeToken<List<MoodleEnrolledCourse>>() {}.type
+            val decoded: List<MoodleEnrolledCourse?> =
+                decodeGson.fromJson(json, type) ?: emptyList()
+            return decoded.filterNotNull()
+        }
     }
 }

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationReceiver.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationReceiver.kt
@@ -28,6 +28,18 @@ class ClassPreparingNotificationReceiver : BroadcastReceiver() {
         // collide the way slotId.hashCode() could.
         val notificationId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
         if (notificationId < 0) return
+
+        // Defence in depth for the term gate, which primarily lives in
+        // ClassPreparingNotificationScheduler.upcomingSlots. v1.4.3 armed these
+        // alarms for pre-開學 days, and an AlarmManager entry outlives the
+        // upgrade until the next scheduleAll cancels it — which only happens on
+        // the next sync or Live Update refresh. Until then a stale alarm would
+        // still land here and post, so re-check at the point of posting rather
+        // than trusting that the alarm should have existed at all.
+        val startDate = runCatching {
+            Instant.ofEpochMilli(startMs).atZone(AppConstants.TAIPEI_ZONE).toLocalDate()
+        }.getOrNull()
+        if (startDate == null || !AppConstants.CurrentTerm.containsDate(startDate)) return
         // The lead-time extra lets us auto-cancel the "即將上課" notification when
         // class actually starts: post-time + leadTimeMs ≈ classStart. Without it
         // (older intents from before the field existed) we fall back to manual

--- a/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationScheduler.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/notification/ClassPreparingNotificationScheduler.kt
@@ -175,6 +175,11 @@ class ClassPreparingNotificationScheduler @Inject constructor(
         val results = mutableListOf<UpcomingSlot>()
         for (dayOffset in 0 until daysAhead) {
             val date = today.plusDays(dayOffset.toLong())
+            // No 即將上課 alarms outside the term. The timetable is populated
+            // weeks before 開學 (選課 opens ahead of the term), and this loop
+            // looks DAYS_AHEAD days out, so an install in late August would
+            // otherwise arm notifications for classes that have not started.
+            if (!AppConstants.CurrentTerm.containsDate(date)) continue
             val weekdayIdx = when (date.dayOfWeek.value) {
                 in 1..7 -> date.dayOfWeek.value // Monday=1 .. Sunday=7
                 else -> continue

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
@@ -940,6 +941,20 @@ class ClassTableViewModel @Inject constructor(
                 assignmentsJob?.join()
             }
             _syncCompleteEvent.tryEmit(Unit)
+        } catch (e: CancellationException) {
+            // Structured concurrency: viewModelScope cancellation has to keep
+            // propagating, or navigating away mid-refresh leaves this coroutine
+            // running against a dead screen.
+            throw e
+        } catch (e: Exception) {
+            // This method had no catch at all. Nothing here is guarded except
+            // the per-course lookups and the assignments job, so anything that
+            // threw in between — a null row in a network payload, a cache row
+            // Gson could not populate — propagated out of viewModelScope. With
+            // no CoroutineExceptionHandler anywhere in the app, that reached
+            // the default uncaught handler and killed the process instead of
+            // failing one refresh. This is the only boundary in that path.
+            Log.e("ClassTableVM", "fetchData failed", e)
         } finally {
             _isLoading.value = false
         }

--- a/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/ui/screen/classtable/ClassTableViewModel.kt
@@ -99,6 +99,49 @@ class ClassTableViewModel @Inject constructor(
 
     private var hasLoaded = false
 
+    /**
+     * Terms the picker offers, newest first, as published by NTUST — see
+     * [SemesterCatalog]. A `StateFlow` rather than a computed getter so a term
+     * the school publishes ahead of the month heuristic (115-1 opened weeks
+     * before the heuristic rolled off 114-2) becomes selectable in the same
+     * session the catalogue lands.
+     */
+    private val _availableSemesters = MutableStateFlow(semesterOptions(_currentSemester.value))
+    val availableSemesters: StateFlow<List<String>> = _availableSemesters
+
+    private val _tripleConflictEvent = MutableSharedFlow<TripleConflictError>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val tripleConflictEvent: SharedFlow<TripleConflictError> = _tripleConflictEvent.asSharedFlow()
+
+    private val _noNetworkEvent = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val noNetworkEvent: SharedFlow<Unit> = _noNetworkEvent.asSharedFlow()
+
+    private val _syncCompleteEvent = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val syncCompleteEvent: SharedFlow<Unit> = _syncCompleteEvent.asSharedFlow()
+
+    // EVERY property this class touches must be declared ABOVE this block.
+    //
+    // Kotlin runs property initializers and init blocks in declaration order,
+    // and the collectors below do not reliably reach a suspension point before
+    // touching ViewModel state: `viewModelScope` dispatches on
+    // Dispatchers.Main.immediate, the ViewModel is constructed on the main
+    // thread, so `launch` runs its body inline rather than posting it. The
+    // authState collector below then sees the StateFlow's current value
+    // immediately — for an already-logged-in user that means fetchData() runs
+    // to completion inside this constructor.
+    //
+    // v1.4.3 shipped `_availableSemesters` declared *after* here and assigned
+    // from fetchData, so it was still null on that inline path and every
+    // launch crashed with "MutableStateFlow.setValue on a null object
+    // reference". Declaring state below this block re-arms that.
     init {
         viewModelScope.launch {
             // Tick at 5s so transitions land within at most a few seconds of
@@ -187,16 +230,6 @@ class ClassTableViewModel @Inject constructor(
     /** The actual live semester code (not whatever the user picked). */
     val liveSemesterCode: String
         get() = courseService.currentSemesterCode()
-
-    /**
-     * Terms the picker offers, newest first, as published by NTUST — see
-     * [SemesterCatalog]. A `StateFlow` rather than a computed getter so a term
-     * the school publishes ahead of the month heuristic (115-1 opened weeks
-     * before the heuristic rolled off 114-2) becomes selectable in the same
-     * session the catalogue lands.
-     */
-    private val _availableSemesters = MutableStateFlow(semesterOptions(_currentSemester.value))
-    val availableSemesters: StateFlow<List<String>> = _availableSemesters
 
     /**
      * Keeps the persisted selection selectable even after it ages out of the
@@ -668,12 +701,6 @@ class ClassTableViewModel @Inject constructor(
         return null
     }
 
-    private val _tripleConflictEvent = MutableSharedFlow<TripleConflictError>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-    val tripleConflictEvent: SharedFlow<TripleConflictError> = _tripleConflictEvent.asSharedFlow()
-
     fun load() {
         if (hasLoaded) return
         hasLoaded = true
@@ -692,18 +719,6 @@ class ClassTableViewModel @Inject constructor(
             fetchData()
         }
     }
-
-    private val _noNetworkEvent = MutableSharedFlow<Unit>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    val noNetworkEvent: SharedFlow<Unit> = _noNetworkEvent.asSharedFlow()
-
-    private val _syncCompleteEvent = MutableSharedFlow<Unit>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    val syncCompleteEvent: SharedFlow<Unit> = _syncCompleteEvent.asSharedFlow()
 
     fun refresh() {
         viewModelScope.launch {

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetBoundaryScheduler.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetBoundaryScheduler.kt
@@ -43,12 +43,14 @@ class WidgetBoundaryScheduler @Inject constructor(
             firstBoundaryOnOrAfterTomorrow(courses, weekday) ?: return
         }
 
+        val triggerMillis = chooseTriggerMillis(triggerCal.timeInMillis, AppClock.nowMillis())
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !alarmManager.canScheduleExactAlarms()) {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, AppClock.realTimeFor(triggerCal.timeInMillis), pi)
+            alarmManager.set(AlarmManager.RTC_WAKEUP, AppClock.realTimeFor(triggerMillis), pi)
         } else {
             alarmManager.setExactAndAllowWhileIdle(
                 AlarmManager.RTC_WAKEUP,
-                AppClock.realTimeFor(triggerCal.timeInMillis),
+                AppClock.realTimeFor(triggerMillis),
                 pi
             )
         }
@@ -90,6 +92,29 @@ class WidgetBoundaryScheduler @Inject constructor(
     companion object {
         internal const val ACTION_BOUNDARY = "org.ntust.app.tigerduck.WIDGET_BOUNDARY"
         internal const val REQUEST_CODE = 9001
+
+        /**
+         * Earlier of the next class boundary and the next 開學 / 結業 flip.
+         *
+         * A term boundary silently changes what the Today and Next Class
+         * widgets are allowed to show — [AppConstants.CurrentTerm.isInSession]
+         * flips at midnight on START — but nothing announces it. The widgets
+         * only re-read that flag when something asks them to redraw, and the
+         * next thing that does is the *first class boundary of 開學日*. Left
+         * alone they would sit on their pre-term empty state through the whole
+         * first morning of the term, which is the morning students are most
+         * likely to look. Same shape at 結業.
+         *
+         * The refresh this triggers re-enters [scheduleForToday], which re-arms
+         * the ordinary boundary chain, so a term flip costs one extra alarm per
+         * term and nothing after it.
+         */
+        internal fun chooseTriggerMillis(boundaryMillis: Long, appNowMillis: Long): Long {
+            val nextTermFlip = listOf(AppConstants.CurrentTerm.START, AppConstants.CurrentTerm.END)
+                .filter { it > appNowMillis }
+                .minOrNull() ?: return boundaryMillis
+            return minOf(nextTermFlip, boundaryMillis)
+        }
 
         internal fun nextBoundaryMinuteAfter(
             courses: List<Course>,

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetDataLoader.kt
@@ -41,12 +41,21 @@ object WidgetDataLoader {
         val weekday = cal.toWeekday()
         val minuteOfDay = cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE)
 
-        val ongoingInfos = computeOngoingCourses(courses, weekday, minuteOfDay)
+        // 選課 fills the timetable weeks before classes begin, so having courses
+        // is not evidence the term has started. Every "now"-scoped derivation
+        // below is suppressed outside it: with all three empty, both Next Class
+        // layouts fall through to their "no more classes" branch on their own.
+        // `courses` itself is left alone — the Week grid is a reference
+        // timetable and keeps rendering, matching the class table screen.
+        val inSession = AppConstants.CurrentTerm.isInSession()
+
+        val ongoingInfos =
+            if (inSession) computeOngoingCourses(courses, weekday, minuteOfDay) else emptyList()
         val ongoingNos = ongoingInfos.map { it.course.courseNo }
-        val nextCourseTodayNo = computeNextCourseTodayNo(
-            courses, weekday, minuteOfDay, ongoingNos,
-        )
-        val tomorrowFirst = computeTomorrowFirst(courses, weekday)
+        val nextCourseTodayNo = if (inSession) {
+            computeNextCourseTodayNo(courses, weekday, minuteOfDay, ongoingNos)
+        } else null
+        val tomorrowFirst = if (inSession) computeTomorrowFirst(courses, weekday) else null
 
         return WidgetState(
             courses = courses,
@@ -55,6 +64,7 @@ object WidgetDataLoader {
             currentWeekday = weekday,
             currentMinuteOfDay = minuteOfDay,
             isLoggedIn = isLoggedIn,
+            isTermInSession = inSession,
             ongoingCourseNos = ongoingNos,
             nextCourseTodayNo = nextCourseTodayNo,
             tomorrowFirstCourseNo = tomorrowFirst?.courseNo,

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetState.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/WidgetState.kt
@@ -11,6 +11,17 @@ data class WidgetState(
     val currentWeekday: Int,
     val currentMinuteOfDay: Int,
     val isLoggedIn: Boolean,
+    /**
+     * Whether [org.ntust.app.tigerduck.AppConstants.CurrentTerm] is in session.
+     *
+     * Gates the "today"-scoped widgets — Next Class and Today — which would
+     * otherwise announce classes for a term that has not started, since 選課
+     * populates the timetable weeks before 開學. The Week grid deliberately
+     * ignores this and keeps rendering: it is a reference timetable, matching
+     * the class table screen, where the today carousel hides outside the term
+     * but the grid stays.
+     */
+    val isTermInSession: Boolean,
     val ongoingCourseNos: List<String>,
     val nextCourseTodayNo: String?,
     /**

--- a/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
+++ b/app/src/main/java/org/ntust/app/tigerduck/widget/content/TodayListContent.kt
@@ -44,7 +44,12 @@ fun TodayListContent(state: WidgetState, colors: WidgetColors, tapAction: Action
     val isWeekend = today == 6 || today == 7
     val order = AppConstants.Periods.chronologicalOrder
 
-    val todayCourses = state.courses
+    // Today is a "today"-scoped surface, so it stays empty until 開學 — the
+    // timetable is cached weeks ahead and would otherwise list classes for a
+    // term that has not started. Filtered here rather than in WidgetDataLoader
+    // because this reads `state.courses` directly, and the Week grid shares
+    // that list and deliberately keeps rendering outside the term.
+    val todayCourses = (if (state.isTermInSession) state.courses else emptyList())
         .filter { it.schedule.containsKey(today) }
         .sortedBy { course ->
             course.schedule[today]!!

--- a/app/src/test/java/org/ntust/app/tigerduck/CurrentTermTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/CurrentTermTest.kt
@@ -56,4 +56,54 @@ class CurrentTermTest {
         assertTrue(AppConstants.CurrentTerm.START < AppConstants.CurrentTerm.END)
         assertTrue(AppConstants.CurrentTerm.END < Long.MAX_VALUE)
     }
+
+    // containsDate — the per-day gate the notification paths use. 開學 is
+    // 2026-09-07, and nothing class-shaped may fire before it.
+
+    @Test
+    fun `the day before 開學 is outside the term`() {
+        assertFalse(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 9, 6)))
+    }
+
+    @Test
+    fun `開學日 itself is inside the term`() {
+        assertTrue(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 9, 7)))
+    }
+
+    @Test
+    fun `the last day of classes is inside the term`() {
+        assertTrue(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 12, 25)))
+    }
+
+    @Test
+    fun `the day after the last day of classes is outside the term`() {
+        assertFalse(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 12, 26)))
+    }
+
+    /**
+     * The regression this gate exists for: the timetable is already cached in
+     * late August because 選課 runs weeks ahead, and the class-preparing
+     * scheduler arms alarms several days out — so every pre-開學 day it can
+     * reach must read false.
+     */
+    @Test
+    fun `no day in the pre-開學 scheduling window is in the term`() {
+        val firstDay = LocalDate.of(2026, 9, 7)
+        for (offset in 1..14) {
+            val date = firstDay.minusDays(offset.toLong())
+            assertFalse(
+                "$date is before 開學 and must not schedule class notifications",
+                AppConstants.CurrentTerm.containsDate(date),
+            )
+        }
+    }
+
+    @Test
+    fun `containsDate does not depend on the debug clock`() {
+        // Unlike isInSession, this answers "is that date in the term", so a
+        // frozen clock must not change the verdict for a given date.
+        freezeAt(LocalDate.of(2026, 8, 30).atTime(9, 0))
+        assertTrue(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 9, 7)))
+        assertFalse(AppConstants.CurrentTerm.containsDate(LocalDate.of(2026, 9, 6)))
+    }
 }

--- a/app/src/test/java/org/ntust/app/tigerduck/data/cache/DataCacheUsableRowsTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/data/cache/DataCacheUsableRowsTest.kt
@@ -1,0 +1,93 @@
+package org.ntust.app.tigerduck.data.cache
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ntust.app.tigerduck.data.model.Course
+
+/**
+ * Covers the gap between `COURSE_NO_TOKEN` and an actually-usable row.
+ *
+ * The sentinel proves a cache file was written with un-obfuscated field names,
+ * but only that the *key* is present. Gson's `Unsafe.allocateInstance` path
+ * bypasses the Kotlin constructor, so a row whose `courseNo` is absent — or
+ * explicitly null — deserializes into a `Course` holding null in a field the
+ * type system declares non-null, and nothing checks it until
+ * `TigerDuckTheme.courseHashIndex` calls `courseNo.fold {}`.
+ *
+ * These build the rows through Gson rather than the constructor on purpose:
+ * the constructor cannot produce the state under test.
+ */
+class DataCacheUsableRowsTest {
+
+    private val gson = Gson()
+
+    private fun rows(json: String): List<Course> =
+        gson.fromJson(json, object : TypeToken<List<Course>>() {}.type)
+
+    @Test
+    fun `a row with an explicitly null courseNo still satisfies the sentinel`() {
+        val json = """[{"courseNo":null,"courseName":"課程"}]"""
+
+        // This is why the sentinel alone was not enough.
+        assertTrue(json.contains(DataCache.COURSE_NO_TOKEN))
+        assertTrue(DataCache.usableRows(rows(json)).isEmpty())
+    }
+
+    @Test
+    fun `a row missing courseNo entirely is dropped`() {
+        val json = """[{"courseName":"課程"}]"""
+
+        assertTrue(DataCache.usableRows(rows(json)).isEmpty())
+    }
+
+    @Test
+    fun `a row missing courseName is dropped because displayName falls back to it`() {
+        val json = """[{"courseNo":"AT1234"}]"""
+
+        assertTrue(DataCache.usableRows(rows(json)).isEmpty())
+    }
+
+    @Test
+    fun `well-formed rows survive untouched`() {
+        val json = """[{"courseNo":"AT1234","courseName":"微積分"}]"""
+
+        val kept = DataCache.usableRows(rows(json))
+
+        assertEquals(1, kept.size)
+        assertEquals("AT1234", kept.first().courseNo)
+    }
+
+    @Test
+    fun `keeps the good rows and drops only the broken ones`() {
+        val json = """
+            [
+              {"courseNo":"AT1234","courseName":"微積分"},
+              {"courseNo":null,"courseName":"壞掉的"},
+              {"courseNo":"AT5678","courseName":"線性代數"}
+            ]
+        """.trimIndent()
+
+        val kept = DataCache.usableRows(rows(json))
+
+        assertEquals(listOf("AT1234", "AT5678"), kept.map { it.courseNo })
+    }
+
+    /**
+     * The regression: every surviving row must tolerate the dereference that
+     * used to NPE deep inside colour assignment.
+     */
+    @Test
+    fun `surviving rows can be dereferenced the way courseHashIndex does`() {
+        val json = """[{"courseNo":null,"courseName":null},{"courseNo":"AT1234","courseName":"微積分"}]"""
+
+        val kept = DataCache.usableRows(rows(json))
+
+        // Would have thrown NullPointerException before the filter landed.
+        val folded = kept.map { c -> c.courseNo.fold(0) { acc, ch -> acc * 31 + ch.code } }
+
+        assertEquals(1, folded.size)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolverTermGateTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/liveactivity/LiveActivityResolverTermGateTest.kt
@@ -1,0 +1,84 @@
+package org.ntust.app.tigerduck.liveactivity
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.ntust.app.tigerduck.AppConstants
+import org.ntust.app.tigerduck.data.model.Course
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.Date
+
+/**
+ * Covers the term gate in `buildTodaySlots`.
+ *
+ * The timetable is cached weeks before 開學 because 選課 opens ahead of the
+ * term, so the schedule alone is not evidence that classes have started.
+ * Without the gate the Live Update would render 上課中 / 即將上課 — and
+ * `todaySlotsAfter` would arm boundary alarms — for days before 開學.
+ *
+ * `todaySlotsAfter` is exercised rather than `resolve`, since the latter needs
+ * a Context-backed `LiveActivityPreferences`. Both run through the same
+ * gated `buildTodaySlots`.
+ */
+class LiveActivityResolverTermGateTest {
+
+    private val resolver = LiveActivityResolver()
+
+    /** Meets Monday, period 3 (10:20–11:10). */
+    private val mondayCourse = Course.fromSchedule(
+        courseNo = "AT1234",
+        courseName = "微積分",
+        schedule = mapOf(1 to listOf("3")),
+    )
+
+    private fun at(date: LocalDate, time: LocalTime): Date =
+        Date.from(date.atTime(time).atZone(AppConstants.TAIPEI_ZONE).toInstant())
+
+    @Test
+    fun `a Monday before 開學 surfaces no slots`() {
+        // 2026-08-31 is a Monday one week before 開學 (2026-09-07, also a
+        // Monday). Same course, same weekday, same time of day — the only
+        // difference from the test below is which side of 開學 it falls on.
+        val slots = resolver.todaySlotsAfter(
+            listOf(mondayCourse),
+            at(LocalDate.of(2026, 8, 31), LocalTime.of(8, 0)),
+        )
+
+        assertTrue("no class notifications before 開學", slots.isEmpty())
+    }
+
+    @Test
+    fun `the same Monday inside the term surfaces its slot`() {
+        val slots = resolver.todaySlotsAfter(
+            listOf(mondayCourse),
+            at(LocalDate.of(2026, 9, 7), LocalTime.of(8, 0)),
+        )
+
+        assertEquals(1, slots.size)
+        assertEquals("AT1234", slots.first().course.courseNo)
+    }
+
+    @Test
+    fun `a Monday after the last day of classes surfaces no slots`() {
+        // 2026-12-28, the first Monday after 2026-12-25.
+        val slots = resolver.todaySlotsAfter(
+            listOf(mondayCourse),
+            at(LocalDate.of(2026, 12, 28), LocalTime.of(8, 0)),
+        )
+
+        assertTrue(slots.isEmpty())
+    }
+
+    @Test
+    fun `every Monday in the run-up to 開學 stays empty`() {
+        for (weeksBefore in 1..4) {
+            val date = LocalDate.of(2026, 9, 7).minusWeeks(weeksBefore.toLong())
+            val slots = resolver.todaySlotsAfter(
+                listOf(mondayCourse),
+                at(date, LocalTime.of(8, 0)),
+            )
+            assertTrue("$date is before 開學 and must surface no slots", slots.isEmpty())
+        }
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/network/MoodleEnrolledDecodeTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/network/MoodleEnrolledDecodeTest.kt
@@ -1,0 +1,72 @@
+package org.ntust.app.tigerduck.network
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the null-row hazard in `core_enrol_get_users_courses` decoding.
+ *
+ * Gson does not strip nulls out of a JSON array, so a payload containing a
+ * null row decodes into a list holding a null while Kotlin's type system
+ * insists the element type is non-null. `ClassTableViewModel.fetchData`
+ * dereferences those elements outside any try/catch, so a single null row
+ * used to escape to the default uncaught handler and kill the process.
+ */
+class MoodleEnrolledDecodeTest {
+
+    @Test
+    fun `drops null rows from the array`() {
+        val json = """
+            [
+              {"id":1,"fullname":"1151 AT1234 課程","idnumber":"1151AT1234"},
+              null,
+              {"id":2,"fullname":"1151 AT5678 課程","idnumber":"1151AT5678"}
+            ]
+        """.trimIndent()
+
+        val decoded = MoodleService.decodeEnrolledCourses(json)
+
+        assertEquals(2, decoded.size)
+        assertEquals(listOf("1151AT1234", "1151AT5678"), decoded.map { it.idnumber })
+    }
+
+    /**
+     * The regression itself: every element must survive a dereference of the
+     * fields `fetchData` reads un-guarded.
+     */
+    @Test
+    fun `every surviving row can be dereferenced without NPE`() {
+        val json = """[null, {"id":1,"idnumber":"1151AT1234"}, null]"""
+
+        val decoded = MoodleService.decodeEnrolledCourses(json)
+
+        // Would have thrown NullPointerException before the filter landed.
+        val semesters = decoded.map { it.semesterCode }
+        val courseNos = decoded.map { it.courseNo }
+
+        assertEquals(listOf("1151"), semesters)
+        assertEquals(listOf("AT1234"), courseNos)
+    }
+
+    @Test
+    fun `an all-null array decodes to empty rather than throwing`() {
+        assertTrue(MoodleService.decodeEnrolledCourses("[null,null]").isEmpty())
+    }
+
+    @Test
+    fun `a JSON null body decodes to empty`() {
+        assertTrue(MoodleService.decodeEnrolledCourses("null").isEmpty())
+    }
+
+    @Test
+    fun `well-formed payloads are unchanged`() {
+        val json = """[{"id":7,"idnumber":"1142PE139B022","fullname":"1142 PE139B022 體育"}]"""
+
+        val decoded = MoodleService.decodeEnrolledCourses(json)
+
+        assertEquals(1, decoded.size)
+        assertEquals(7, decoded.first().id)
+        assertEquals("1142", decoded.first().semesterCode)
+    }
+}

--- a/app/src/test/java/org/ntust/app/tigerduck/widget/WidgetBoundarySchedulerTest.kt
+++ b/app/src/test/java/org/ntust/app/tigerduck/widget/WidgetBoundarySchedulerTest.kt
@@ -1,5 +1,6 @@
 package org.ntust.app.tigerduck.widget
 
+import org.ntust.app.tigerduck.AppConstants
 import org.ntust.app.tigerduck.data.model.Course
 import org.junit.Assert.*
 import org.junit.Test
@@ -41,5 +42,79 @@ class WidgetBoundarySchedulerTest {
     fun `ignores courses on other weekdays`() {
         val course = Course.fromSchedule("CS101", "Test", schedule = mapOf(2 to listOf("3")))
         assertNull(WidgetBoundaryScheduler.nextBoundaryMinuteAfter(listOf(course), weekday = 1, currentMinute = 0))
+    }
+
+    // --- chooseTriggerMillis: term flips have to pre-empt the class boundary ---
+
+    private val termStart = AppConstants.CurrentTerm.START
+    private val termEnd = AppConstants.CurrentTerm.END
+    private val oneDay = 24L * 60 * 60 * 1000
+
+    @Test
+    fun `wakes at 開學 rather than the first class boundary of 開學日`() {
+        // Evening before 開學, chain has handed off to 開學日's first class.
+        val firstClassOnOpeningDay = termStart + 8 * 60 * 60 * 1000
+        assertEquals(
+            termStart,
+            WidgetBoundaryScheduler.chooseTriggerMillis(
+                boundaryMillis = firstClassOnOpeningDay,
+                appNowMillis = termStart - 6 * 60 * 60 * 1000,
+            ),
+        )
+    }
+
+    @Test
+    fun `keeps the class boundary when it lands before the term flip`() {
+        val boundary = termStart - 3 * oneDay
+        assertEquals(
+            boundary,
+            WidgetBoundaryScheduler.chooseTriggerMillis(
+                boundaryMillis = boundary,
+                appNowMillis = termStart - 4 * oneDay,
+            ),
+        )
+    }
+
+    @Test
+    fun `wakes at 結業 rather than the following day's stale boundary`() {
+        val boundaryAfterTermEnds = termEnd + 8 * 60 * 60 * 1000
+        assertEquals(
+            termEnd,
+            WidgetBoundaryScheduler.chooseTriggerMillis(
+                boundaryMillis = boundaryAfterTermEnds,
+                appNowMillis = termEnd - 2 * 60 * 60 * 1000,
+            ),
+        )
+    }
+
+    @Test
+    fun `ignores 開學 once it has passed and uses 結業 instead`() {
+        val midTermNow = termStart + 30 * oneDay
+        val boundary = termEnd + oneDay
+        assertEquals(
+            termEnd,
+            WidgetBoundaryScheduler.chooseTriggerMillis(boundary, midTermNow),
+        )
+    }
+
+    @Test
+    fun `falls through to the class boundary once the term is over`() {
+        val afterTerm = termEnd + 5 * oneDay
+        val boundary = afterTerm + 60 * 60 * 1000
+        assertEquals(
+            boundary,
+            WidgetBoundaryScheduler.chooseTriggerMillis(boundary, afterTerm),
+        )
+    }
+
+    @Test
+    fun `a term flip exactly at now does not re-arm on itself`() {
+        // Guards the alarm loop: at the instant of the flip the refresh
+        // re-enters scheduleForToday, and START must no longer be a candidate.
+        val boundary = termStart + 8 * 60 * 60 * 1000
+        assertEquals(
+            boundary,
+            WidgetBoundaryScheduler.chooseTriggerMillis(boundary, termStart),
+        )
     }
 }

--- a/metadata/org.ntust.app.tigerduck.fdroid.yml
+++ b/metadata/org.ntust.app.tigerduck.fdroid.yml
@@ -16,8 +16,8 @@ RepoType: git
 Repo: https://github.com/tigerduck-app/tigerduck-app-android.git
 
 Builds:
-  - versionName: 1.4.3-fdroid
-    versionCode: 21
+  - versionName: 1.4.4-fdroid
+    versionCode: 22
     commit: f834773a7abee9be142c8d753c464a57006bdf8f
     subdir: app
     submodules: true
@@ -26,5 +26,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 1.4.3-fdroid
-CurrentVersionCode: 21
+CurrentVersion: 1.4.4-fdroid
+CurrentVersionCode: 22

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -17,8 +17,8 @@ android {
         applicationId = "org.ntust.app.tigerduck"
         minSdk = 30
         targetSdk = 36
-        versionCode = 21
-        versionName = "1.4.3"
+        versionCode = 22
+        versionName = "1.4.4"
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary

Hotfix release **1.4.4** (versionCode 22). Fixes the 1.4.3 launch crash, and stops class notifications and the today-scoped widgets firing before 開學.

### 1. The crash — `6fd0f7d1`

```
java.lang.NullPointerException: Attempt to invoke interface method
'void kotlinx.coroutines.flow.MutableStateFlow.setValue(java.lang.Object)'
on a null object reference
    at ClassTableViewModel.fetchData(ClassTableViewModel.kt:735)
    at ClassTableViewModel$3$1.emit(ClassTableViewModel.kt:141)
    at kotlinx.coroutines.flow.StateFlowImpl.collect(StateFlow.kt:401)
    at ClassTableViewModel.<init>(ClassTableViewModel.kt:130)
```

An initialisation-order bug. `init` occupied lines 101–174; `_availableSemesters` was declared at line 197. Kotlin runs property initialisers and init blocks in declaration order, so that field was null for the whole of `init`.

Nothing dispatches away before it is read: `viewModelScope` uses `Dispatchers.Main.immediate` and the ViewModel is built on the main thread, so `launch` runs its body inline; `authState` is a `StateFlow`, so `collect` delivers the current value immediately. An already-logged-in user therefore runs `fetchData()` to completion inside the constructor. The whole trace is one synchronous stack with no dispatch in it.

**Why it looked time-dependent.** Reaching line 735 requires `fetchData` to get there without suspending. `semesterCatalog.refreshIfStale()` sits two lines above and suspends only once the 1-hour TTL has expired. On the first launch after upgrading, `semesterCatalogRefreshedAt` is 0 → it really fetches → suspends → `init` completes → the field initialises → no crash. Every launch in the following hour returns from the TTL check without suspending, and crashes. So the app had to be *relaunched*, not merely left running, inside that window — which is why a plain upgrade-and-use test missed it.

`_availableSemesters` and the write at line 735 both arrived in c31f0f26, so 1.4.2 is unaffected.

Fix hoists all four backing fields declared after `init` above it. Only the first crashed; the other three are the same hazard and reachable from `fetchData` / `refresh`. A comment on `init` records the constraint.

### 2. No class notifications before 開學 — `79b52280`, `6c2e6ab0`

The timetable is cached weeks early (選課 opens ahead of the term), so holding courses was never evidence classes had begun. Nothing on the notification path checked the term window.

- `ClassPreparingNotificationScheduler.upcomingSlots` walks 10 days out — on 2026-08-30 that covered eight pre-開學 days of 即將上課 alarms.
- `LiveActivityResolver.buildTodaySlots` feeds both the Live Update and `todaySlotsAfter`, which arms boundary alarms.

`AppConstants.CurrentTerm.containsDate` adds a per-day counterpart to `isInSession` (which answers per-instant and does not fit a scheduler deciding whole days ahead). It reuses the existing hard-coded START/END rather than restating 09-07, so the term stays pinned in one place, and fails closed the same way.

`6c2e6ab0` re-checks at the receiver: the scheduler gate cannot retract an alarm already in AlarmManager, and 1.4.3's stale alarms outlive the upgrade until the next `scheduleAll` cancels them.

Assignment notifications are deliberately untouched — Moodle due-date driven, not timetable driven.

### 3. Widgets — `c239a5ac`

Next Class and Today are gated the same way. The **Week grid is deliberately not** — it is a reference timetable, matching the class table screen, where the today carousel hides outside the term but the grid stays.

### 4. Speculative, not the cause — `43ea88ee`

Written before the stack trace arrived. Two real latent null-safety holes (Gson does not strip null elements from a JSON array; `COURSE_NO_TOKEN` is satisfied by `{"courseNo":null}`), each with tests that fail without the fix. **Neither was this bug.** Kept because both are genuine, but they should not be read as the fix. The error boundary it adds to `fetchData` would have *swallowed* the real NPE — it stays as defence in depth, logging at error level, but is no longer load-bearing.

## TODO left in code

`AppConstants.CurrentTerm` carries a TODO to serve 開學時間 / 結業時間 from the backend so a term rollover stops needing an app release. Every consumer already goes through `CODE` / `isInSession` / `containsDate`, so only that object changes.

## Verification

- 64 unit tests pass across `play`, `fdroid` and `:shared`; `minifyPlayReleaseWithR8` clean.
- Merged manifests confirm 22 / 1.4.4 on playRelease, fdroidRelease and wear release.
- Regression tests were checked for teeth by neutralising each fix: 8/11 fail for the null-safety pair (two on a real NPE), 3/4 for the Live Activity term gate.

**Not verified — needs a device.** The project has no Robolectric or mocking dependency, so none of the following is reachable from a JVM test, and all of it is verified by reading only:

- the crash fix (ViewModel construction)
- both notification gates (need `Context` / `AlarmManager`)
- the widget gate (Glance composables + Hilt entry point)

Suggested manual pass before merging:

1. Launch, force-stop, relaunch **within the hour** — reproduces the crash on 1.4.3, must not crash here.
2. Install 1.4.3, sync a real timetable, install this over it (the checklist's upgrade item — a clean install does not exercise it).
3. Confirm no 即將上課 notification and no ongoing Live Update before Sep 7; Next Class shows "no more classes", Today is empty, Week grid still populated.

## Notes

- The fdroid `commit:` field still points at the v1.4.3 tree — correct per the 1.4.3 bump template; the release workflow rewrites it when the tag is cut.
- `CONTRIBUTING.md` documents fix branches → `dev`. This targets `main` directly as a hotfix, matching #115 (`hotfix/1151-support` → `main`) for 1.4.3.
